### PR TITLE
Fix error in `all` component when a package has no library component

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -19,7 +19,7 @@ with haskellLib;
   foldComponents = tys: f: z: conf:
     let
       comps = conf.components or {};
-      libComp = acc: if comps ? library then f comps.library acc else acc;
+      libComp = acc: if (comps.library or null) != null then f comps.library acc else acc;
       subComps = acc:
         lib.foldr
           (ty: acc': foldrAttrVals f acc' (comps.${ty} or {}))


### PR DESCRIPTION
This small change to a library function corrects folding over package components, which, among other things, makes the `all` component work when there is no `library` component.