### PR TITLE
wip: Add callCabalToNix

### DIFF
--- a/call-cabal-to-nix.nix
+++ b/call-cabal-to-nix.nix
@@ -1,0 +1,78 @@
+{ stdenv, lib, buildPackages, mkPkgSet, nix-tools }:
+
+let
+
+  haskellSrc2nix = { name, src ? null, extraCabal2nixOptions ? "" }:
+    buildPackages.stdenv.mkDerivation {
+      name = "cabal-to-nix-${name}";
+      nativeBuildInputs = [ nix-tools ];
+      preferLocalBuild = true;
+      allowSubstitutes = false;
+      phases = ["installPhase"];
+      LANG = "en_US.UTF-8";
+      LOCALE_ARCHIVE = lib.optionalString (stdenv.buildPlatform.libc == "glibc") "${buildPackages.glibcLocales}/lib/locale/locale-archive";
+      installPhase = ''
+        export HOME="$TMP"
+        mkdir -p "$out"
+        cabal-to-nix "${src}/${name}.cabal" ${extraCabal2nixOptions} > "$out/default.nix"
+      '';
+    };
+
+  haskellSrc2plan = { name, src, ghc }:
+    buildPackages.stdenv.mkDerivation {
+      name = "plan-to-nix-${name}";
+      nativeBuildInputs = [ nix-tools buildPackages.cabal-install ];
+      preferLocalBuild = true;
+      allowSubstitutes = false;
+      phases = ["installPhase"];
+      LANG = "en_US.UTF-8";
+      LOCALE_ARCHIVE = lib.optionalString (stdenv.buildPlatform.libc == "glibc") "${buildPackages.glibcLocales}/lib/locale/locale-archive";
+      installPhase = ''
+        mkdir -p "$out"
+
+        export HOME="$TMP"
+        mkdir -p "$HOME/.cabal"
+
+        # fixme: this won't work in a sandboxed build
+        cabal new-update
+        # touch "$HOME/.cabal/config"
+
+        # need to copy sources because cabal wants to write cabal.project.local
+        cp -R --no-preserve=mode ${src}/* .
+
+        cabal new-configure --builddir="$TMP/dist-newstyle" --with-compiler ${ghc}/bin/${ghc.targetPrefix}ghc
+        plan-to-nix "$TMP/dist-newstyle/cache/plan.json" > "$out/default.nix"
+      '';
+    };
+
+in
+  name: src: ghc:
+    let
+      filter = path: type:
+                 lib.hasSuffix "${name}.cabal" path ||
+                 # baseNameOf path == "cabal.project" ||
+                 baseNameOf path == "package.yaml";
+      src' = if lib.canCleanSource src
+              then lib.cleanSourceWith { inherit src filter; }
+            else src;
+      expr = haskellSrc2nix {
+        inherit name;
+        src = src';
+      };
+      plan = haskellSrc2plan {
+        inherit name ghc;
+        src = src';
+      };
+    in
+      mkPkgSet {
+        pkg-def = import (plan + /default.nix);
+        pkg-def-overlays = [ { "${name}" = import (expr + /default.nix); } ];
+        modules = [ {
+          packages."${name}" = {
+            src = lib.mkForce src;
+            # Adds the generated nix as an input, to prevent garbage collection.
+            preConfigure = "# Generated from ${expr} and ${plan}";
+          };
+        } ];
+      }
+  # fixme: allow more args for generation, etc.

--- a/default.nix
+++ b/default.nix
@@ -97,6 +97,9 @@ let
       update-hackage = self.callPackage ./scripts/update-hackage.nix {};
       update-stackage = self.callPackage ./scripts/update-stackage.nix {};
     };
+
+    callCabalToNix = self.callPackage ./call-cabal-to-nix.nix {};
+
   });
 
 in

--- a/test/default.nix
+++ b/test/default.nix
@@ -15,6 +15,7 @@ in {
   with-packages = callPackage ./with-packages { inherit (haskell) mkPkgSet; inherit util; };
   builder-haddock = callPackage ./builder-haddock { inherit (haskell) mkPkgSet; };
   stack-simple = callPackage ./stack-simple { inherit (haskell) mkStackPkgSet; };
+  ifd = callPackage ./ifd { inherit (haskell) callCabalToNix; inherit (pkgs.haskellPackages) ghc; inherit util; };
 
   # Run unit tests with: nix-instantiate --eval --strict -A unit
   # An empty list means success.

--- a/test/ifd/default.nix
+++ b/test/ifd/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, util, callCabalToNix, ghc }:
+
+with stdenv.lib;
+
+let
+  pkgSet = callCabalToNix "cabal-simple" ../cabal-simple ghc;
+
+  packages = pkgSet.config.hsPkgs;
+
+in
+  stdenv.mkDerivation {
+    name = "ifd-test";
+
+    buildCommand = ''
+      exe="${packages.cabal-simple.components.exes.cabal-simple}/bin/cabal-simple"
+
+      printf "checking whether executable runs... " >& 2
+      $exe
+
+      touch $out
+    '';
+
+    meta.platforms = platforms.all;
+
+    passthru = {
+      # Used for debugging with nix repl
+      inherit pkgSet packages;
+    };
+  }


### PR DESCRIPTION
It's a bit of a pain to run `cabal new-configure ; plan-to-nix ; cabal-to-nix`. This should be automated. One way to do this is with IFD.

As currently implemented, this needs the Nix sandbox disabled to work, because it needs to run `cabal update`. I'm not yet sure how to get a fixed-output derivation for `01-index.tar.gz`. This file is always being appended to.
