### PR TITLE
docs: Update import instructions in user guide

### DIFF
--- a/docs/user-guide-cabal.md
+++ b/docs/user-guide-cabal.md
@@ -49,7 +49,6 @@ file as follows:
 
 ```nix
 let plan = import ./plan.nix; in
-{ ... }:
 { pkg-def = plan;
   overlay =
     { local-package-a = ./local-package-a.nix;

--- a/docs/user-guide-stack.md
+++ b/docs/user-guide-stack.md
@@ -35,26 +35,5 @@ packages.  The overlay specifies which `extra-deps` (here: o-clock-0.1.1)
 we wanted to overlay over the stackage snapshot, and what local
 packages we want (here: my-package).
 
-We will then create the following `nix/default.nix` file:
-
-```nix
-{ pkgs ? import <nixpkgs> {} }:
-
-let
-  haskell = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz) { inherit pkgs; };
-
-  pkgSet = haskell.mkStackPkgSet {
-    stack-pkgs = import ./pkgs.nix;
-    pkg-def-overlays = [];
-    modules = [];
-  };
-
-in
-  pkgSet.config.hsPkgs
-```
-
-This generated file is a template, so you can customize it as
-necessary.
-
 *If you came here from the [User Guide](/user-guide), go back and
  complete the setup.*


### PR DESCRIPTION
This should make the user guide consistent with how hackage and stackage are imported.

The ascii box diagram still needs to be updated.

There is too much boilerplate in the docs. The tools should generate template files with comments explaining pinning, etc.
