### PR TITLE
Fix tests

### DIFF
--- a/test/callStackToNix/stack.yaml
+++ b/test/callStackToNix/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-13.6
+resolver: lts-13.19
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
With the nixpkgs bump (#131) there is no ghc-8.6.3 anymore.