### PR TITLE
docs: Add instructions for installing nix-tools

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,3 +1,5 @@
+#+STARTUP: showall hidestars
+
 * Alternative Haskell Infrastructure for Nixpkgs
 
 [[https://travis-ci.org/input-output-hk/haskell.nix][https://travis-ci.org/input-output-hk/haskell.nix.svg?branch=master]]
@@ -8,7 +10,7 @@ It works by automatically translating your Cabal or Stack project and
 its dependencies into Nix code. Most of your dependencies are already
 translated, so you generally won't have too much generated code.
 
-For the full documentation, see https://input-output-hk.github.io/haskell.nix/.
+For the documentation, see https://input-output-hk.github.io/haskell.nix/.
 
 ** Quickstart
 
@@ -32,3 +34,8 @@ Haskell packages in Nix. It depends on other repos, which are:
 
 - [[https://github.com/input-output-hk/stackage.nix][stackage.nix]] — all of the [[https://www.stackage.org/][Stackage]] snapshots, converted to Nix
   expressions.
+
+** IRC Channel
+
+Join the [[https://www.irccloud.com/invite?channel=%23nix-tools&hostname=irc.freenode.net&port=6697&ssl=1][#nix-tools]] channel on irc.freenode.net to get help or discuss
+the development of =haskell.nix= and =nix-tools=.

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,9 +50,9 @@ tricky to do.  This also leads to the cyclic dependencies issue.
 
 ### cyclic dependencies
 
-Because the Haskell builder in `nixpkgs` exposes packages at the
-package level, if packages mutually depend on each other through tests
-and libraries, lead to cyclic dependencies that nix can't resolve.  By
+The Haskell builder in `nixpkgs` exposes packages at the
+package level. If packages mutually depend on each other through tests
+and libraries, this leads to cyclic dependencies that nix can't resolve. By
 exposing the components to nix as separate derivations this will only
 occur if you have mutually dependent components.
 
@@ -73,17 +73,17 @@ the optimum.
 
 ### more logic in nix
 
-The `cabal2nix` tool has a resolver that resolved system dependencies
-and licenses to values in `nixpkgs`.  This logic end up being a simple
-dictionary lookup and can be a simple nix expression.  This also
+The `cabal2nix` tool has a resolver that resolves system dependencies
+and licenses to values in `nixpkgs`.  This logic ends up being a simple
+dictionary lookup and therefore can be a simple nix expression. This also
 offloads some of the work the cabal to nix translation tool needs to
 do into nix, and as such if changes are necessary (or needed to be
 performed ad hoc) there is no need to rebuild the conversion tool and
 subsequently mark every derived expression as out of date.
 
-### decoupleing
+### decoupling
 
-Finally by treating Haskell.nix and nixpkgs as separate entities we
+Finally, by treating Haskell.nix and nixpkgs as separate entities we
 can decouple the Haskell packages and infrastructure from the nixpkgs
 package set, and rely on it to provide us with system packages while
 staying up to date with Haskell packages from hackage while retaining

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -6,6 +6,20 @@ produce a `pkgs.nix` expressions.  Getting a copy of the haskell.nix,
 hackage.nix (and potentially stackage.nix) source will then equip us
 to produce derivations that we can `nix build`.
 
+## Installing `nix-tools`
+
+To build the latest `nix-tools` and store the result at `./nt`, run:
+
+```bash
+nix build -f https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz nix-tools --out-link nt
+```
+
+If you would like to then install `nix-tools` into your profile, run:
+
+```bash
+nix-env -i ./nt
+```
+
 ## Setup
 
 The general structure will be the same for haskell.nix, independent of


### PR DESCRIPTION
- Added section to user guide on how to install `nix-tools`.
- Fixed some sentences in the introduction.
- Added a link to the `#nix-tools` IRC channel in the readme, in case the docs don't fully answer users' questions.
