### PR TITLE
Add Buildkite pipeline for updating hackage.nix and stackage.nix

### DIFF
--- a/.buildkite/updates.yml
+++ b/.buildkite/updates.yml
@@ -1,0 +1,16 @@
+steps:
+  - label: 'Update hackage.nix'
+    command:
+      - nix-build -I nixpkgs=channel:nixos-18.09 -A maintainer-scripts.update-hackage -o update-hackage.sh
+      - echo "+++ Updating hackage.nix"
+      - ./update-hackage.sh
+    agents:
+      system: x86_64-linux
+
+  - label: 'Update stackage.nix'
+    command:
+      - nix-build -I nixpkgs=channel:nixos-18.09 -A maintainer-scripts.update-stackage -o update-stackage.sh
+      - echo "+++ Updating stackage.nix"
+      - ./update-stackage.sh
+    agents:
+      system: x86_64-linux

--- a/nix-tools/nix-tools-src.json
+++ b/nix-tools/nix-tools-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/nix-tools",
-  "rev": "232e4fde7f942ef234b649144016d5da0f7e2745",
-  "date": "2019-02-11T12:59:38+08:00",
-  "sha256": "1nrm9vcq443isk09z1fmlp8zxnw9p3cx95zbda29s5mky17ky2c0",
+  "rev": "38bf6fd0adef4d22fe06def521f5d793c081f6ed",
+  "date": "2019-03-20T12:40:31+10:00",
+  "sha256": "0y8xap5cvc9rssjjvlgv6lyi8ixpxnq675r3gkz2ix7hrsgk8989",
   "fetchSubmodules": false
 }

--- a/scripts/update-hackage.nix
+++ b/scripts/update-hackage.nix
@@ -1,11 +1,8 @@
-{ stdenv, writeScript, coreutils, glibc, git, nix-tools, cabal-install, nix-prefetch-git }@args:
+{ stdenv, writeScript, coreutils, glibc, git, openssh, nix-tools, cabal-install, nix-prefetch-git }@args:
 
 import ./update-external.nix args {
   name = "hackage";
   script = ''
-    # Make sure the hackage index is recent.
-    cabal new-update
-
     # Clone or update the Hackage Nix expressions repo.
     if [ -d hackage.nix ]; then
       cd hackage.nix
@@ -14,6 +11,10 @@ import ./update-external.nix args {
     else
       git clone git@github.com:input-output-hk/hackage.nix.git
     fi
+
+    # Make sure the hackage index is recent.
+    echo "Updating local hackage index..."
+    cabal update
 
     echo "Running hackage-to-nix..."
 

--- a/scripts/update-stackage.nix
+++ b/scripts/update-stackage.nix
@@ -1,4 +1,4 @@
-{ stdenv, writeScript, coreutils, glibc, git, nix-tools, cabal-install, nix-prefetch-git }@args:
+{ stdenv, writeScript, coreutils, glibc, git, openssh, nix-tools, cabal-install, nix-prefetch-git }@args:
 
 import ./update-external.nix args {
   name = "stackage";


### PR DESCRIPTION
IOHK Buildkite agents have ssh keys. They can be given push access to hackage.nix and stackage.nix. This Buildkite pipeline will be scheduled to run every day, so that the repos stay up to date.
