### PR TITLE
Adds `hackage-package`.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -212,17 +212,13 @@ let
       sources = [ hackageSrc stackageSrc pkgs.path ];
     };
 
-    # Utility
-    stackage-lts-set = lts:
-      assert (if !(pkgs.lib.hasPrefix "lts-" lts || pkgs.lib.hasPrefix "nightly-" lts) then throw "argument to stackage-lts-set needs to start with either lts- or nightly-!" else true);
-      let src = buildPackages.pkgs.runCommand "stackage-${lts}-set-src" { nativeBuildInputs = [ buildPackages.nix-tools ]; } ''
-        mkdir -p $out
-        echo "resolver: ${lts}" > $out/stack.yaml
-        '';
-      in let stack-pkgs = import (callStackToNix { inherit src; });
-      in let pkg-set = mkStackPkgSet { inherit stack-pkgs; };
-      in pkg-set.config.hsPkgs;
-
+    # Build a specific package (name, version) against a given index-stage
+    # from hackage.  This is useful if you want to build an executable from
+    # a given package.
+    # NB: If no explicit index-state is provided the most recent one from
+    # the index-state-hashes is used.  This guarantees reproducability wrt
+    # to the haskell.nix revision.  If reproducability beyond haskell.nix
+    # is required, a specific index-state should be provided!
     hackage-package =
       { name
       , version

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,12 +1,48 @@
 # User Guide
 
-So you want to use [Haskell.nix][] with your stack or cabal project. The
-general approach will be to pick the right tool from `nix-tools` and
-produce a `pkgs.nix` expression.  Getting a copy of the `nix-tools`
-(and potentially the [Haskell.nix][] source), will then equip us to
-produce derivations that we can `nix build`.
+[Haskell.nix][] can be use for two different use cases:
+
+1. to build a specific package from hackage or a [stackage][] lts or nightly set.
+
+   To build a package, say [lens][], from a stackage snapshot, say [lts-13.28][],
+   you could run
+   ```bash
+   nix build '(with import ./. {}; snapshots."lts-13.28").lens.components.library'
+   ```
+   which would build the [lens][] library component from the lens package as fixed
+   by the [lts-13.28][] stackage snapshot.
+   
+   To build any package from hackage, say [lens][], in version, say 4.17.1, you
+   could run
+   ```bash
+   nix build '(with import ./. {}; (hackage-package { name = "lens"; version = "4.17.1"; })).components.library'
+   ```
+   which would build the [lens][] library component from the [lens-4.17.1][] package
+   from hackage.  The dependencies would be solved against the most recent 
+   [hackage-index-state][] that comes via the [hackage.nix][] pin with your
+   [haskell.nix][] checkout.  A specific one can be specified as well:
+   ```bash
+   nix build '(with import ./. {}; (hackage-package { name = "lens"; version = "4.17.1"; index-state = "2019-07-14T00:00:00Z"; })).components.library'
+   ```
+   which would use the hackage index as of `2019-07-14T00:00:00Z` to produce a build plan
+   for the [lens-4.17.1][] package.
+   
+
+2. to build a stack or cabal project.
+ 
+    So you want to use [Haskell.nix][] with your stack or cabal project. The
+    general approach will be to pick the right tool from `nix-tools` and
+    produce a `pkgs.nix` expression.  Getting a copy of the `nix-tools`
+    (and potentially the [Haskell.nix][] source), will then equip us to
+    produce derivations that we can `nix build`.
 
 [haskell.nix]: https://github.com/input-output-hk/haskell.nix
+[stackage]: https://stackage.org
+[lts-13.28]: https://www.stackage.org/lts-13.28
+[lens]: https://hackage.haskell.org/package/lens
+[lens-4.17.1]: https://hackage.haskell.org/package/lens-4.17.1
+[hackage.nix]: https://github.com/input-output-hk/hackage.nix
+[hackage-index-state]: https://github.com/input-output-hk/hackage.nix/blob/master/index-state-hashes.nix
 
 ## Installing `nix-tools`
 


### PR DESCRIPTION
This allows us to build a package from hackage.

```
nix build '(with import ./. {}; (hackage-package { name = "lens"; version = "4.17.1"; })).components.library'
```
would build the lens library.

Building the same package from a stockage lts set can be achieved via:
```
nix build '(with import ./. {}; snapshots."lts-13.28").lens.components.library'
```
would build the lens library component from the lts-13.28 stackage set.