### PR TITLE
boot-pkgs: Add iserv and friends

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -21,6 +21,7 @@ let
   #       means outside of hackage.
   boot-pkgs = [ "rts" "ghc" "ghc-boot-th" "ghc-boot" "ghci"
                 "ghc-heap" # since ghc 8.6.
+                "iserv" "libiserv" "iserv-proxy"
               ];
   strip-pkg-def = pkgs: pkg-def: hackage: with pkgs.lib;
     mapAttrs (k: v: if k == "packages"


### PR DESCRIPTION
The packages iserv, iserv-proxy, and libiserv are provided by GHC, but are not
available on Hackage and are not installable.