### PR TITLE
Build Hoogle index for development shell

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -20,6 +20,13 @@ let
     inherit ghc haskellLib nonReinstallablePkgs;
   };
 
+  hoogleLocal = let
+    nixpkgsHoogleLocal = import (pkgs.path + /pkgs/development/haskell-modules/hoogle.nix);
+  in { packages ? [], hoogle ? pkgs.haskellPackages.hoogle }:
+    haskellLib.weakCallPackage pkgs nixpkgsHoogleLocal {
+      inherit packages hoogle;
+    };
+
 in {
   # Build a Haskell package from its config.
   # TODO: this pkgs is the adjusted pkgs, but pkgs.pkgs is unadjusted
@@ -29,7 +36,7 @@ in {
 
   # Same as haskellPackages.shellFor in nixpkgs.
   shellFor = haskellLib.weakCallPackage pkgs ./shell-for.nix {
-    inherit hsPkgs ghcForComponent makeConfigFiles;
+    inherit hsPkgs ghcForComponent makeConfigFiles hoogleLocal haskellLib;
     inherit (buildPackages) glibcLocales;
   };
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -80,4 +80,16 @@ with haskellLib;
     let f' = if lib.isFunction f then f else import f;
         args' = (builtins.intersectAttrs (builtins.functionArgs f') scope) // args;
     in f' args';
+
+  # Collect all (transitive) Haskell library dependencies of a
+  # component.
+  ## flatLibDepends :: Component -> [Package]
+  flatLibDepends = component:
+    let
+      makePairs = map (p: rec { key="${val}"; val=(p.components.library or p); });
+      closure = builtins.genericClosure {
+        startSet = makePairs component.depends;
+        operator = {val,...}: makePairs val.config.depends;
+      };
+    in map ({val,...}: val) closure;
 }

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -61,4 +61,11 @@ nix-shell $NIX_BUILD_ARGS \
     --run 'cd shell-for && cabal new-build all'
 echo >& 2
 
+printf "*** Checking shellFor has a working hoogle index...\n" >& 2
+nix-shell $NIX_BUILD_ARGS \
+    --pure ./default.nix \
+    -A shell-for.env \
+    --run 'hoogle ConduitT | grep Data.Conduit'
+echo >& 2
+
 printf "\n*** Finished successfully\n" >& 2


### PR DESCRIPTION
This PR depends on #121.

It works, but uses `pkgs.haskellPackages.hoogle` from nixpkgs, which is not ideal. With PR #151 merged, this could be replaced with `haskellPackages.hoogle.components.exes.hoogle`, which takes hoogle from a recent LTS snapshot.
