### PR TITLE
Fix issue with testWrapper (exposed by #238)

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -197,7 +197,7 @@ stdenv.mkDerivation ({
   checkPhase = ''
     runHook preCheck
 
-    ${component.testWrapper} ${testExecutable} ${lib.concatStringsSep " " component.testFlags}
+    ${if component.testWrapper == null then "" else component.testWrapper} ${testExecutable} ${lib.concatStringsSep " " component.testFlags}
 
     runHook postCheck
   '';

--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -197,7 +197,7 @@ stdenv.mkDerivation ({
   checkPhase = ''
     runHook preCheck
 
-    ${if component.testWrapper == null then "" else component.testWrapper} ${testExecutable} ${lib.concatStringsSep " " component.testFlags}
+    ${toString component.testWrapper} ${testExecutable} ${lib.concatStringsSep " " component.testFlags}
 
     runHook postCheck
   '';

--- a/modules/plan.nix
+++ b/modules/plan.nix
@@ -130,8 +130,8 @@ let
     };
     # Wrapper for test executable run in checkPhase
     testWrapper = mkOption {
-      type = str;
-      default = (def.testWrapper or "");
+      type = nullOr str;
+      default = (def.testWrapper or null);
     };
     postCheck = mkOption {
       type = nullOr str;

--- a/modules/plan.nix
+++ b/modules/plan.nix
@@ -131,7 +131,9 @@ let
     # Wrapper for test executable run in checkPhase
     testWrapper = mkOption {
       type = nullOr str;
-      default = (def.testWrapper or null);
+      default = def.testWrapper or null;
+      description = "A command to run for executing tests in checkPhase, which takes the original test command as its arguments.";
+      example = "echo";
     };
     postCheck = mkOption {
       type = nullOr str;


### PR DESCRIPTION
We were relying on the `string` type's merge function quietly
concatenating strings.

Described [here](https://github.com/NixOS/nixpkgs/blob/700cc56a0e7e1daf7410420ac66978ae3225fbb2/lib/types.nix#L218-L221)

This should fix the broken buildkite tests.