### PR TITLE
builder: Install benchmarks properly

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -104,8 +104,8 @@ let
     && (haskellLib.isLibrary componentId)
     && stdenv.hostPlatform == stdenv.buildPlatform;
 
-  testExecutable = "dist/build/${componentId.cname}/${componentId.cname}"
-    + lib.optionalString stdenv.hostPlatform.isWindows ".exe";
+  exeExt = lib.optionalString stdenv.hostPlatform.isWindows ".exe";
+  testExecutable = "dist/build/${componentId.cname}/${componentId.cname}${exeExt}";
 
 in stdenv.lib.fix (drv:
 
@@ -235,11 +235,8 @@ stdenv.mkDerivation ({
     ''}
     ${lib.optionalString (haskellLib.isTest componentId || haskellLib.isBenchmark componentId || haskellLib.isAll componentId) ''
       mkdir -p $out/${name}
-      if [ -f "dist/build/${componentId.cname}/${componentId.cname}" ]; then
-        cp dist/build/${componentId.cname}/${componentId.cname} $out/${name}/
-      fi
-      if [ -f "dist/build/${componentId.cname}/${componentId.cname}.exe" ]; then
-        cp dist/build/${componentId.cname}/${componentId.cname}.exe $out/${name}/
+      if [ -f ${testExecutable} ]; then
+        cp ${testExecutable} $out/${name}/
       fi
     ''}
     runHook postInstall

--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -233,7 +233,7 @@ stdenv.mkDerivation ({
         ${ghc.targetPrefix}ghc-pkg -v0 --package-db ${configFiles}/package.conf.d -f $out/package.conf.d register ${name}.conf
       fi
     ''}
-    ${lib.optionalString (haskellLib.isTest componentId || haskellLib.isAll componentId) ''
+    ${lib.optionalString (haskellLib.isTest componentId || haskellLib.isBenchmark componentId || haskellLib.isAll componentId) ''
       mkdir -p $out/${name}
       if [ -f "dist/build/${componentId.cname}/${componentId.cname}" ]; then
         cp dist/build/${componentId.cname}/${componentId.cname} $out/${name}/

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -55,6 +55,7 @@ with haskellLib;
   isLibrary = componentId: componentId.ctype == "lib";
   isAll = componentId: componentId.ctype == "all";
   isTest = componentId: componentId.ctype == "test";
+  isBenchmark = componentId: componentId.ctype == "bench";
 
   # Format a componentId as it should appear as a target on the
   # command line of the setup script.


### PR DESCRIPTION
It's coming up with the following error:
```
[3 of 3] Compiling Main             ( test/bench/Main.hs, dist/build/restore/restore-tmp/Main.o )
Linking dist/build/restore/restore ...
installing
post-installation fixup
builder for '/nix/store/djjd66x9ji266l11py6h6s7diqbhw0bf-cardano-wallet-http-bridge-2019.5.24-bench-restore.drv' failed to produce output path '/nix/store/3ilya2a1dfkv164kfx8b76646id19hfa-cardano-wallet-http-bridge-2019.5.24-bench-restore'
error: build of '/nix/store/djjd66x9ji266l11py6h6s7diqbhw0bf-cardano-wallet-http-bridge-2019.5.24-bench-restore.drv' failed
```
