### PR TITLE
index-state from cabal.project by default

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -26,8 +26,7 @@ let
     else builtins.readFile ((maybeCleanedSource.origSrc or maybeCleanedSource) + "/cabal.project");
 
   # Look for a index-state: field in the cabal.project file
-  index-state-found = if index-state != null then index-state
-    else
+  parseIndexState = rawCabalProject:
       let
         indexState = pkgs.lib.lists.concatLists (
           pkgs.lib.lists.filter (l: l != null)
@@ -35,6 +34,10 @@ let
               (pkgs.lib.splitString "\n" rawCabalProject)));
       in
         pkgs.lib.lists.head (indexState ++ [ null ]);
+
+  index-state-found = if index-state != null
+    then index-state
+    else parseIndexState rawCabalProject;
 
   # Lookup hash for the index state we found
   index-sha256-found = if index-sha256 != null

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -1,7 +1,8 @@
 { dotCabal, pkgs, runCommand, nix-tools, cabal-install, ghc, hpack, symlinkJoin, cacert, index-state-hashes }:
 let defaultGhc = ghc;
     defaultCabalInstall = cabal-install;
-in { index-state ? null, index-sha256 ? null, src, ghc ? defaultGhc, cabal-install ? defaultCabalInstall }:
+in { index-state ? null, index-sha256 ? null, src, ghc ? defaultGhc,
+  cabal-install ? defaultCabalInstall, cabalProject ? null }:
 
 # cabal-install versions before 2.4 will generate insufficient plan information.
 assert (if (builtins.compareVersions cabal-install.version "2.4.0.0") < 0
@@ -21,7 +22,9 @@ let
   index-state-found = if index-state != null then index-state
     else
       let
-        rawCabalProject = builtins.readFile ((cabalFiles.origSrc or cabalFiles) + "/cabal.project");
+        rawCabalProject = if cabalProject != null
+          then cabalProject
+          else builtins.readFile ((maybeCleanedSource.origSrc or maybeCleanedSource) + "/cabal.project");
         indexState = pkgs.lib.lists.concatLists (
           pkgs.lib.lists.filter (l: l != null)
             (builtins.map (l: builtins.match "^index-state: *(.*)" l)

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -1,10 +1,8 @@
 { dotCabal, pkgs, runCommand, nix-tools, cabal-install, ghc, hpack, symlinkJoin, cacert, index-state-hashes }:
 let defaultGhc = ghc;
     defaultCabalInstall = cabal-install;
-in { index-state, index-sha256 ? index-state-hashes.${index-state} or null, src, ghc ? defaultGhc, cabal-install ? defaultCabalInstall }:
+in { index-state ? null, index-sha256 ? null, src, ghc ? defaultGhc, cabal-install ? defaultCabalInstall }:
 
-# better error message than just assert failed.
-assert (if index-sha256 == null then throw "provided sha256 for index-state ${index-state} is null!" else true);
 # cabal-install versions before 2.4 will generate insufficient plan information.
 assert (if (builtins.compareVersions cabal-install.version "2.4.0.0") < 0
          then throw "cabal-install (current version: ${cabal-install.version}) needs to be at least 2.4 for plan-to-nix to work without cabal-to-nix"
@@ -17,7 +15,32 @@ let
       filter = path: type:
         type == "directory" ||
         pkgs.lib.any (i: (pkgs.lib.hasSuffix i path)) [ ".project" ".cabal" "package.yaml" ]; }
-    else  src;
+    else src;
+
+  # Look for a index-state: field in the cabal.project file
+  index-state-found = if index-state != null then index-state
+    else
+      let
+        rawCabalProject = builtins.readFile ((cabalFiles.origSrc or cabalFiles) + "/cabal.project");
+        indexState = pkgs.lib.lists.concatLists (
+          pkgs.lib.lists.filter (l: l != null)
+            (builtins.map (l: builtins.match "^index-state: *(.*)" l)
+              (pkgs.lib.splitString "\n" rawCabalProject)));
+      in
+        pkgs.lib.lists.head (indexState ++ [ null ]);
+
+  # Lookup hash for the index state we found
+  index-sha256-found = if index-sha256 != null
+    then index-sha256
+    else index-state-hashes.${index-state-found} or null;
+
+in
+  assert (if index-state-found == null
+    then throw "No index state passed and none found in cabal.project" else true);
+  assert (if index-sha256-found == null
+    then throw "provided sha256 for index-state ${index-state-found} is null!" else true);
+
+let
   plan = runCommand "plan-to-nix-pkgs" {
     nativeBuildInputs = [ nix-tools ghc hpack cabal-install pkgs.rsync pkgs.git ];
   } ''
@@ -32,7 +55,9 @@ let
     find . -name package.yaml -exec hpack "{}" \;
     export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
     export GIT_SSL_CAINFO=${cacert}/etc/ssl/certs/ca-bundle.crt
-    HOME=${dotCabal { inherit index-state; sha256 = index-sha256; }} cabal new-configure \
+    HOME=${dotCabal {
+      index-state = index-state-found;
+      sha256 = index-sha256-found; }} cabal new-configure \
         --with-ghc=${ghc.targetPrefix}ghc \
         --with-ghc-pkg=${ghc.targetPrefix}ghc-pkg
 

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -18,13 +18,17 @@ let
         pkgs.lib.any (i: (pkgs.lib.hasSuffix i path)) [ ".project" ".cabal" "package.yaml" ]; }
     else src;
 
+  # Using origSrc bypasses any cleanSourceWith so that it will work when
+  # access to the store is restricted.  If origSrc was already in the store
+  # you can pass the project in as a string.
+  rawCabalProject = if cabalProject != null
+    then cabalProject
+    else builtins.readFile ((maybeCleanedSource.origSrc or maybeCleanedSource) + "/cabal.project");
+
   # Look for a index-state: field in the cabal.project file
   index-state-found = if index-state != null then index-state
     else
       let
-        rawCabalProject = if cabalProject != null
-          then cabalProject
-          else builtins.readFile ((maybeCleanedSource.origSrc or maybeCleanedSource) + "/cabal.project");
         indexState = pkgs.lib.lists.concatLists (
           pkgs.lib.lists.filter (l: l != null)
             (builtins.map (l: builtins.match "^index-state: *(.*)" l)

--- a/test/call-cabal-project-to-nix/default.nix
+++ b/test/call-cabal-project-to-nix/default.nix
@@ -8,6 +8,8 @@ let
       index-state = "2019-04-30T00:00:00Z";
       # reuse the cabal-simple test project
       src = ../cabal-simple;
+      # Hydra currently has issues reading from files in the store
+      cabalProject = builtins.readFile ../cabal-simple/cabal.project;
     });
   };
   packages = pkgSet.config.hsPkgs;


### PR DESCRIPTION
Change callCabalProjectToNix to use the `index-state` specified in the
`cabal.project` file by default.