### PR TITLE
Include `--enable-tests` in callCabalProjectToNix

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -156,7 +156,8 @@ let
       index-state = index-state-found;
       sha256 = index-sha256-found; }} cabal new-configure \
         --with-ghc=${ghc.targetPrefix}ghc \
-        --with-ghc-pkg=${ghc.targetPrefix}ghc-pkg
+        --with-ghc-pkg=${ghc.targetPrefix}ghc-pkg \
+        --enable-tests
 
     export LANG=C.utf8 # Needed or stack-to-nix will die on unicode inputs
     mkdir -p $out


### PR DESCRIPTION
I am not sure if it affects all versions of `cabal-install`, but I have found that sometimes adding this gets it to include packages in the `plan.json` that are not otherwise included (presumably because they are only needed for building the tests).