### PR TITLE
Revert changes to buildPackages for nix-tools

### DIFF
--- a/call-stack-to-nix.nix
+++ b/call-stack-to-nix.nix
@@ -1,15 +1,14 @@
-/* The function obtained when this is applied to a package set calls
- * the stack-to-nix tool on a supplied source set and then
+/* The function obtained when this is applied to a package set calls 
+ * the stack-to-nix tool on a supplied source set and then 
  * imports the resulting pkgs.nix. The application of this function
  * to a source path can thus be used directly as the input to mkStackPackageSet
- */
-{ nix-tools, pkgs }:
-{ src, stackYaml ? null }:
+ */ 
+{ nix-tools, pkgs }: { src, stackYaml ? null }:
 let
   pkgsNix = pkgs.stdenv.mkDerivation {
     name = "pkgs-nix";
     inherit src;
-    nativeBuildInputs = [ nix-tools pkgs.nix-prefetch-git ];
+    nativeBuildInputs = [ nix-tools pkgs.nix-prefetch-git pkgs.rsync ];
     installPhase = ''
       export LANG=C.utf8 # Needed or stack-to-nix will die on unicode inputs
       mkdir -p $out

--- a/default.nix
+++ b/default.nix
@@ -52,7 +52,12 @@ let
     override = "stackage";
   });
 
-  packages = self: ({
+  packages = pkgs: self: (rec {
+    inherit pkgs; # Make pkgs available via callPackage
+
+    # Packages built to run on the build platform, not the host platform
+    buildPackages = pkgs.buildPackages.lib.makeScope pkgs.buildPackages.newScope (packages pkgs.buildPackages);
+
     # Utility functions for working with the component builder.
     haskellLib = let hl = import ./lib { inherit (pkgs) lib; haskellLib = hl; }; in hl;
 
@@ -106,12 +111,11 @@ let
       };
 
     # Programs for generating Nix expressions from Cabal and Stack
-    # files. We need to make sure we build this from the buildPackages,
-    # we never want to actually cross compile nix-tools on it's own.
-    nix-tools = pkgs.buildPackages.callPackage ./nix-tools { inherit fetchExternal; inherit (self) mkCabalProjectPkgSet; };
+    # files.
+    nix-tools = self.callPackage ./nix-tools { inherit fetchExternal; };
 
     # Function to call stackToNix
-    callStackToNix = self.callPackage ./call-stack-to-nix.nix {};
+    callStackToNix = buildPackages.callPackage ./call-stack-to-nix.nix {};
 
     # Snapshots of Hackage and Stackage, converted to Nix expressions,
     # regularly updated.
@@ -126,4 +130,4 @@ let
   });
 
 in
-  pkgs.lib.makeScope pkgs.newScope packages
+  pkgs.lib.makeScope pkgs.newScope (packages pkgs)

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -12,7 +12,7 @@ rm -rvf */cabal.project.local */.ghc.environment* */dist */dist-newstyle */.stac
 echo >& 2
 
 printf "*** Running the nix-build tests...\n" >& 2
-nix build $NIX_BUILD_ARGS --no-link --keep-going -f ./default.nix
+nix-build $NIX_BUILD_ARGS --no-out-link --keep-going ./default.nix
 echo >& 2
 
 printf "*** Running the unit tests... " >& 2


### PR DESCRIPTION
The changes made before merging #116 broke the use of callStackToNix in a cross-compiled package set. This reverts those changes. Before the changes, callStackToNix would use nix-tools and nix-prefetch-git from the build platform, after the changes, it attempts to build them on the cross-compilation target, and then run them on the build platform.

Simply calling the nix-tools derivation from pkgs.buildPackages is not sufficient, seemingly due to the way haskell.nix propagates the package set and stdenv. I was not able to track down exactly why, but it seems necessary to make a buildPackages scope that can be used to call callStackToNix and/or nix-tools.

This PR reverts that set of changes, so that callStackToNix will work properly on cross-compiled builds.