### PR TITLE
Buildkite: Fix daily update git push

### DIFF
--- a/scripts/update-pins.nix
+++ b/scripts/update-pins.nix
@@ -22,5 +22,7 @@ in
 
     use_ssh_key ${sshKey}
 
-    git push ${repo}
+    if [ "$BUILDKITE_BRANCH" = master ]; then
+      git push ${repo} HEAD:master
+    fi
   ''


### PR DESCRIPTION
https://buildkite.com/input-output-hk/haskell-dot-nix-nightly-updates/builds/63

The daily build is failing due to:
1. Wrong git command - this PR fixes it.
2. SSH key not installed - we will need another infra deploy for that.
