### PR TITLE
Update comp-builder to run tests directly

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -104,6 +104,9 @@ let
     && (haskellLib.isLibrary componentId)
     && stdenv.hostPlatform == stdenv.buildPlatform;
 
+  testExecutable = "dist/build/${componentId.cname}/${componentId.cname}"
+    + lib.optionalString stdenv.hostPlatform.isWindows ".exe";
+
 in stdenv.lib.fix (drv:
 
 stdenv.mkDerivation ({
@@ -179,9 +182,9 @@ stdenv.mkDerivation ({
 
   checkPhase = ''
     runHook preCheck
-    $SETUP_HS test ${lib.concatStringsSep " " component.setupTestFlags}
-    mkdir -p $out/${name}
-    cp dist/test/*.log $out/${name}/
+
+    ${component.testWrapper} ${testExecutable} ${lib.concatStringsSep " " component.testFlags}
+
     runHook postCheck
   '';
 

--- a/modules/plan.nix
+++ b/modules/plan.nix
@@ -43,9 +43,9 @@ let
             type = listOfFilteringNulls str;
             default = (def.setupBuildFlags or []);
           };
-          setupTestFlags = mkOption {
+          testFlags = mkOption {
             type = listOfFilteringNulls str;
-            default = (def.setupTestFlags or []);
+            default = (def.testFlags or []);
           };
           setupInstallFlags = mkOption {
             type = listOfFilteringNulls str;
@@ -122,6 +122,11 @@ let
     preCheck = mkOption {
       type = nullOr string;
       default = (def.preCheck or null);
+    };
+    # Wrapper for test executable run in checkPhase
+    testWrapper = mkOption {
+      type = string;
+      default = (def.testWrapper or "");
     };
     postCheck = mkOption {
       type = nullOr string;


### PR DESCRIPTION
This PR aims to get around several issues we've been experiencing running test suites with cabal. Instead of using `$SETUP_HS` to run the test executables in `checkPhase`, we run them directly.

To allow for test wrappers, such as `wine`, required on some systems, we add a `testWrapper` option to the package options. This will then be set in `iohk-nix/mingw_w64.nix` instead of `setupTestFlags` to get the same `wine` wrapper in place.