### PR TITLE
Buildkite: fix dependencies of check-hydra script

### DIFF
--- a/scripts/check-hydra.nix
+++ b/scripts/check-hydra.nix
@@ -1,4 +1,4 @@
-{ stdenv, writeScript, coreutils, time, hydra, jq }:
+{ stdenv, writeScript, coreutils, time, gnutar, hydra, jq }:
 
 with stdenv.lib;
 
@@ -7,7 +7,7 @@ writeScript "check-hydra.sh" ''
 
   set -euo pipefail
 
-  export PATH="${makeBinPath [ coreutils time hydra jq ]}"
+  export PATH="${makeBinPath [ coreutils time gnutar hydra jq  ]}"
 
   echo '~~~ Evaluating release.nix'
   command time --format '%e' -o eval-time.txt \


### PR DESCRIPTION
CI has started to fail: https://buildkite.com/input-output-hk/haskell-dot-nix/builds/309#b1e8be70-54b4-411f-bd15-9b81b6721c42
This should fix it.

