### PR TITLE
weakCallPackage:  don't drop unexpected args

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -78,6 +78,6 @@ with haskellLib;
   #
   weakCallPackage = scope: f: args:
     let f' = if lib.isFunction f then f else import f;
-        args' = scope // args;
-    in f' (builtins.intersectAttrs (builtins.functionArgs f') args');
+        args' = (builtins.intersectAttrs (builtins.functionArgs f') scope) // args;
+    in f' args';
 }


### PR DESCRIPTION
Make explicit argument name mistakes easier to catch, by not dropping them.