### PR TITLE
builder: Add haddock and hoogle

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -21,6 +21,8 @@
 , postCheck
 , preInstall
 , postInstall
+, preHaddock
+, postHaddock
 
 , shellHook
 
@@ -73,7 +75,9 @@ let
 
   buildComp = componentId: component: comp-builder {
     inherit componentId component package name src flags setup cabalFile patches revision
-            preUnpack postUnpack preConfigure postConfigure preBuild postBuild preCheck postCheck preInstall postInstall
+            preUnpack postUnpack preConfigure postConfigure
+            preBuild postBuild preCheck postCheck
+            preInstall postInstall preHaddock postHaddock
             shellHook
             ;
   };

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -61,6 +61,9 @@ with haskellLib;
     if componentId.ctype == "all" then ""
     else "${componentId.ctype}:${componentId.cname}";
 
+  # Remove null or empty values from an attrset.
+  optionalHooks = lib.filterAttrs (_: hook: hook != null && hook != "");
+
   # Avoid pkgs.callPackage for now. It does a lot of nonsense with OOP
   # style programming that we should avoid until we know we want it.
 

--- a/modules/package.nix
+++ b/modules/package.nix
@@ -135,6 +135,10 @@ in {
             type = listOfFilteringNulls str;
             default = config.setupInstallFlags;
           };
+          setupHaddockFlags = mkOption {
+            type = listOfFilteringNulls str;
+            default = config.setupHaddockFlags;
+          };
           doExactConfig = mkOption {
             type = bool;
             default = config.doExactConfig;
@@ -146,6 +150,11 @@ in {
           doCrossCheck = mkOption {
             type = bool;
             default = config.doCrossCheck;
+          };
+          doHaddock = mkOption {
+            description = "Enable building of the Haddock documentation from the annotated Haskell source code.";
+            type = bool;
+            default = config.doHaddock;
           };
         };
       };
@@ -225,6 +234,10 @@ in {
       type = listOfFilteringNulls str;
       default = [];
     };
+    setupHaddockFlags = mkOption {
+      type = listOfFilteringNulls str;
+      default = [];
+    };
     preUnpack = mkOption {
       type = nullOr lines;
       default = null;
@@ -265,6 +278,14 @@ in {
       type = nullOr string;
       default = null;
     };
+    preHaddock = mkOption {
+      type = nullOr string;
+      default = null;
+    };
+    postHaddock = mkOption {
+      type = nullOr string;
+      default = null;
+    };
     shellHook = mkOption {
       type = nullOr string;
       default = null;
@@ -281,6 +302,11 @@ in {
       description = "Run doCheck also in cross compilation settings. This can be tricky as the test logic must know how to run the tests on the target.";
       type = bool;
       default = false;
+    };
+    doHaddock = mkOption {
+      description = "Enable building of the Haddock documentation from the annotated Haskell source code.";
+      type = bool;
+      default = true;
     };
   };
 

--- a/test/builder-haddock/Setup.hs
+++ b/test/builder-haddock/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/test/builder-haddock/TestHaddock.hs
+++ b/test/builder-haddock/TestHaddock.hs
@@ -1,0 +1,6 @@
+-- | Haddock test stuff
+module TestHaddock (hello) where
+
+-- | Standard hello text.
+hello :: String
+hello = "Hello, world!"

--- a/test/builder-haddock/default.nix
+++ b/test/builder-haddock/default.nix
@@ -1,0 +1,92 @@
+{ pkgs
+, haskell
+, stdenv
+}:
+
+with stdenv.lib;
+
+let
+  pkgSet = haskell.mkPkgSet {
+    inherit pkgs;
+    # generated with:
+    #   cabal new-build
+    #   plan-to-nix dist-newstyle/cache/plan.json > plan.nix
+    #   cabal-to-nix test-haddock.cabal > test-haddock.nix
+    pkg-def = import ./plan.nix;
+    pkg-def-overlays = [
+      { test-haddock = ./test-haddock.nix; }
+    ];
+    modules = [
+      # overrides to fix the build
+      {
+        packages.transformers-compat.components.library.doExactConfig = true;
+      }
+
+      {
+        # Add a hook to the haddock phase
+        packages.test-haddock.postHaddock = ''
+          echo "==="
+          echo "This is the postHaddock hook. The files are:"
+          find .
+          echo "==="
+        '';
+
+        # Check that the package option works
+        packages.stm.doHaddock = false;
+      }
+    ];
+  };
+
+  packages = pkgSet.config.hsPkgs;
+
+in
+  stdenv.mkDerivation {
+    name = "builder-haddock-test";
+
+    buildCommand = let
+      inherit (packages.test-haddock.components) library;
+      noDocLibrary = packages.stm.components.library;
+    in ''
+      ########################################################################
+      # test haddock
+
+      doc="${toString library.doc}"
+      docDir="${toString library.haddockDir}"
+
+      # exeDoc="$ disabled {toString packages.test-haddock.components.exes.test-haddock.doc}"
+      # printf "checking that executable output does not have docs ... " >& 2
+      # echo $exeDoc
+      # test "$exeDoc" = ""
+
+      printf "checking that documentation directory was built... " >& 2
+      echo "$doc" >& 2
+      test -n "$doc"
+
+      printf "checking that documentation was generated... " >& 2
+      grep hello "$docDir/TestHaddock.html" > /dev/null
+      echo yes >& 2
+
+      printf "checking for hoogle index of package... " >& 2
+      grep hello "$docDir/test-haddock.txt" > /dev/null
+      echo yes >& 2
+
+      printf "checking for absence of documentation in another package... " >& 2
+      if [ -d "${toString noDocLibrary.haddockDir}" ]; then
+        echo "it exists - FAIL" >& 2
+      else
+        echo PASS >& 2
+      fi
+
+      printf "checking for absence of library package store paths in docs... " >& 2
+      if grep -R ${library} "$docDir" > /dev/null; then
+        echo "Found ${library} - FAIL" >& 2
+        exit 1
+      else
+        echo "PASS" >& 2
+      fi
+
+      touch $out
+    '';
+
+    meta.platforms = platforms.all;
+} // { inherit packages pkgSet; }

--- a/test/builder-haddock/plan.nix
+++ b/test/builder-haddock/plan.nix
@@ -1,0 +1,23 @@
+hackage:
+  {
+    packages = {
+      "ghc-prim".revision = hackage."ghc-prim"."0.5.2.0".revisions.default;
+      "stm".revision = hackage."stm"."2.4.5.1".revisions.default;
+      "rts".revision = hackage."rts"."1.0".revisions.default;
+      "base".revision = hackage."base"."4.11.1.0".revisions.default;
+      "array".revision = hackage."array"."0.5.2.0".revisions.default;
+      "integer-gmp".revision = hackage."integer-gmp"."1.0.2.0".revisions.default;
+    };
+    compiler = {
+      version = "8.4.4";
+      nix-name = "ghc844";
+      packages = {
+        "ghc-prim" = "0.5.2.0";
+        "stm" = "2.4.5.1";
+        "rts" = "1.0";
+        "base" = "4.11.1.0";
+        "array" = "0.5.2.0";
+        "integer-gmp" = "1.0.2.0";
+      };
+    };
+  }

--- a/test/builder-haddock/test-haddock.cabal
+++ b/test/builder-haddock/test-haddock.cabal
@@ -1,0 +1,15 @@
+cabal-version:       2.2
+name:                test-haddock
+version:             0.1.0.0
+license:             NONE
+author:              Rodney Lorrimar
+maintainer:          rodney.lorrimar@iohk.io
+
+library
+  exposed-modules:     TestHaddock
+  other-modules:       Paths_test_haddock
+  -- other-extensions:
+  build-depends:       base ^>=4.11.1.0
+                     , stm
+  -- hs-source-dirs:
+  default-language:    Haskell2010

--- a/test/builder-haddock/test-haddock.nix
+++ b/test/builder-haddock/test-haddock.nix
@@ -1,0 +1,36 @@
+{ system
+, compiler
+, flags
+, pkgs
+, hsPkgs
+, pkgconfPkgs
+, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.2";
+      identifier = {
+        name = "test-haddock";
+        version = "0.1.0.0";
+      };
+      license = "NONE";
+      copyright = "";
+      maintainer = "rodney.lorrimar@iohk.io";
+      author = "Rodney Lorrimar";
+      homepage = "";
+      url = "";
+      synopsis = "";
+      description = "";
+      buildType = "Simple";
+    };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs.base)
+          (hsPkgs.stm)
+        ];
+      };
+    };
+  } // rec {
+    src = pkgs.lib.mkDefault ./.;
+  }

--- a/test/cabal-simple/default.nix
+++ b/test/cabal-simple/default.nix
@@ -19,7 +19,13 @@ let
       { cabal-simple = ./cabal-simple.nix;
       }
     ];
-    modules = [ ];
+    modules = [
+     {
+       # Package has no exposed modules which causes
+       #   haddock: No input file(s)
+       packages.cabal-simple.doHaddock = false;
+     }
+    ];
   };
 
   packages = pkgSet.config.hsPkgs;
@@ -56,8 +62,8 @@ in
     meta.platforms = platforms.all;
 
     passthru = {
-      inherit (packages) cabal-simple;
-      inherit pkgSet;
+      # Used for debugging with nix repl
+      inherit pkgSet packages;
 
       # Used for testing externally with nix-shell (../tests.sh).
       # This just adds cabal-install to the existing shells.

--- a/test/default.nix
+++ b/test/default.nix
@@ -21,6 +21,7 @@ in {
   cabal-simple = callPackage ./cabal-simple { inherit haskell util; };
   cabal-22 = callPackage ./cabal-22 { inherit haskell; };
   with-packages = callPackage ./with-packages { inherit haskell util; };
+  builder-haddock = callPackage ./builder-haddock { inherit haskell; };
 
   # Run unit tests with: nix-instantiate --eval --strict -A unit
   # An empty list means success.


### PR DESCRIPTION
Adds haddock building to the component builder. This can be accessed with the `pkgSet.config.hsPkgs.PACKAGE.components.library.doc` attribute.

Hoogle databases are built for each component, but there are no combined Hoogle databases generated yet. That can be done in another PR.