### PR TITLE
shellFor: Use CABAL_CONFIG only with exactDeps = true

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -146,7 +146,6 @@ stdenv.mkDerivation ({
         (builtins.trace "WARNING: license \"${package.license}\" not found" license-map.LicenseRef-OtherLicense);
   };
 
-  CABAL_CONFIG = configFiles + /cabal.config;
   LANG = "en_US.UTF-8";         # GHC needs the locale configured during the Haddock phase.
   LC_ALL = "en_US.UTF-8";
 

--- a/builder/make-config-files.nix
+++ b/builder/make-config-files.nix
@@ -75,6 +75,9 @@ in { identifier, component, fullName, flags ? {} }:
 
     echo ${lib.concatStringsSep " " (lib.mapAttrsToList (fname: val: "--flags=${lib.optionalString (!val) "-" + fname}") flags)} >> $out/configure-flags
 
+    # Provide a cabal config without remote package repositories
+    echo "write-ghc-environment-files: never" >> $out/cabal.config
+
     # Provide a GHC environment file
     cat > $out/ghc-environment <<EOF
     package-db $out/package.conf.d

--- a/builder/setup-builder.nix
+++ b/builder/setup-builder.nix
@@ -45,7 +45,6 @@ in
         inherit configFiles cleanSrc;
       };
 
-      CABAL_CONFIG = configFiles + /cabal.config;
       phases = ["unpackPhase" "buildPhase" "installPhase"];
       buildPhase = ''
         for f in Setup.hs Setup.lhs; do

--- a/builder/shell-for.nix
+++ b/builder/shell-for.nix
@@ -8,6 +8,7 @@
         (builtins.attrValues selected)
 , additional ? _: []
 , withHoogle ? true
+, exactDeps ? false
 , ... } @ args:
 
 let
@@ -80,9 +81,10 @@ in
     installPhase = "echo $nativeBuildInputs $buildInputs > $out";
     LANG = "en_US.UTF-8";
     LOCALE_ARCHIVE = lib.optionalString (stdenv.hostPlatform.libc == "glibc") "${glibcLocales}/lib/locale/locale-archive";
-    CABAL_CONFIG = "${configFiles}/cabal.config";
 
     passthru = (mkDrvArgs.passthru or {}) // {
       ghc = ghcEnv;
     };
+  } // lib.optionalAttrs exactDeps {
+    CABAL_CONFIG = "${configFiles}/cabal.config";
   })

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 This file contains a summary of changes to Haskell.nix and `nix-tools`
 that will impact users.
 
+## October 12, 2019
+ * [`shellFor`](https://input-output-hk.github.io/haskell.nix/reference/library/#shellfor) no longer sets `CABAL_CONFIG` by default.
+   This avoids surprising users, but means that Cabal may select a plan which is different to your Haskell.nix package set.
+   If you would like the old behaviour, use `shellFor { exactDeps = true; }`.
+
 ## August 9, 2019
  * Add the [`haskellLib.collectComponents`](https://input-output-hk.github.io/haskell.nix/reference/library/#haskellLib) function.
 

--- a/docs/reference/library.md
+++ b/docs/reference/library.md
@@ -285,7 +285,7 @@ packages with `ghci` or `cabal v2-build` (but not Stack).
 
 ```
 shellFor =
-    { packages, withHoogle ? true, ...}: ...
+    { packages, withHoogle ? true, exactDeps ? false, ...}: ...
 ```
 
 
@@ -293,16 +293,18 @@ shellFor =
 |----------------|------|---------------------|
 | `packages`     | Function | Package selection function. It takes a list of [Haskell packages](#haskell-package) and returns a subset of these packages. |
 | `withHoogle` | Boolean | Whether to build a Hoogle documentation index and provide the `hoogle` command. |
+| `exactDeps` | Boolean | Prevents the Cabal solver from choosing any package dependency other than what are in the package set. |
 | `{ ... }` | Attrset | All the other arguments are passed to [`mkDerivation`](https://nixos.org/nixpkgs/manual/#sec-using-stdenv). |
 
 **Return value**: a derivation
 
 !!! warning
 
-    `shellFor` will set the `CABAL_CONFIG` environment variable to disable
-    remote package servers. This is a [known
-    limitation](../dev/removing-with-package-wrapper.md) which we would
-    like to solve.
+    `exactDeps = true` will set the `CABAL_CONFIG` environment variable
+    to disable remote package servers. This is a
+    [known limitation](../dev/removing-with-package-wrapper.md)
+    which we would like to solve. Use `exactDeps = false` if this is a
+    problem.
 
 
 ## ghcWithPackages

--- a/docs/user-guide/development.md
+++ b/docs/user-guide/development.md
@@ -68,6 +68,10 @@ in
     # You might want some extra tools in the shell (optional).
     buildInputs = with pkgs.haskellPackages;
       [ hlint stylish-haskell ghcid ];
+
+    # Prevents cabal from choosing alternate plans, so that
+    # *all* dependencies are provided by Nix.
+    exactDeps = true;
   }
 ```
 

--- a/test/shell-for/default.nix
+++ b/test/shell-for/default.nix
@@ -23,6 +23,7 @@ let
     # This adds cabal-install to the shell, which helps tests because
     # they use a nix-shell --pure. Normally you would BYO cabal-install.
     buildInputs = [ cabal-install ];
+    exactDeps = true;
   };
 
   envPkga = pkgSet.config.hsPkgs.shellFor {
@@ -31,6 +32,7 @@ let
     # This adds cabal-install to the shell, which helps tests because
     # they use a nix-shell --pure. Normally you would BYO cabal-install.
     buildInputs = [ cabal-install ];
+    exactDeps = true;
   };
 
   envDefault = pkgSet.config.hsPkgs.shellFor {


### PR DESCRIPTION
[`shellFor`](https://input-output-hk.github.io/haskell.nix/reference/library/#shellfor) no longer sets `CABAL_CONFIG` by default.

This avoids surprising users, but means that Cabal may select a plan which is different to your Haskell.nix package set. If you would like the old behaviour, use `shellFor { exactDeps = true; }`