### PR TITLE
Add Hydra jobset and Buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,9 +1,9 @@
 env:
-  NIX_PATH: "nixpkgs=channel:nixos-19.03"
+  NIX_PATH: "nixpkgs=channel:nixos-18.09"
   NIX_BUILD_ARGS: "--cores 0 --max-jobs 2"
 
 steps:
   - label: 'Run tests'
-    command: ./test/tests.sh
+    command: "NIX_PATH=nixpkgs=channel:nixos-18.09 ./test/tests.sh"
     agents:
       system: x86_64-linux

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,9 @@
+env:
+  NIX_PATH: "nixpkgs=channel:nixos-19.03"
+  NIX_BUILD_ARGS: "--cores 0 --max-jobs 2"
+
+steps:
+  - label: 'Run tests'
+    command: ./test/tests.sh
+    agents:
+      system: x86_64-linux

--- a/README.org
+++ b/README.org
@@ -3,6 +3,7 @@
 * Alternative Haskell Infrastructure for Nixpkgs
 
 [[https://travis-ci.org/input-output-hk/haskell.nix][https://travis-ci.org/input-output-hk/haskell.nix.svg?branch=master]]
+[[https://buildkite.com/input-output-hk/haskell-dot-nix][https://badge.buildkite.com/d453edcd29bd2f8f3f3b32c9b7d6777a33773d9671c37a6ccc.svg]]
 
 =haskell.nix= is an experimental new builder for Haskell packages.
 

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,7 @@
+with (import ./default.nix {});
+
+{
+  inherit nix-tools;
+
+  tests = callPackage ./test {};
+}

--- a/test/default.nix
+++ b/test/default.nix
@@ -1,12 +1,10 @@
-{ pkgs ? import <nixpkgs> { } }:
+{ pkgs ? import <nixpkgs> { }
+, haskell ? pkgs.callPackage ../. { }
+}:
 
 with pkgs;
 
 let
-
-  # The new Haskell infra applied to nix representation of Hackage
-  haskell = pkgs.callPackage ../. { };
-
   util = callPackage ./util.nix {};
 
 in {


### PR DESCRIPTION
Add some very basic CI.

The Buildkite pipeline is for running non-pure tests.

The Hydra jobset will allow us to add nix-tools to the IOHK binary cache.

Needs input-output-hk/nix-tools#44 merged first.
Hydra jobset PR: input-output-hk/iohk-ops#548

Buildkite: https://buildkite.com/input-output-hk/haskell-dot-nix
