### PR TITLE
Fix project flags

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -127,7 +127,7 @@ let
         pkg-def-extras = [ plan-pkgs.extras ] ++ pkg-def-extras;
         # set doExactConfig = true, as we trust cabals resolution for
         # the plan.
-        modules = [ { doExactConfig = true; } patchesModule ] ++ modules;
+        modules = [ { doExactConfig = true; } patchesModule ] ++ plan-pkgs.modules or [] ++ modules;
       };
 
     # Package sets for all stackage snapshots.

--- a/default.nix
+++ b/default.nix
@@ -107,7 +107,7 @@ let
         pkg-def-extras = [ stack-pkgs.extras ] ++ pkg-def-extras;
         # set doExactConfig = true. The stackage set should be consistent
         # and we should trust stackage here!
-        modules = [ { doExactConfig = true; } patchesModule ] ++ modules;
+        modules = [ { doExactConfig = true; } patchesModule ] ++ stack-pkgs.modules or [] ++ modules;
       };
 
     # Create a Haskell package set based on a Cabal configuration.

--- a/docs/user-guide/projects.md
+++ b/docs/user-guide/projects.md
@@ -29,6 +29,8 @@ let
       # example:
       #  packages.cbors.patches = [ ./one.patch ];
       #  packages.cbors.flags.optimize-gmp = false;
+      # It may be better to set flags in stack.yaml instead (overrides will
+      # be included for them automatically by `stack-to-nix`).
     ];
   };
 
@@ -36,7 +38,17 @@ let
   pkgSet = haskell.mkCabalProjectPkgSet {
     plan-pkgs = my-pkgs;
     pkg-def-extras = [];
-    modules = [];
+    modules = [
+      # specific package overrides would go here
+      # example:
+      #  packages.cbors.patches = [ ./one.patch ];
+      # To override a flag you will need to use mkOverride to make
+      # it clear that you wish to replace the value found in the
+      # `plan.json` file (all the flags values are included there
+      # by `cabal`).
+      #  packages.cbors.flags.optimize-gmp = stdenv.lib.mkOverride 10 false;
+      # It may be better to set flags in `cabal.project` instead.
+    ];
   };
 
 in pkgSet.config.hsPkgs // { _config = pkgSet.config; }

--- a/nix-tools/nix-tools-src.json
+++ b/nix-tools/nix-tools-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/nix-tools",
-  "rev": "47ab47199194990681d24afd725e3f0e942e4f3d",
-  "date": "2019-09-30T23:06:49+13:00",
-  "sha256": "1wbfs4k2sadzz0swrpbmdhsph0icfqni8f3dzxcny0vzpx7fiwfq",
+  "rev": "92951c5de726b5e54b494f97711c080ba33fdd08",
+  "date": "2019-10-10T12:55:50+13:00",
+  "sha256": "1xf3llli08axrhhda80hx95nmbwmdcz0y4r2vmgfhi3lqbcww8vk",
   "fetchSubmodules": false
 }

--- a/nix-tools/nix-tools-src.json
+++ b/nix-tools/nix-tools-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/nix-tools",
-  "rev": "92951c5de726b5e54b494f97711c080ba33fdd08",
-  "date": "2019-10-10T12:55:50+13:00",
+  "rev": "5d4649a833cb8b963266cea016d5a12a30022266",
+  "date": "2019-10-11T14:24:33+13:00",
   "sha256": "1xf3llli08axrhhda80hx95nmbwmdcz0y4r2vmgfhi3lqbcww8vk",
   "fetchSubmodules": false
 }

--- a/test/buildable/default.nix
+++ b/test/buildable/default.nix
@@ -9,7 +9,7 @@ let
   });
   pkgSet = mkCabalProjectPkgSet {
     plan-pkgs = plan.pkgs;
-    modules = [ { packages.buildable-test.flags.exclude-broken = true; } ];
+    modules = [ { packages.buildable-test.flags.exclude-broken = mkOverride 10 true; } ];
   };
   packages = pkgSet.config.hsPkgs;
 in

--- a/test/buildable/default.nix
+++ b/test/buildable/default.nix
@@ -9,6 +9,11 @@ let
   });
   pkgSet = mkCabalProjectPkgSet {
     plan-pkgs = plan.pkgs;
+    # We need mkOverride to override the value from `plan.json`.
+    # Normally we could set the flag in `cabal.project`,
+    # but for this test that does not work because then cabal would
+    # see the exe is not buildable and exclude it before haskell.nix
+    # can.
     modules = [ { packages.buildable-test.flags.exclude-broken = mkOverride 10 true; } ];
   };
   packages = pkgSet.config.hsPkgs;

--- a/test/default.nix
+++ b/test/default.nix
@@ -22,6 +22,8 @@ in pkgs.recurseIntoAttrs {
   callCabalProjectToNix = haskell.callPackage ./call-cabal-project-to-nix {};
   cabal-source-repo = haskell.callPackage ./cabal-source-repo {};
   buildable = haskell.callPackage ./buildable {};
+  project-flags-cabal = haskell.callPackage ./project-flags/cabal.nix {};
+  project-flags-stack = haskell.callPackage ./project-flags/stack.nix {};
 
   # Run unit tests with: nix-instantiate --eval --strict -A unit.tests
   # An empty list means success.

--- a/test/project-flags/.gitignore
+++ b/test/project-flags/.gitignore
@@ -1,0 +1,2 @@
+.stack-work/
+*~

--- a/test/project-flags/Setup.hs
+++ b/test/project-flags/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/test/project-flags/app/Main.hs
+++ b/test/project-flags/app/Main.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE CPP #-}
+module Main where
+
+import Lib
+
+#ifdef TEST_FLAG
+main :: IO ()
+main = someFunc
+#endif

--- a/test/project-flags/cabal.nix
+++ b/test/project-flags/cabal.nix
@@ -1,0 +1,34 @@
+{ stdenv, mkCabalProjectPkgSet, callCabalProjectToNix, importAndFilterProject }:
+
+with stdenv.lib;
+
+let
+  plan = (importAndFilterProject (callCabalProjectToNix {
+      index-state = "2019-04-30T00:00:00Z";
+      src = ./.;
+    }));
+  pkgSet = mkCabalProjectPkgSet {
+    plan-pkgs = plan.pkgs;
+  };
+  packages = pkgSet.config.hsPkgs;
+in
+  stdenv.mkDerivation {
+    name = "call-cabal-project-to-nix-test";
+
+    buildCommand = ''
+      exe="${packages.test-project-flags.components.exes.test-project-flags-exe}/bin/test-project-flags-exe"
+
+      printf "checking whether executable runs... " >& 2
+      $exe
+
+      touch $out
+    '';
+
+    meta.platforms = platforms.all;
+
+    passthru = {
+      # Attributes used for debugging with nix repl
+      inherit pkgSet packages;
+      plan-nix = plan.nix;
+    };
+  }

--- a/test/project-flags/cabal.project
+++ b/test/project-flags/cabal.project
@@ -1,0 +1,4 @@
+packages: .
+
+package test-project-flags
+  flags: +test-flag

--- a/test/project-flags/src/Lib.hs
+++ b/test/project-flags/src/Lib.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE CPP #-}
+module Lib
+    ( someFunc
+    ) where
+
+#ifdef TEST_FLAG
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"
+#endif

--- a/test/project-flags/stack.nix
+++ b/test/project-flags/stack.nix
@@ -1,0 +1,33 @@
+{ stdenv, mkStackPkgSet, callStackToNix, importAndFilterProject }:
+
+with stdenv.lib;
+
+let
+  stack = (importAndFilterProject (callStackToNix {
+    src = ./.;
+  }));
+  pkgSet = mkStackPkgSet {
+    stack-pkgs = stack.pkgs;
+  };
+  packages = pkgSet.config.hsPkgs;
+in
+  stdenv.mkDerivation {
+    name = "callStackToNix-test";
+
+    buildCommand = ''
+      exe="${packages.test-project-flags.components.exes.test-project-flags-exe}/bin/test-project-flags-exe"
+
+      printf "checking whether executable runs... " >& 2
+      $exe
+
+      touch $out
+    '';
+
+    meta.platforms = platforms.all;
+
+    passthru = {
+      # Attributes used for debugging with nix repl
+      inherit pkgSet packages;
+      stack-nix = stack.nix;
+    };
+  }

--- a/test/project-flags/stack.yaml
+++ b/test/project-flags/stack.yaml
@@ -1,0 +1,8 @@
+resolver: lts-13.19
+
+packages:
+- .
+
+flags:
+  test-project-flags:
+    test-flag: true

--- a/test/project-flags/test-project-flags.cabal
+++ b/test/project-flags/test-project-flags.cabal
@@ -1,0 +1,28 @@
+cabal-version:       >=1.10
+name:                test-project-flags
+version:             0.1.0.0
+license:             PublicDomain
+author:              Hamish Mackenzie
+maintainer:          Hamish.Mackenzie@iohk.io
+build-type:          Simple
+
+flag test-flag
+  description: A flag that needs to be turned on
+  default: False
+
+library
+  build-depends:     base >=4.7 && <5
+  exposed-modules:   Lib
+  hs-source-dirs:    src
+  default-language:  Haskell2010
+  if flag(test-flag)
+    cpp-options: -DTEST_FLAG
+
+executable test-project-flags-exe
+  main-is:           Main.hs
+  build-depends:     base >=4.7 && <5, test-project-flags
+  hs-source-dirs:    app
+  ghc-options:       -threaded -rtsopts -with-rtsopts=-N
+  default-language:  Haskell2010
+  if flag(test-flag)
+    cpp-options: -DTEST_FLAG


### PR DESCRIPTION
Project flags (from `stack.yaml` and `plan.json`) are exported in a `modules` attribute by `stack-to-nix` and `plan-to-nix`, but are not currently used.  This change updates `mkStackPkgSet` and `mkCabalProjectPkgSet` so that the `modules` attribute is used (if present) and includes tests to check they are.