### PR TITLE
Use modules from stack-to-nix in mkStackPkgSet

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -107,7 +107,7 @@ let
         pkg-def-extras = [ stack-pkgs.extras ] ++ pkg-def-extras;
         # set doExactConfig = true. The stackage set should be consistent
         # and we should trust stackage here!
-        modules = [ { doExactConfig = true; } patchesModule ] ++ modules;
+        modules = [ { doExactConfig = true; } patchesModule ] ++ stack-pkgs.modules or [] ++ modules;
       };
 
     # Create a Haskell package set based on a Cabal configuration.


### PR DESCRIPTION
`stack-to-nix` outputs `modules` that includes overrides for cabal flags based on the `flags` section in the `stack.yaml` files.  While extending this to work form `ghc-options` sections, I noticed that the `modules` do not seem to be used `mkStackPkgSet`.