### PR TITLE
Add hooks to all components

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -12,12 +12,12 @@
 , cabal-generator
 , patches ? []
 
-, preUnpack ? null, postUnpack ? null
-, preConfigure ? null, postConfigure ? null
-, preBuild ? null, postBuild ? null
-, preCheck ? null, postCheck ? null
-, preInstall ? null, postInstall ? null
-, preHaddock ? null, postHaddock ? null
+, preUnpack ? component.preUnpack, postUnpack ? component.postUnpack
+, preConfigure ? component.preConfigure, postConfigure ? component.postConfigure
+, preBuild ? component.preBuild , postBuild ? component.postBuild
+, preCheck ? component.preCheck , postCheck ? component.postCheck
+, preInstall ? component.preInstall , postInstall ? component.postInstall
+, preHaddock ? component.preHaddock , postHaddock ? component.postHaddock
 , shellHook ? ""
 
 , doCheck ? component.doCheck || haskellLib.isTest componentId

--- a/builder/hspkg-builder.nix
+++ b/builder/hspkg-builder.nix
@@ -13,19 +13,6 @@
 , revisionSha256
 , patches
 
-, preUnpack
-, postUnpack
-, preConfigure
-, postConfigure
-, preBuild
-, postBuild
-, preCheck
-, postCheck
-, preInstall
-, postInstall
-, preHaddock
-, postHaddock
-
 , shellHook
 
 , ...
@@ -75,9 +62,6 @@ let
 
   buildComp = componentId: component: comp-builder {
     inherit componentId component package name src flags setup cabalFile cabal-generator patches revision
-            preUnpack postUnpack preConfigure postConfigure
-            preBuild postBuild preCheck postCheck
-            preInstall postInstall preHaddock postHaddock
             shellHook
             ;
   };

--- a/modules/package.nix
+++ b/modules/package.nix
@@ -87,7 +87,7 @@ with types;
     components = let
       componentType = submodule {
         # add the shared componentOptions
-        options = (componentOptions config) // {
+        options = (packageOptions config) // {
           depends = mkOption {
             type = listOfFilteringNulls unspecified;
             default = [];


### PR DESCRIPTION
Currently one can override the hooks used during nix build, such as `postInstall`, only at the level of a cabal package. This PR extends these hooks as options at the level of individual components. The specific use case that motivated this change was adding an environment variable to a test executable. In the `postInstall` phase, I wanted to run `makeWrapper` to add the env var into the executable, but I did not want to do this for all components in the pacakge. While I could have added conditional logic to the `postInstall` of the package, to detect the presence of the test executable, it seemed neater and a clearer expression of intent, to add this at the component level.

The components will still default to the package level option if you provide one, but that will then be overridden by a component level one. A full solution to this would probably fold the `packageOptions` and `componentOptions` into one, as they are now all shared, but I think this is good enough for now :)