### PR TITLE
Add mapping in system-nixpkgs-map bz2->pkgs.bzip2

### DIFF
--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -27,6 +27,7 @@ pkgs:
      Imlib2 = pkgs.imlib2;
      asound = pkgs.alsaLib;
      ffi = null;
+     bz2 = pkgs.bzip2;
    }
 # -- windows
 // { advapi32 = null; gdi32 = null; imm32 = null; msimg32 = null;


### PR DESCRIPTION
Thanks to @angerman for showing me where to do this.

This adds a mapping so packages that ask for the `bz2` system library will get it from the `bzip2` derivation in nixpkgs.