### PR TITLE
Add cleanSourceHaskell and use it on nix-tools

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -38,6 +38,8 @@ let
   # overridden with NIX_PATH.
   fetchExternal = import ./lib/fetch-external.nix;
 
+  cleanSourceHaskell = pkgs.callPackage ./lib/clean-source-haskell.nix {};
+
   # All packages from Hackage as Nix expressions
   hackage = import (fetchExternal {
     name     = "hackage-exprs-source";
@@ -108,7 +110,7 @@ let
     # Programs for generating Nix expressions from Cabal and Stack
     # files. We need to make sure we build this from the buildPackages,
     # we never want to actually cross compile nix-tools on it's own.
-    nix-tools = pkgs.buildPackages.callPackage ./nix-tools { inherit fetchExternal; inherit (self) mkCabalProjectPkgSet; };
+    nix-tools = pkgs.buildPackages.callPackage ./nix-tools { inherit fetchExternal cleanSourceHaskell; inherit (self) mkCabalProjectPkgSet; };
 
     # Function to call stackToNix
     callStackToNix = self.callPackage ./call-stack-to-nix.nix {};
@@ -126,6 +128,9 @@ let
 
     # Make this handy overridable fetch function available.
     inherit fetchExternal;
+
+    # Function for cleaning haskell source diretories.
+    inherit cleanSourceHaskell;
 
     # Produce a fixed output derivation from a moving target (hackage index tarball)
     hackageTarball = { index-state, sha256 }:

--- a/default.nix
+++ b/default.nix
@@ -38,6 +38,7 @@ let
   # overridden with NIX_PATH.
   fetchExternal = import ./lib/fetch-external.nix;
 
+  # Function for cleaning haskell source directories pulled from iohk-nix
   cleanSourceHaskell = pkgs.callPackage ./lib/clean-source-haskell.nix {};
 
   # All packages from Hackage as Nix expressions

--- a/lib/clean-source-haskell.nix
+++ b/lib/clean-source-haskell.nix
@@ -1,3 +1,10 @@
+# This function cleans common build products and files not needed to do a
+# haskell build from a source directory.
+# This can avoid unecessary builds when these files change.
+# It has been copied from iohk-nix so that it can be used internally in
+# haskell.nix and made available to projects that do not use iohk-nix.
+# The original version is here:
+# https://github.com/input-output-hk/iohk-nix/blob/c01bbd4e0c55a4101e2078d24046e0b2a731f871/clean-source-haskell.nix
 { pkgs }: src:
   let lib = pkgs.lib;
   in if (builtins.typeOf src) == "path"

--- a/lib/clean-source-haskell.nix
+++ b/lib/clean-source-haskell.nix
@@ -1,0 +1,18 @@
+{ pkgs }: src:
+  let lib = pkgs.lib;
+  in if (builtins.typeOf src) == "path"
+    then lib.cleanSourceWith {
+      filter = with pkgs.stdenv;
+        name: type: let baseName = baseNameOf (toString name); in ! (
+          # Filter out cabal build products.
+          baseName == "dist" || baseName == "dist-newstyle" ||
+          baseName == "cabal.project.local" ||
+          lib.hasPrefix ".ghc.environment" baseName ||
+          # Filter out stack build products.
+          lib.hasPrefix ".stack-work" baseName ||
+          # Filter out files which are commonly edited but don't
+          # affect the cabal build.
+          lib.hasSuffix ".nix" baseName
+        );
+      src = lib.cleanSource src;
+    } else src

--- a/nix-tools/default.nix
+++ b/nix-tools/default.nix
@@ -1,11 +1,11 @@
-{ symlinkJoin, fetchExternal, mkCabalProjectPkgSet }:
+{ symlinkJoin, fetchExternal, cleanSourceHaskell, mkCabalProjectPkgSet }:
 
 let
-  src = fetchExternal {
+  src = cleanSourceHaskell (fetchExternal {
     name     = "nix-tools-src";
     specJSON = ./nix-tools-src.json;
     override = "nix-tools";
-  };
+  });
 
   pkgSet = mkCabalProjectPkgSet {
     plan-pkgs = import ./pkgs.nix;


### PR DESCRIPTION
Currently if you override nix-tools using `-I nix-tools` to point to
a local directory that has build output directories like `dist-newstyle`
those directories are hashed and copied to the nix store if they have
changes.  This change adds the `cleanHaskellSource` function from
`iohk-nix` and runs it on nix-tools.