### PR TITLE
Add mappings to system-nixpkgs-map.nix

### DIFF
--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -29,6 +29,7 @@ pkgs:
      ffi = null;
      bz2 = pkgs.bzip2;
      util = pkgs.utillinux;
+     magic = pkgs.file;
    }
 # -- windows
 // { advapi32 = null; gdi32 = null; imm32 = null; msimg32 = null;

--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -30,6 +30,7 @@ pkgs:
      bz2 = pkgs.bzip2;
      util = pkgs.utillinux;
      magic = pkgs.file;
+     pq = pkgs.postgresql.lib; # just the lib output because we don't want all of postgres
    }
 # -- windows
 // { advapi32 = null; gdi32 = null; imm32 = null; msimg32 = null;


### PR DESCRIPTION
* The libmagic library is under the `file` attribute in Nixpkgs.
* The libpq library is under the `postgresql.lib` attribute in Nixpkgs.