### PR TITLE
Add ghcWithPackages and ghcWithHoogle to hsPkgs

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -27,6 +27,20 @@ let
       inherit packages hoogle;
     };
 
+  # Same as haskellPackages.shellFor in nixpkgs.
+  shellFor = haskellLib.weakCallPackage pkgs ./shell-for.nix {
+    inherit hsPkgs ghcForComponent makeConfigFiles hoogleLocal haskellLib;
+    inherit (buildPackages) glibcLocales;
+  };
+
+  # Same as haskellPackages.ghcWithPackages and ghcWithHoogle in nixpkgs.
+  withPackages = {withHoogle}: packages: (shellFor {
+    name = ghc.name + "-with-packages";
+    packages = _: [];
+    additional = packages;
+    inherit withHoogle;
+  }).ghc;
+
 in {
   # Build a Haskell package from its config.
   # TODO: this pkgs is the adjusted pkgs, but pkgs.pkgs is unadjusted
@@ -34,9 +48,8 @@ in {
     inherit haskellLib ghc buildGHC comp-builder;
   };
 
-  # Same as haskellPackages.shellFor in nixpkgs.
-  shellFor = haskellLib.weakCallPackage pkgs ./shell-for.nix {
-    inherit hsPkgs ghcForComponent makeConfigFiles hoogleLocal haskellLib;
-    inherit (buildPackages) glibcLocales;
-  };
+  inherit shellFor;
+
+  ghcWithPackages = withPackages { withHoogle = false; };
+  ghcWithHoogle = withPackages { withHoogle = true; };
 }

--- a/builder/shell-for.nix
+++ b/builder/shell-for.nix
@@ -1,9 +1,10 @@
 { lib, stdenv, glibcLocales, pkgconfig, ghcForComponent, makeConfigFiles, hsPkgs, hoogleLocal, haskellLib }:
 
-{ packages, withHoogle ? true, ... } @ args:
+{ packages, additional ? _: [], withHoogle ? true, ... } @ args:
 
 let
   selected = packages hsPkgs;
+  additionalSelected = additional hsPkgs;
   selectedConfigs = map (p: p.components.all.config) selected;
 
   name = if lib.length selected == 1
@@ -15,7 +16,7 @@ let
   # new-style commands.
   packageInputs = lib.filter
     (input: lib.all (cfg: input.identifier != cfg.identifier) selected)
-    (lib.concatMap (cfg: cfg.depends) selectedConfigs);
+    (lib.concatMap (cfg: cfg.depends) selectedConfigs ++ additionalSelected);
 
   # Add the system libraries and build tools of the selected haskell
   # packages to the shell.
@@ -53,7 +54,7 @@ let
     # inherit (hsPkgs) hoogle;
   };
 
-  mkDrvArgs = builtins.removeAttrs args ["packages" "withHoogle"];
+  mkDrvArgs = builtins.removeAttrs args ["packages" "additional" "withHoogle"];
 in
   stdenv.mkDerivation (mkDrvArgs // {
     name = mkDrvArgs.name or name;

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,14 @@
 This file contains a summary of changes to Haskell.nix and `nix-tools`
 that will impact users.
 
+## June 21, 2019
+ * Add `ghcWithPackages` and `ghcWithHoogle` to hsPkgs ([documentation](https://input-output-hk.github.io/haskell.nix/reference/library/#package-set-functions).
+ * Benchmark components can now build successfully.
+ * Reduced the closure bloat of nix-tools, and added closure size limit to CI.
+ * Added more reference documentation and set up auto-generated
+   documentation for [Module Options](https://input-output-hk.github.io/haskell.nix/reference/modules/).
+ * Miscellaneous bug fixes.
+
 ## June 7, 2019
   * Several additions to the [documentation](https://input-output-hk.github.io/haskell.nix/).
     * More information about getting nix-tools, Haskell.nix, pinning.

--- a/modules/component-driver.nix
+++ b/modules/component-driver.nix
@@ -41,7 +41,7 @@ in
   };
 
   config.hsPkgs =
-    { inherit (builder) shellFor;
+    { inherit (builder) shellFor ghcWithPackages ghcWithHoogle;
       buildPackages = buildModules.config.hsPkgs;
     } //
     lib.mapAttrs

--- a/test/snapshots/default.nix
+++ b/test/snapshots/default.nix
@@ -1,19 +1,33 @@
-{ stdenv, haskellPackages }:
+{ stdenv, haskellPackages, snapshots }:
 
 with stdenv.lib;
 
+let
+  env = snapshots."lts-12.21".ghcWithHoogle
+    (ps: with ps; [ conduit conduit-extra resourcet ]);
+
+in
   stdenv.mkDerivation {
     name = "shell-for-test";
 
     buildCommand = ''
       ########################################################################
-      # test snapshot ghcWithHoogle
+      # test single component from haskellPackages
 
       printf "checking that the latest LTS snapshot has the lens package...\n" >& 2
       test -d ${haskellPackages.lens.components.library}
+
+      ########################################################################
+      # test snapshot ghcWithHoogle
+
+      printf "checking that the ghcWithPackages env has the package...\n" >& 2
+      ${env}/bin/ghc-pkg list | grep conduit
 
       touch $out
     '';
 
     meta.platforms = platforms.all;
-  }
+    passthru = {
+      inherit env;
+    };
+}


### PR DESCRIPTION
These functions are like in nixpkgs `haskellPackages`. They let you select packages from a larger package set and easily get a shell. The difference between `ghcWithPackages` and `shellFor` is that `ghcWithPackages` provides the packages, but `shellFor` provides the _dependencies_ of the packages.

Depends on #147 being merged first.
