### PR TITLE
Fix callCabalProjectToNix when using nix sandboxes

### DIFF
--- a/lib/cabalProjectToNix.nix
+++ b/lib/cabalProjectToNix.nix
@@ -79,4 +79,5 @@ in
     # todo: should we clean `src` to drop any .git, .nix, ... other irelevant files?
     rsync -a "${src}/" "$out/"
     rsync -a ${plan}/ $out/
+    chmod +w $out
   ''

--- a/lib/cabalProjectToNix.nix
+++ b/lib/cabalProjectToNix.nix
@@ -79,5 +79,8 @@ in
     # todo: should we clean `src` to drop any .git, .nix, ... other irelevant files?
     rsync -a "${src}/" "$out/"
     rsync -a ${plan}/ $out/
+    # Rsync will have made $out read only and that can cause problems when
+    # nix sandboxing is enabled (since it can prevent nix from moving the directory
+    # out of the chroot sandbox).
     chmod +w $out
   ''


### PR DESCRIPTION
I am not sure why this works on hydra, but on default install of nix
on ubuntu it fails to rename the plan-and-src $out because it is made
read only by rsync.