### PR TITLE
Build without GHC environment files, instead using wrappers

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -221,7 +221,6 @@ stdenv.mkDerivation ({
   };
 
   CABAL_CONFIG = configFiles + /cabal.config;
-  GHC_ENVIRONMENT = configFiles + /ghc-environment;
   LANG = "en_US.UTF-8";         # GHC needs the locale configured during the Haddock phase.
   LC_ALL = "en_US.UTF-8";
 
@@ -232,7 +231,7 @@ stdenv.mkDerivation ({
     ++ component.pkgconfig;
 
   nativeBuildInputs =
-    [ghc buildPackages.removeReferencesTo]
+    [shellWrappers buildPackages.removeReferencesTo]
     ++ lib.optional (component.pkgconfig != []) pkgconfig
     ++ executableToolDepends;
 

--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, ghc, lib, pkgconfig, writeText, runCommand, haskellLib, nonReinstallablePkgs, withPackage, hsPkgs }:
+{ stdenv, buildPackages, ghc, lib, pkgconfig, writeText, runCommand, haskellLib, nonReinstallablePkgs, ghcForComponent, hsPkgs }:
 
 { componentId
 , component
@@ -181,8 +181,9 @@ let
 
   # Unfortunately, we need to wrap ghc commands for cabal builds to
   # work in the nix-shell. See ../doc/removing-with-package-wrapper.md.
-  shellWrappers = withPackage {
-    inherit package configFiles;
+  shellWrappers = ghcForComponent {
+    componentName = fullName;
+    inherit configFiles;
   };
 
   # the target dir for haddock documentation

--- a/builder/default.nix
+++ b/builder/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, buildPackages, stdenv, lib, haskellLib, ghc, buildGHC, fetchurl, writeText, runCommand, pkgconfig, nonReinstallablePkgs, withPackage, hsPkgs }:
+{ pkgs, buildPackages, stdenv, lib, haskellLib, ghc, buildGHC, fetchurl, writeText, runCommand, pkgconfig, nonReinstallablePkgs, ghcForComponent, hsPkgs }:
 
 { flags
 , package
@@ -72,7 +72,7 @@ let
       '';
     };
 
-  comp-builder = haskellLib.weakCallPackage pkgs ./comp-builder.nix { inherit ghc haskellLib nonReinstallablePkgs withPackage hsPkgs; };
+  comp-builder = haskellLib.weakCallPackage pkgs ./comp-builder.nix { inherit ghc haskellLib nonReinstallablePkgs ghcForComponent hsPkgs; };
 
   buildComp = componentId: component: comp-builder {
     inherit componentId component package name src flags setup cabalFile cabal-generator patches revision

--- a/builder/ghc-for-component-wrapper.nix
+++ b/builder/ghc-for-component-wrapper.nix
@@ -1,12 +1,16 @@
-# This is a simplified version of the ghcWithPackages wrapper in
-# nixpkgs, adapted to work with the package database of a single
-# component.
+# The ghcForComponent function wraps ghc so that it is configured with
+# the package database of all dependencies of a given component.
+# It has been adapted from the ghcWithPackages wrapper in nixpkgs.
+#
+# This wrapper exists so that nix-shells for components will have a
+# GHC automatically configured with the dependencies in the package
+# database.
+
 { lib, stdenv, ghc, runCommand, lndir, makeWrapper
 }:
 
-{ package
-, configFiles
-, postBuild ? ""
+{ componentName  # Full derivation name of the component
+, configFiles    # The component's "config" derivation
 }:
 
 let
@@ -18,12 +22,11 @@ let
   docDir         = "$out/share/doc/ghc/html";
   packageCfgDir  = "${libDir}/package.conf.d";
 
-in runCommand "${ghc.name}-for-${package.identifier.name}" {
+in runCommand "${componentName}-${ghc.name}" {
   preferLocalBuild = true;
   passthru = {
     inherit (ghc) version meta;
     baseGhc = ghc;
-    inherit package;
   };
 } (
   ''

--- a/builder/with-package-wrapper.nix
+++ b/builder/with-package-wrapper.nix
@@ -10,15 +10,15 @@
 }:
 
 let
-  isGhcjs       = ghc.isGhcjs or false;
+  isGhcjs        = ghc.isGhcjs or false;
   ghcCommand'    = if isGhcjs then "ghcjs" else "ghc";
-  ghcCommand = "${ghc.targetPrefix}${ghcCommand'}";
-  ghcCommandCaps= lib.toUpper ghcCommand';
-  libDir        = "$out/lib/${ghcCommand}-${ghc.version}";
-  docDir        = "$out/share/doc/ghc/html";
-  packageCfgDir = "${libDir}/package.conf.d";
+  ghcCommand     = "${ghc.targetPrefix}${ghcCommand'}";
+  ghcCommandCaps = lib.toUpper ghcCommand';
+  libDir         = "$out/lib/${ghcCommand}-${ghc.version}";
+  docDir         = "$out/share/doc/ghc/html";
+  packageCfgDir  = "${libDir}/package.conf.d";
 
-in runCommand "${ghc.name}-with-${package.identifier.name}" {
+in runCommand "${ghc.name}-for-${package.identifier.name}" {
   preferLocalBuild = true;
   passthru = {
     inherit (ghc) version meta;
@@ -32,49 +32,56 @@ in runCommand "${ghc.name}-with-${package.identifier.name}" {
     # Start with a ghc...
     mkdir -p $out/bin
     ${lndir}/bin/lndir -silent ${ghc} $out
-
-    # ...and replace package database with the one from target package config.
-    rm -rf ${libDir}
-    mkdir -p ${libDir}
-    # ... yet retain the lib/.../bin directory. This contains `unlit' and friends.
-    ${lndir}/bin/lndir -silent ${ghc}/lib/${ghcCommand}-${ghc.version}/bin ${libDir}
-
+    # ... remove all of the package directories
+    rm -rf ${libDir}/*/
+    # ... but retain the lib/ghc/bin directory. This contains `unlit' and friends.
+    ln -s ${ghc}/lib/${ghcCommand}-${ghc.version}/bin ${libDir}
+    # Replace the package database with the one from target package config.
     ln -s ${configFiles}/package.conf.d ${packageCfgDir}
 
     # Wrap compiler executables with correct env variables.
     # The NIX_ variables are used by the patched Paths_ghc module.
-    # The GHC_ENVIRONMENT variable forces ghc to use the build
-    # dependencies of the component.
 
-    for prg in ${ghcCommand} ${ghcCommand}i ${ghcCommand}-${ghc.version} ${ghcCommand}i-${ghc.version} runghc runhaskell; do
+    for prg in ${ghcCommand} ${ghcCommand}i ${ghcCommand}-${ghc.version} ${ghcCommand}i-${ghc.version}; do
       if [[ -x "${ghc}/bin/$prg" ]]; then
         rm -f $out/bin/$prg
         makeWrapper ${ghc}/bin/$prg $out/bin/$prg                           \
+          --add-flags '"-B$NIX_${ghcCommandCaps}_LIBDIR"'                   \
           --set "NIX_${ghcCommandCaps}"        "$out/bin/${ghcCommand}"     \
           --set "NIX_${ghcCommandCaps}PKG"     "$out/bin/${ghcCommand}-pkg" \
           --set "NIX_${ghcCommandCaps}_DOCDIR" "${docDir}"                  \
-          --set "NIX_${ghcCommandCaps}_LIBDIR" "${libDir}"                  \
-          --set "${ghcCommandCaps}_ENVIRONMENT" "${configFiles}/ghc-environment"
+          --set "NIX_${ghcCommandCaps}_LIBDIR" "${libDir}"
       fi
     done
 
+    for prg in runghc runhaskell; do
+      if [[ -x "${ghc}/bin/$prg" ]]; then
+        rm -f $out/bin/$prg
+        makeWrapper ${ghc}/bin/$prg $out/bin/$prg                           \
+          --add-flags "-f $out/bin/${ghcCommand}"                           \
+          --set "NIX_${ghcCommandCaps}"        "$out/bin/${ghcCommand}"     \
+          --set "NIX_${ghcCommandCaps}PKG"     "$out/bin/${ghcCommand}-pkg" \
+          --set "NIX_${ghcCommandCaps}_DOCDIR" "${docDir}"                  \
+          --set "NIX_${ghcCommandCaps}_LIBDIR" "${libDir}"
+      fi
+    done
+
+    # Wrap haddock, if the base GHC provides it.
+    if [[ -x "${ghc}/bin/haddock" ]]; then
+      rm -f $out/bin/haddock
+      makeWrapper ${ghc}/bin/haddock $out/bin/haddock    \
+        --add-flags '"-B$NIX_${ghcCommandCaps}_LIBDIR"'  \
+        --set "NIX_${ghcCommandCaps}_LIBDIR" "${libDir}"
+    fi
+
     # Point ghc-pkg to the package database of the component using the
-    # GHC_PACKAGE_PATH variable.
+    # --global-package-db flag.
 
     for prg in ${ghcCommand}-pkg ${ghcCommand}-pkg-${ghc.version}; do
       if [[ -x "${ghc}/bin/$prg" ]]; then
         rm -f $out/bin/$prg
-        makeWrapper ${ghc}/bin/$prg $out/bin/$prg \
-          --set "${ghcCommandCaps}_PACKAGE_PATH" "${configFiles}/package.conf.d"
+        makeWrapper ${ghc}/bin/$prg $out/bin/$prg --add-flags "--global-package-db=${packageCfgDir}"
       fi
     done
-
-    # fixme: check if this is needed
-    # haddock was referring to the base ghc, https://github.com/NixOS/nixpkgs/issues/36976
-    if [[ -x "${ghc}/bin/haddock" ]]; then
-      rm -f $out/bin/haddock
-      makeWrapper ${ghc}/bin/haddock $out/bin/haddock    \
-        --set "NIX_${ghcCommandCaps}_LIBDIR" "${libDir}"
-    fi
   ''
 )

--- a/modules/component-driver.nix
+++ b/modules/component-driver.nix
@@ -6,10 +6,10 @@ let
     ghc = config.ghc.package;
     buildGHC = buildModules.config.ghc.package;
     inherit (config) nonReinstallablePkgs hsPkgs;
-    inherit withPackage;
+    inherit ghcForComponent;
   };
 
-  withPackage = import ../builder/with-package-wrapper.nix {
+  ghcForComponent = import ../builder/ghc-for-component-wrapper.nix {
     inherit lib;
     inherit (pkgs.buildPackages) stdenv runCommand makeWrapper;
     inherit (pkgs.buildPackages.xorg) lndir;


### PR DESCRIPTION
This lets ghci work in development shells.

Fixes #44.
