### PR TITLE
Never build with more than -j4 because of slowdown

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -182,7 +182,8 @@ stdenv.mkDerivation ({
 
   buildPhase = ''
     runHook preBuild
-    $SETUP_HS build -j$NIX_BUILD_CORES ${lib.concatStringsSep " " component.setupBuildFlags}
+    # https://gitlab.haskell.org/ghc/ghc/issues/9221
+    $SETUP_HS build -j$(($NIX_BUILD_CORES > 4 ? 4 : $NIX_BUILD_CORES)) ${lib.concatStringsSep " " component.setupBuildFlags}
     runHook postBuild
   '';
 


### PR DESCRIPTION
[Same thing happens in nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/generic-builder.nix#L83). https://gitlab.haskell.org/ghc/ghc/issues/9221