### PR TITLE
docs: Remove build directory paths from generated text

### DIFF
--- a/scripts/update-docs.nix
+++ b/scripts/update-docs.nix
@@ -16,8 +16,12 @@ in
 
     source ${./git.env}
 
+    rev=$(git rev-parse --short HEAD)
+    cd $(git rev-parse --show-toplevel)
+
     echo "Preprocessing..."
-    cat docs/reference/modules-preamble.md ${generatedOptions} > docs/reference/modules.md
+    cat docs/reference/modules-preamble.md ${generatedOptions} |
+      sed -e "s,$PWD/\?,," > docs/reference/modules.md
 
     echo "Building..."
     rm -rf site
@@ -26,7 +30,6 @@ in
     sed -i -e '/Build Date/d' site/index.html
     sed -i -e '/lastmod/d' site/sitemap.xml
     rm -f site/sitemap.xml.gz
-    rev=$(git rev-parse --short HEAD)
     rm docs/reference/modules.md
 
     echo "Updating git index..."


### PR DESCRIPTION
Removes paths such as `/var/lib/buildkite-agent/builds/buildkite-packet-3/input-output-hk/haskell-dot-nix/` from the generated docs.
