### PR TITLE
tests: Add more tests for "all" component merging

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -37,11 +37,15 @@ let
     echo "${field}: ${lib.concatStringsSep " " xs}" >> $out/cabal.config
   '';
 
+  componentDepends = if haskellLib.isAll componentId
+    then lib.filter (p: p.identifier.name != componentId.cname) component.depends
+    else component.depends;
+
   flatDepends =
     let
       makePairs = map (p: rec { key="${val}"; val=p.components.library; });
       closure = builtins.genericClosure {
-        startSet = makePairs component.depends;
+        startSet = makePairs componentDepends;
         operator = {val,...}: makePairs val.config.depends;
       };
     in map ({val,...}: val) closure;
@@ -99,7 +103,7 @@ let
     clear-package-db
     package-db $out/package.conf.d
     EOF
-    ${lib.concatMapStringsSep "\n" (p: envDep "--package-db ${p.components.library}/package.conf.d" p.identifier.name) component.depends}
+    ${lib.concatMapStringsSep "\n" (p: envDep "--package-db ${p.components.library}/package.conf.d" p.identifier.name) componentDepends}
     ${lib.concatMapStringsSep "\n" (envDep "") (lib.remove "ghc" nonReinstallablePkgs)}
 
   '' + lib.optionalString component.doExactConfig ''
@@ -107,7 +111,7 @@ let
     echo "allow-newer: ${package.identifier.name}:*" >> $out/cabal.config
     echo "allow-older: ${package.identifier.name}:*" >> $out/cabal.config
 
-    ${lib.concatMapStringsSep "\n" (p: exactDep "--package-db ${p.components.library}/package.conf.d" p.identifier.name) component.depends}
+    ${lib.concatMapStringsSep "\n" (p: exactDep "--package-db ${p.components.library}/package.conf.d" p.identifier.name) componentDepends}
     ${lib.concatMapStringsSep "\n" (exactDep "") nonReinstallablePkgs}
 
   ''

--- a/test/cabal-simple/cabal-simple.cabal
+++ b/test/cabal-simple/cabal-simple.cabal
@@ -30,6 +30,7 @@ executable cabal-simple
   -- other-modules:
   -- other-extensions:
   build-depends:       base >=4.11 && <4.12
+                     , cabal-simple
                      , extra
                      , optparse-applicative
   -- hs-source-dirs:

--- a/test/cabal-simple/cabal-simple.nix
+++ b/test/cabal-simple/cabal-simple.nix
@@ -36,6 +36,7 @@
         "cabal-simple" = {
           depends = [
             (hsPkgs.base)
+            (hsPkgs.cabal-simple)
             (hsPkgs.extra)
             (hsPkgs.optparse-applicative)
           ];

--- a/test/default.nix
+++ b/test/default.nix
@@ -15,10 +15,12 @@ let
 
   haskellLib = let hl = import ../lib { inherit lib; haskellLib = hl; }; in hl;
 
+  util = callPackage ./util.nix {};
+
 in {
-  cabal-simple = callPackage ./cabal-simple { inherit haskell; };
+  cabal-simple = callPackage ./cabal-simple { inherit haskell util; };
   cabal-22 = callPackage ./cabal-22 { inherit haskell; };
-  with-packages = callPackage ./with-packages { inherit haskell; };
+  with-packages = callPackage ./with-packages { inherit haskell util; };
 
   # Run unit tests with: nix-instantiate --eval --strict -A unit
   # An empty list means success.

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -43,4 +43,11 @@ nix-shell $NIX_BUILD_ARGS \
     --run 'echo CABAL_CONFIG=$CABAL_CONFIG && echo GHC_ENVIRONMENT=$GHC_ENVIRONMENT && cd with-packages && rm -rf dist-newstyle .ghc-environment* && cabal new-build'
 echo >& 2
 
+printf "*** Checking that a nix-shell works for a multi-target project...\n" >& 2
+nix-shell $NIX_BUILD_ARGS \
+    --pure ./default.nix \
+    -A cabal-simple.test-shell \
+    --run 'cd cabal-simple && rm -rf dist-newstyle .ghc-environment* && cabal new-build'
+echo >& 2
+
 printf "\n*** Finished successfully\n" >& 2

--- a/test/util.nix
+++ b/test/util.nix
@@ -1,0 +1,8 @@
+{ cabal-install }:
+
+{
+  # Add cabal as a buildInput for a haskell derivation. Useful for nix-shell.
+  addCabalInstall = drv: drv.overrideAttrs (oldAttrs: {
+    buildInputs = (oldAttrs.buildInputs or []) ++ [ cabal-install ];
+  });
+}

--- a/test/with-packages/default.nix
+++ b/test/with-packages/default.nix
@@ -1,9 +1,11 @@
 { pkgs
 , haskell
 , stdenv
+, util
 }:
 
 with stdenv.lib;
+with util;
 
 let
   pkgSet = haskell.mkPkgSet {
@@ -34,21 +36,31 @@ let
 
   packages = pkgSet.config.hsPkgs;
 
-  # Add cabal as a buildInput for a haskell derivation. Useful for nix-shell.
-  addCabalInstall = drv: drv.overrideAttrs (oldAttrs: {
-    buildInputs = (oldAttrs.buildInputs or []) ++ [ pkgs.cabal-install ];
-  });
+  package = packages.test-with-packages;
+  inherit (package.components) library;
+
+  pkgId = p: "${p.identifier.name}-${p.identifier.version}";
+  showDepends = component: concatMapStringsSep " " pkgId component.depends;
 
 in
   stdenv.mkDerivation {
     name = "with-packages-test";
+    libraryDepends = showDepends pkgSet.config.packages.test-with-packages.components.library;
+    allDepends = showDepends pkgSet.config.packages.test-with-packages.components.all;
 
-    buildCommand = let
-      package = packages.test-with-packages;
-      inherit (package.components) library;
-    in ''
+    buildCommand = ''
       ########################################################################
       # test with-packages
+
+      printf "checking merging of the 'all' component depends ... " >& 2
+      if [ -n "$libraryDepends" -a "$libraryDepends" = "$allDepends" ]; then
+        echo "PASS" >& 2
+      else
+        echo "FAIL" >& 2
+        echo "libraryDepends = $libraryDepends"
+        echo "allDepends = $allDepends"
+        exit 1
+      fi
 
       printf "checking that the 'all' component works... " >& 2
       echo ${package.components.all} >& 2
@@ -62,7 +74,7 @@ in
 
       printf "checking that components.library.env has the dependencies... " >& 2
       ${library.env}/bin/runghc ${./Point.hs}
-      # echo >& 2
+      echo >& 2
 
       touch $out
     '';


### PR DESCRIPTION
- Make the cabal-simple executable depend on the library component -- a better exercise for the merged all component build.

- Test building cabal-simple with "cabal new-build" in nix-shell.

- Check the contents of components.all.depends for the with-packages test.

Related to #42 and #43.
