### PR TITLE
update-hackage: actually modify the hacakge.nix copy of the index state

### DIFF
--- a/scripts/update-hackage.nix
+++ b/scripts/update-hackage.nix
@@ -13,6 +13,7 @@ import ./update-external.nix
       git clone git@github.com:input-output-hk/hackage.nix.git
     fi
 
+    set -x
     # Make sure the hackage index is recent.
     echo "Updating local hackage index..."
     cabal update
@@ -23,8 +24,8 @@ import ./update-external.nix
 
     echo "Running update-index-state-hashes..."
 
-    ${update-index-state-hashes}/bin/update-index-state-hashes > ./index-state-hashes.nix
-
     cd hackage.nix
+
+    ${update-index-state-hashes}/bin/update-index-state-hashes > index-state-hashes.nix
   '';
 }

--- a/scripts/update-index-state-hashes.nix
+++ b/scripts/update-index-state-hashes.nix
@@ -37,6 +37,6 @@ writeShellScriptBin "update-index-state-hashes" ''
       fi
     done
     
-    # emit the finall closing brace.
+    # emit the final closing brace.
     echo '}'
     ''


### PR DESCRIPTION
This hasn't updated in some time because it wasn't actually modifying the copy in `hackage.nix`.