### PR TITLE
Use release-lib.nix for Hydra

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,9 +4,16 @@ steps:
     agents:
       system: x86_64-linux
 
+  - label: 'Check that jobset will evaluate in Hydra'
+    command:
+      - nix-build build.nix -A maintainer-scripts.check-hydra -o check-hydra.sh
+      - ./check-hydra.sh
+    agents:
+      system: x86_64-linux
+
   - label: 'Update docs'
     command:
-      - nix-build -A maintainer-scripts.update-docs -o update-docs.sh
+      - nix-build build.nix -A maintainer-scripts.update-docs -o update-docs.sh
       - ./update-docs.sh
     branches: master
     agents:

--- a/.buildkite/updates.yml
+++ b/.buildkite/updates.yml
@@ -1,7 +1,7 @@
 steps:
   - label: 'Update hackage.nix'
     command:
-      - nix-build -A maintainer-scripts.update-hackage -o update-hackage.sh
+      - nix-build build.nix -A maintainer-scripts.update-hackage -o update-hackage.sh
       - echo "+++ Updating hackage.nix"
       - ./update-hackage.sh
     artifact_paths:
@@ -11,7 +11,7 @@ steps:
 
   - label: 'Update stackage.nix'
     command:
-      - nix-build -A maintainer-scripts.update-stackage -o update-stackage.sh
+      - nix-build build.nix -A maintainer-scripts.update-stackage -o update-stackage.sh
       - echo "+++ Updating stackage.nix"
       - ./update-stackage.sh
     artifact_paths:
@@ -25,7 +25,7 @@ steps:
   - label: 'Update pins'
     command:
       - 'buildkite-agent artifact download "*.json" .'
-      - nix-build -A maintainer-scripts.update-pins -o update-pins.sh
+      - nix-build build.nix -A maintainer-scripts.update-pins -o update-pins.sh
       - ./update-pins.sh
     agents:
       system: x86_64-linux

--- a/build.nix
+++ b/build.nix
@@ -25,5 +25,6 @@ in {
     update-stackage = haskell.callPackage ./scripts/update-stackage.nix {};
     update-pins = haskell.callPackage ./scripts/update-pins.nix {};
     update-docs = haskell.callPackage ./scripts/update-docs.nix {};
+    check-hydra = haskell.callPackage ./scripts/check-hydra.nix {};
   };
 }

--- a/build.nix
+++ b/build.nix
@@ -1,0 +1,29 @@
+# This file contains the package set used by the release.nix jobset.
+#
+# It is separate from default.nix because that file is the public API
+# of Haskell.nix, which shouldn't have tests, etc.
+
+{ pkgs ? import nixpkgs nixpkgsArgs
+, nixpkgs ? ./nixpkgs
+# Provide args to the nixpkgs instantiation.
+, system ? builtins.currentSystem
+, crossSystem ? null
+, config ? {}
+, nixpkgsArgs ? { inherit system crossSystem config; }
+}:
+
+let
+  haskell = import ./default.nix { inherit pkgs; };
+
+in {
+  inherit (haskell) nix-tools source-pins;
+  tests = import ./test/default.nix { inherit haskell; };
+
+  # Scripts for keeping Hackage and Stackage up to date, and CI tasks.
+  maintainer-scripts = pkgs.dontRecurseIntoAttrs {
+    update-hackage = haskell.callPackage ./scripts/update-hackage.nix {};
+    update-stackage = haskell.callPackage ./scripts/update-stackage.nix {};
+    update-pins = haskell.callPackage ./scripts/update-pins.nix {};
+    update-docs = haskell.callPackage ./scripts/update-docs.nix {};
+  };
+}

--- a/default.nix
+++ b/default.nix
@@ -132,14 +132,6 @@ let
     # regularly updated.
     inherit hackage stackage;
 
-    # Scripts for keeping Hackage and Stackage up to date.
-    maintainer-scripts = {
-      update-hackage = self.callPackage ./scripts/update-hackage.nix {};
-      update-stackage = self.callPackage ./scripts/update-stackage.nix {};
-      update-pins = self.callPackage ./scripts/update-pins.nix {};
-      update-docs = self.callPackage ./scripts/update-docs.nix {};
-    };
-
     # Make this handy overridable fetch function available.
     inherit fetchExternal;
 

--- a/docs/maintainer-scripts.md
+++ b/docs/maintainer-scripts.md
@@ -8,10 +8,10 @@ scripts in this repo.
 
 To run the updater scripts manually, use:
 
-    nix-build -A maintainer-scripts.update-hackage -o update-hackage.sh
+    nix-build build.nix -A maintainer-scripts.update-hackage -o update-hackage.sh
     ./update-hackage.sh
 
-    nix-build -A maintainer-scripts.update-stackage -o update-stackage.sh
+    nix-build build.nix -A maintainer-scripts.update-stackage -o update-stackage.sh
     ./update-stackage.sh
 
 The scripts will clone the repo, generate the latest data, then

--- a/nix-tools/default.nix
+++ b/nix-tools/default.nix
@@ -6,7 +6,7 @@ let
   src = cleanSourceHaskell (fetchExternal {
     name     = "nix-tools-src";
     specJSON = ./nix-tools-src.json;
-    override = "nix-tools";
+    override = "nix-tools-src";
   });
 
   pkgSet = mkCabalProjectPkgSet {

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,35 @@
-let
-  haskell = import ./default.nix {};
-in {
-  inherit (haskell) nix-tools source-pins;
+{ supportedSystems ? [ "x86_64-linux" ] # spare our "x86_64-darwin" builders for now
+, scrubJobs ? true
+, haskell-nix ? { outPath = ./.; rev = "abcdef"; }
+, nixpkgsArgs ? {}
+}:
 
-  tests = import ./test { inherit haskell; };
-}
+let fixedNixpkgs = import ./nixpkgs {}; in
+with fixedNixpkgs.lib;
+with (import (fixedNixpkgs.path + "/pkgs/top-level/release-lib.nix") {
+  inherit supportedSystems scrubJobs nixpkgsArgs;
+  packageSet = import (haskell-nix + /build.nix);
+});
+
+let
+  # Remove tests which have meta.disabled = true
+  filterTests = let
+    nonEmpty = attrs: length (attrValues attrs) != 0;
+    removeDisabled = filterAttrs (system: test: !(test.meta.disabled or false));
+  in jobs: jobs // {
+    tests = filterAttrs (_: nonEmpty) (mapAttrs (name: removeDisabled) jobs.tests);
+  };
+
+  jobs = {
+    native = filterTests (mapTestOn (packagePlatforms pkgs));
+  } // {
+    # On IOHK Hydra, "required" is a special job that updates the
+    # GitHub CI status.
+    required = fixedNixpkgs.releaseTools.aggregate {
+      name = "haskell.nix-required";
+      meta.description = "All jobs required to pass CI";
+      constituents = collect isDerivation jobs.native;
+    };
+  };
+
+in jobs

--- a/scripts/check-hydra.nix
+++ b/scripts/check-hydra.nix
@@ -1,0 +1,39 @@
+{ stdenv, writeScript, coreutils, time, hydra, jq }:
+
+with stdenv.lib;
+
+writeScript "check-hydra.sh" ''
+  #!${stdenv.shell}
+
+  set -euo pipefail
+
+  export PATH="${makeBinPath [ coreutils time hydra jq ]}"
+
+  echo '~~~ Evaluating release.nix'
+  command time --format '%e' -o eval-time.txt \
+      hydra-eval-jobs \
+      --option allowed-uris "https://github.com/NixOS https://github.com/input-output-hk" \
+      -I . release.nix > eval.json
+  EVAL_EXIT_CODE="$?"
+  if [ "$EVAL_EXIT_CODE" != 0 ]
+  then
+    rm eval.json eval-time.txt
+    echo -e "\\e[31;1mERROR: Failed to evaluate release.nix\\e[0m"
+    exit 1
+  fi
+  EVAL_TIME=$(cat eval-time.txt)
+  jq . < eval.json
+  ERRORS=$(jq -r 'map_values(.error)|to_entries[]|select(.value)|@text "\(.key): \(.value)"' < eval.json)
+  NUM_ERRORS=$(jq -r '[ map_values(.error)|to_entries[]|select(.value) ] |length' < eval.json)
+  rm eval.json eval-time.txt
+
+  if [ "$NUM_ERRORS" != 0 ]
+  then
+    echo -e "\\e[31;1mERROR: evaluation completed in $EVAL_TIME seconds with $NUM_ERRORS errors\\e[0m"
+    echo "$ERRORS"
+    exit 1
+  else
+    echo -e "\\e[32;1mOK: evaluation completed in $EVAL_TIME seconds with no errors\\e[0m"
+    exit 0
+  fi
+''

--- a/test/default.nix
+++ b/test/default.nix
@@ -1,5 +1,4 @@
-{ system ? builtins.currentSystem
-, pkgs ? import nixpkgs { inherit system; }
+{ pkgs ? import nixpkgs { }
 , nixpkgs ? ../nixpkgs
 , haskell ? pkgs.callPackage ../. { }
 }:
@@ -9,7 +8,7 @@ with pkgs;
 let
   util = callPackage ./util.nix {};
 
-in {
+in pkgs.recurseIntoAttrs {
   cabal-simple = haskell.callPackage ./cabal-simple { inherit util; };
   cabal-sublib = haskell.callPackage ./cabal-sublib { inherit util; };
   cabal-22 = haskell.callPackage ./cabal-22 {};


### PR DESCRIPTION
- Imports release-lib from Nixpkgs and does the `mapTestOn` stuff in `release.nix`
- Removes non-API builds from the `default.nix` package set and puts them in `build.nix`. So when users import Haskell.nix, they won't get irrelevant CI stuff.
- Adds a Buildkite CI pipeline which should make it more obvious when Hydra evaluation fails.
