### PR TITLE
gobject-introspction is not always available

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, ghc, lib, pkgconfig, gobject-introspection, haskellLib, makeConfigFiles, ghcForComponent, hsPkgs }:
+{ stdenv, buildPackages, ghc, lib, pkgconfig, gobject-introspection ? null, haskellLib, makeConfigFiles, ghcForComponent, hsPkgs }:
 
 { componentId
 , component


### PR DESCRIPTION
I think adding `? null` is probably a good fix.  The other option was add pkgs as a parameter get `gobject-introspection` out of that (so it would not need to be passed explicitly).  I think I prefer `? null` as having the explicit `gobject-interospection` argument makes it clearer what dependencies the function has.