### PR TITLE
Reduce closure size of nix-tools

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,6 +11,14 @@ steps:
     agents:
       system: x86_64-linux
 
+  - label: 'Check closure size'
+    command:
+      - nix-build build.nix -A maintainer-scripts.check-closure-size -o check-closure-size.sh
+      - echo "+++ Closure size (MB)"
+      - ./check-closure-size.sh
+    agents:
+      system: x86_64-linux
+
   - label: 'Update docs'
     command:
       - nix-build build.nix -A maintainer-scripts.update-docs -o update-docs.sh

--- a/build.nix
+++ b/build.nix
@@ -26,5 +26,6 @@ in {
     update-pins = haskell.callPackage ./scripts/update-pins.nix {};
     update-docs = haskell.callPackage ./scripts/update-docs.nix {};
     check-hydra = haskell.callPackage ./scripts/check-hydra.nix {};
+    check-closure-size = haskell.callPackage ./scripts/check-closure-size.nix {};
   };
 }

--- a/default.nix
+++ b/default.nix
@@ -125,7 +125,8 @@ let
     # we never want to actually cross compile nix-tools on it's own.
     nix-tools = pkgs.buildPackages.callPackage ./nix-tools {
       inherit fetchExternal cleanSourceHaskell;
-      inherit (pkgs.buildPackages.haskellPackages) hpack;
+      hpack = pkgs.buildPackages.haskell.lib.justStaticExecutables
+        (pkgs.buildPackages.haskellPackages.hpack);
       inherit (self) mkCabalProjectPkgSet;
     };
 

--- a/nix-tools/default.nix
+++ b/nix-tools/default.nix
@@ -1,5 +1,5 @@
 { lib, symlinkJoin, makeWrapper
-, hpack, git, nix, nix-prefetch-scripts
+, hpack, git, nix, nix-prefetch-git
 , fetchExternal, cleanSourceHaskell, mkCabalProjectPkgSet }:
 
 let
@@ -27,7 +27,7 @@ let
 
   hsPkgs = pkgSet.config.hsPkgs;
 
-  tools = [ hpack git nix nix-prefetch-scripts ];
+  tools = [ hpack git nix nix-prefetch-git ];
 in
   symlinkJoin {
     name = "nix-tools";

--- a/scripts/check-closure-size.nix
+++ b/scripts/check-closure-size.nix
@@ -1,0 +1,29 @@
+{ stdenv, writeScript, coreutils, gawk, nix
+, nix-tools
+, limitMB ? 500
+}:
+
+with stdenv.lib;
+
+writeScript "check-closure-size.sh" ''
+  #!${stdenv.shell}
+
+  set -euo pipefail
+
+  export PATH="${makeBinPath [ coreutils gawk nix ]}"
+
+  get_closure_size() {
+    du -scm $(nix-store -qR $1) | sort -n | tail -n25
+  }
+
+  nt="$(get_closure_size ${nix-tools})"
+  echo '	${nix-tools}'
+  echo "$nt"
+
+  total=$(awk '$2 == "total" { print $1; }' <<< "$nt")
+  
+  if [ $total -gt ${toString limitMB} ]; then
+    echo "Closure size exceeds limit of ${toString limitMB}MB!"
+    exit 1
+  fi
+''


### PR DESCRIPTION
The `nix-tools` build seemed a bit large.

* Adds CI to check closure size -- sets the limit at a rather generous 500MB.
* Reduces `nix-tools` closure from 2804MB to 456MB.

There is still `gcc` and `linux-headers` in the closure, which we should remove references to.

```
13	/nix/store/3vmll5gkz1sbkq9xqwhs0ffdzmp240ay-nix-tools-0.1.0.0-exe-plan-to-nix
13	/nix/store/f1h3h4frngzbfivcd2gnsyh401gj9s51-vector-algorithms-0.8.0.1
13	/nix/store/lr88fciqfpw5bygv4lq1mpgiy4amjjvy-nix-tools-0.1.0.0-exe-cabal-to-nix
14	/nix/store/ci0x17pbavxz53gzvi6fr4fyl9ayywam-mime-types-0.1.0.9
15	/nix/store/px2rlxp0pr7fhzabq50cznvb9my3112w-vector-0.12.0.2-doc
17	/nix/store/v2dk6zm4crj8rjrz77fd1x162a523kfi-attoparsec-0.13.2.2
18	/nix/store/50gwlzl7vx0nbk90fqras4j1rq65hx95-mercurial-4.9
20	/nix/store/qcspyn7vydm54mjb32f54wg01lhary95-mono-traversable-1.0.11.0
28	/nix/store/mn13g64mksgyw9lkn5227ai86qh07w5s-basement-0.0.10-doc
28	/nix/store/rl9sy4z8dc10jvnxyhbj64cczxr30r8v-hpack-0.31.2
29	/nix/store/681354n3k44r8z90m35hm8945vsp95h1-glibc-2.27
29	/nix/store/v4jl5riqh43l3hcnswgp6b2yzvxsinir-tls-1.4.1
31	/nix/store/hvn7503bgx9c55hzgnq2s82ncxmhrlbh-bazaar-2.7.0
33	/nix/store/0y7jmqnj48ikjh37n3dl9kqw9hnn68nq-binutils-2.31.1
33	/nix/store/3lkpkyjii4wpav0m0zg05msnqhgqx7y1-basement-0.0.10
38	/nix/store/ccl7j6yhkz0x5gf4vyxll824d5hzgayw-git-2.19.2
42	/nix/store/32k9hj4wf45z1q1sq63racdkwnkj7mxb-vector-0.12.0.2
51	/nix/store/snprfi0acg5bpbzhrggri7q85wvf0v0g-python-2.7.16
55	/nix/store/kiz6c6f5hwsz3sf3jcwx8cqyfl05xi5b-cryptonite-0.25
55	/nix/store/mbknmpmc1n46cyf5mbyszgl02w60fj81-aeson-1.4.2.0
56	/nix/store/3m1hc2mrz6zhqng088s4fw0rzfb1g6qy-perl-5.28.1
130	/nix/store/d4n93jn9fdq8fkmkm1q8f32lfagvibjk-gcc-7.4.0
259	/nix/store/8r12vxaw5hj5g0vf4rwvamc1sfv8d540-ghc-8.6.4-doc
1355	/nix/store/d4c9yp4w96g45fivnljg32zjrvdfp10h-ghc-8.6.4
2804	total
```
