### PR TITLE
Add snapshots attribute

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -109,6 +109,11 @@ let
         modules = [ ghcHackagePatches.${compiler.nix-name} ] ++ modules;
       };
 
+    # Package sets for all stackage snapshots.
+    snapshots = self.callPackage ./snapshots.nix {};
+    # Pick a recent LTS snapshot to be our "default" package set.
+    haskellPackages = self.snapshots."lts-13.18";
+
     # Programs for generating Nix expressions from Cabal and Stack
     # files. We need to make sure we build this from the buildPackages,
     # we never want to actually cross compile nix-tools on it's own.

--- a/snapshots.nix
+++ b/snapshots.nix
@@ -1,3 +1,11 @@
+# This provides a package set for each snapshot in Stackage.
+#
+# It allows you to use a bare snapshot without having to invoke
+# mkStackPkgSet with a stack.yaml project.
+#
+# A particular package in a snapshot would be accessed with:
+#   snapshots."lts-13.18".conduit
+
 { lib, mkPkgSet, stackage }:
 
 with lib;
@@ -12,9 +20,9 @@ let
   # the half-open version interval [start, end).
   ltsInRange = start: end: name: let
     components = splitString "-" name;
-    version = last components;
+    version = concatStringsSep "-" (drop 1 components);
   in
-    assert length components == 2;
+    assert length components >= 2;
     head components == "lts"
     && versionAtLeast version start
     && versionOlder version end;

--- a/snapshots.nix
+++ b/snapshots.nix
@@ -35,9 +35,23 @@ let
           };
         };
       };
+
+      # Add hsc2hs to the snapshot. This is a build tool for many
+      # packages. Stackage does not include it in the snapshots
+      # because it is expected that hsc2hs comes with ghc.
+      fix-hsc2hs = {
+        extra = hackage: {
+          packages = {
+            "hsc2hs" = (((hackage.hsc2hs)."0.68.4").revisions).default;
+          };
+        };
+      };
     };
+
+    applyFix = name: fix: optional ((fix.predicate or (const true)) name) fix.extra;
+
   in
-    name: concatLists (mapAttrsToList (_: fix: optional (fix.predicate name) fix.extra) fixes);
+    name: concatLists (mapAttrsToList (_: applyFix name) fixes);
 
 in
   mapAttrs mkSnapshot stackage

--- a/snapshots.nix
+++ b/snapshots.nix
@@ -1,0 +1,43 @@
+{ lib, mkPkgSet, stackage }:
+
+with lib;
+
+let
+  mkSnapshot = name: pkg-def: (mkPkgSet {
+    inherit pkg-def;
+    pkg-def-extras = pkg-def-extras name;
+  }).config.hsPkgs;
+
+  # Tests whether snapshot name is an LTS within
+  # the half-open version interval [start, end).
+  ltsInRange = start: end: name: let
+    components = splitString "-" name;
+    version = last components;
+  in
+    assert length components == 2;
+    head components == "lts"
+    && versionAtLeast version start
+    && versionOlder version end;
+
+  # A function to get pkg-def-extras with build fixes for certain
+  # snapshots.
+  pkg-def-extras = let
+    fixes = {
+      # Work around a mismatch between stackage metadata and the
+      # libraries shipped with GHC.
+      # https://github.com/commercialhaskell/stackage/issues/4466
+      fix-ghc-transformers = {
+        predicate = ltsInRange "12" "14";
+        extra = hackage: {
+          packages = {
+            "transformers" = (((hackage.transformers)."0.5.6.2").revisions).default;
+            "process" = (((hackage.process)."1.6.5.0").revisions).default;
+          };
+        };
+      };
+    };
+  in
+    name: concatLists (mapAttrsToList (_: fix: optional (fix.predicate name) fix.extra) fixes);
+
+in
+  mapAttrs mkSnapshot stackage

--- a/test/default.nix
+++ b/test/default.nix
@@ -16,8 +16,8 @@ in {
   with-packages = haskell.callPackage ./with-packages { inherit util; };
   builder-haddock = haskell.callPackage ./builder-haddock {};
   stack-simple = haskell.callPackage ./stack-simple {};
+  snapshots = haskell.callPackage ./snapshots {};
   callStackToNix = haskell.callPackage ./callStackToNix {};
-
   callCabalProjectToNix = haskell.callPackage ./call-cabal-project-to-nix {};
 
   # Run unit tests with: nix-instantiate --eval --strict -A unit

--- a/test/snapshots/default.nix
+++ b/test/snapshots/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, haskellPackages }:
+
+with stdenv.lib;
+
+  stdenv.mkDerivation {
+    name = "shell-for-test";
+
+    buildCommand = ''
+      ########################################################################
+      # test snapshot ghcWithHoogle
+
+      printf "checking that the latest LTS snapshot has the lens package...\n" >& 2
+      test -d ${haskellPackages.lens.components.library}
+
+      touch $out
+    '';
+
+    meta.platforms = platforms.all;
+  }


### PR DESCRIPTION
This provides stackage LTS package sets that you can just use without needing `mkStackPkgSet`.

This will be useful together with `ghcWithPackages` and `ghcWithHoogle` (PR #150).
