### PR TITLE
fix typo, --help argument does not exist

### DIFF
--- a/README.org
+++ b/README.org
@@ -18,7 +18,7 @@ This will download and build =nix-tools=.
 
 #+begin_src sh
 nix build -f https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz nix-tools -o nt
-./nt/bin/cabal-to-nix --help
+./nt/bin/cabal-to-nix
 #+end_src
 
 ** Related repos


### PR DESCRIPTION
If we follow the readme we have this error:

```
./nt/bin/cabal-to-nix --help
cabal-to-nix: dieVerbatim: user error (cabal-to-nix: Error Parsing: file "--help" doesn't exist. Cannot continue.
)
```
