### PR TITLE
Add custom errors for some missing attributes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -112,10 +112,11 @@ let
         pkg-def = plan-pkgs.pkgs;
         # The compiler referenced in the stack config
         compiler = (plan-pkgs.extras hackage).compiler or (pkg-def hackage).compiler;
+        patchesModule = ghcHackagePatches.${compiler.nix-name} or {};
       in self.mkPkgSet {
         inherit pkg-def;
         pkg-def-extras = [ plan-pkgs.extras ] ++ pkg-def-extras;
-        modules = [ ghcHackagePatches.${compiler.nix-name} ] ++ modules;
+        modules = [ patchesModule ] ++ modules;
       };
 
     # Package sets for all stackage snapshots.

--- a/default.nix
+++ b/default.nix
@@ -88,7 +88,10 @@ let
 
       let
         # The Stackage release referenced in the stack config
-        pkg-def = stackage.${stack-pkgs.resolver};
+        pkg-def = stackage.${stack-pkgs.resolver} or (throw ''
+          This version of stackage.nix does not know about the Stackage resolver ${stack-pkgs.resolver}.
+          You may need to update haskell.nix to one that includes a newer stackage.nix.
+        '');
         # The compiler referenced in the stack config
         compiler = (stack-pkgs.extras hackage).compiler or (pkg-def hackage).compiler;
         patchesModule = ghcHackagePatches.${compiler.nix-name} or {};

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -43,7 +43,7 @@ with haskellLib;
     let
       comps = config.components;
       applyLibrary = cname: f { cname = config.package.identifier.name; ctype = "lib"; };
-      applySubComp = ctype: cname: f { inherit cname; ctype = componentPrefix.${ctype}; };
+      applySubComp = ctype: cname: f { inherit cname; ctype = componentPrefix.${ctype} or (throw "Missing component mapping for ${ctype}."); };
       applyAllComp = f { cname = config.package.identifier.name; ctype = "all"; };
       libComp = if comps.library == null then {} else lib.mapAttrs applyLibrary (removeAttrs comps (subComponentTypes ++ [ "all" ]));
       subComps = lib.mapAttrs

--- a/modules/hackage.nix
+++ b/modules/hackage.nix
@@ -66,7 +66,12 @@ in {
     # this should allow us to use `config` overrides
     # in the nixpkgs setup, and properly override the
     # complier as needed.
-    default = pkgs.buildPackages.haskell.compiler.${config.compiler.nix-name};
+    default = pkgs.buildPackages.haskell.compiler.${config.compiler.nix-name} or (throw ''
+      This version of Nixpkgs does not contain GHC ${config.compiler.version} 
+      (or it is not present at attribute '${config.compiler.nix-name})').
+      Either switch to a version of Nixpkgs which does have this version, or use a version
+      of GHC which the current version of Nixpkgs contains.
+    '');
     defaultText = "pkgs.buildPackages.haskell.compiler.\${config.compiler.nix-name}";
   };
 


### PR DESCRIPTION
I looked at all the cases that looked like they were accessing a variable attribute. This covers two of the big cases: missing Stackage resolvers, and missing GHC versions.