### PR TITLE
Use hpack to generate cabal files when required

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, ghc, lib, pkgconfig, writeText, runCommand, haskellLib, nonReinstallablePkgs, withPackage }:
+{ stdenv, buildPackages, ghc, lib, pkgconfig, writeText, runCommand, haskellLib, nonReinstallablePkgs, withPackage, hsPkgs }:
 
 { componentId
 , component
@@ -9,6 +9,7 @@
 , flags
 , revision
 , cabalFile
+, cabal-generator
 , patches ? []
 
 , preUnpack ? null, postUnpack ? null
@@ -240,9 +241,11 @@ stdenv.mkDerivation ({
   # Phases
   preInstallPhases = lib.optional doHaddock' "haddockPhase";
 
-  prePatch = lib.optionalString (cabalFile != null) ''
-    cat ${cabalFile} > ${package.identifier.name}.cabal
-  '';
+  prePatch = if (cabalFile != null)
+     then ''cat ${cabalFile} > ${package.identifier.name}.cabal''
+     else if (cabal-generator == "hpack")
+         then ''${hsPkgs.hpack.components.exes.hpack}/bin/hpack''
+         else "";
 
   configurePhase = ''
     runHook preConfigure

--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -243,9 +243,9 @@ stdenv.mkDerivation ({
 
   prePatch = if (cabalFile != null)
      then ''cat ${cabalFile} > ${package.identifier.name}.cabal''
-     else if (cabal-generator == "hpack")
-         then ''${hsPkgs.hpack.components.exes.hpack}/bin/hpack''
-         else "";
+     else lib.optionalString (cabal-generator == "hpack") ''
+       ${hsPkgs.hpack.components.exes.hpack}/bin/hpack
+     '';
 
   configurePhase = ''
     runHook preConfigure

--- a/builder/default.nix
+++ b/builder/default.nix
@@ -1,8 +1,9 @@
-{ pkgs, buildPackages, stdenv, lib, haskellLib, ghc, buildGHC, fetchurl, writeText, runCommand, pkgconfig, nonReinstallablePkgs, withPackage }:
+{ pkgs, buildPackages, stdenv, lib, haskellLib, ghc, buildGHC, fetchurl, writeText, runCommand, pkgconfig, nonReinstallablePkgs, withPackage, hsPkgs }:
 
 { flags
 , package
 , components
+, cabal-generator
 
 , name
 , sha256
@@ -71,10 +72,10 @@ let
       '';
     };
 
-  comp-builder = haskellLib.weakCallPackage pkgs ./comp-builder.nix { inherit ghc haskellLib nonReinstallablePkgs withPackage; };
+  comp-builder = haskellLib.weakCallPackage pkgs ./comp-builder.nix { inherit ghc haskellLib nonReinstallablePkgs withPackage hsPkgs; };
 
   buildComp = componentId: component: comp-builder {
-    inherit componentId component package name src flags setup cabalFile patches revision
+    inherit componentId component package name src flags setup cabalFile cabal-generator patches revision
             preUnpack postUnpack preConfigure postConfigure
             preBuild postBuild preCheck postCheck
             preInstall postInstall preHaddock postHaddock

--- a/modules/component-driver.nix
+++ b/modules/component-driver.nix
@@ -5,9 +5,8 @@ let
     inherit haskellLib;
     ghc = config.ghc.package;
     buildGHC = buildModules.config.ghc.package;
-    inherit (config) nonReinstallablePkgs;
+     inherit (config) nonReinstallablePkgs hsPkgs;
     inherit withPackage;
-    inherit (config) hsPkgs;
   };
 
   withPackage = import ../builder/with-package-wrapper.nix {

--- a/modules/component-driver.nix
+++ b/modules/component-driver.nix
@@ -5,7 +5,7 @@ let
     inherit haskellLib;
     ghc = config.ghc.package;
     buildGHC = buildModules.config.ghc.package;
-     inherit (config) nonReinstallablePkgs hsPkgs;
+    inherit (config) nonReinstallablePkgs hsPkgs;
     inherit withPackage;
   };
 

--- a/modules/component-driver.nix
+++ b/modules/component-driver.nix
@@ -7,6 +7,7 @@ let
     buildGHC = buildModules.config.ghc.package;
     inherit (config) nonReinstallablePkgs;
     inherit withPackage;
+    inherit (config) hsPkgs;
   };
 
   withPackage = import ../builder/with-package-wrapper.nix {


### PR DESCRIPTION
Fixes #80 
No `nix-tools` changes are needed, `hpack` is taken from `hsPkgs` as it was suggested by @angerman 