### PR TITLE
tests: Add test case with fully static build of pandoc

### DIFF
--- a/test/default.nix
+++ b/test/default.nix
@@ -24,6 +24,7 @@ in pkgs.recurseIntoAttrs {
   buildable = haskell.callPackage ./buildable {};
   project-flags-cabal = haskell.callPackage ./project-flags/cabal.nix {};
   project-flags-stack = haskell.callPackage ./project-flags/stack.nix {};
+  fully-static = haskell.callPackage ./fully-static { inherit (pkgs) buildPackages; };
 
   # Run unit tests with: nix-instantiate --eval --strict -A unit.tests
   # An empty list means success.

--- a/test/fully-static/cross.nix
+++ b/test/fully-static/cross.nix
@@ -1,0 +1,15 @@
+{ pkgs ? import nixpkgs { }
+, nixpkgs ? ../../nixpkgs
+}:
+
+let
+  pkgs' = pkgs.pkgsCross.musl64;
+  haskellMusl64 = pkgs.callPackage ../../. { pkgs = pkgs'; };
+
+  test = haskellMusl64.callPackage ./default.nix {
+    inherit (pkgs') buildPackages;
+  };
+
+in {
+  inherit (test) pandoc-gmp pandoc-integer-simple;
+}

--- a/test/fully-static/default.nix
+++ b/test/fully-static/default.nix
@@ -1,0 +1,79 @@
+{ mkStackPkgSet, callStackToNix, importAndFilterProject
+, stdenv, gmp6, openssl, zlib, libffi
+, buildPackages
+}:
+
+with stdenv.lib;
+
+let
+  pkgSet = { gpl ? true }: mkStackPkgSet {
+    stack-pkgs = (importAndFilterProject (callStackToNix {
+      src = ./.;
+    })).pkgs;
+    pkg-def-extras = [];
+    modules = [
+      # Musl libc fully static build
+      (let
+        staticLibs = [
+          zlib.static
+          (openssl.override { static = true; }).out
+          (libffi.overrideAttrs (oldAttrs: {
+            dontDisableStatic = true;
+            configureFlags = (oldAttrs.configureFlags or []) ++ [
+              "--enable-static"
+              "--disable-shared"
+            ];
+          }))
+        ] ++ optional gpl (gmp6.override { withStatic = true; });
+
+        withFullyStatic = {
+          configureFlags =
+             optionals stdenv.hostPlatform.isMusl ([
+               "--disable-executable-dynamic"
+               "--disable-shared"
+               "--ghc-option=-optl=-pthread"
+               "--ghc-option=-optl=-static"
+             ] ++ map (drv: "--ghc-option=-optl=-L${drv}/lib") staticLibs);
+        };
+      in {
+        # Select a non-GMP compiler, usually for software licensing reasons.
+        ghc.package = mkIf (stdenv.hostPlatform.isMusl && !gpl)
+            buildPackages.haskell.compiler.integer-simple.${compiler};
+
+        # Add GHC flags and libraries for fully static build
+        packages.pandoc.components.exes.pandoc = withFullyStatic;
+      })
+    ];
+  };
+  packagesGmp = (pkgSet { gpl = true; }).config.hsPkgs;
+  packagesIntegerSimple = (pkgSet { gpl = false; }).config.hsPkgs;
+in
+  stdenv.mkDerivation {
+    name = "fully-static-test";
+
+    depsBuildBuild = [ buildPackages.file ];
+
+    buildCommand = flip concatMapStrings
+      [ packagesGmp /* packagesIntegerSimple */ ]
+      (packages: ''
+        exe="${packages.pandoc.components.exes.pandoc}/bin/pandoc"
+
+        printf "checking whether executable runs... " >& 2
+        $exe --version
+
+      '' + optionalString stdenv.hostPlatform.isMusl ''
+        printf "checking whether executable is static... " >& 2
+        file $exe
+        file $exe | grep "statically linked"
+
+      '') + "touch $out";
+
+    meta.platforms = platforms.all;
+
+    passthru = {
+      # Attributes used for debugging with nix repl
+      inherit pkgSet buildPackages;
+      pandoc-gmp = packagesGmp.pandoc.components.exes.pandoc;
+      pandoc-integer-simple = packagesIntegerSimple.pandoc.components.exes.pandoc;
+    };
+  }

--- a/test/fully-static/default.nix
+++ b/test/fully-static/default.nix
@@ -6,10 +6,17 @@
 with stdenv.lib;
 
 let
+  # IFD stack-to-nix
+  stack-pkgs = (importAndFilterProject (callStackToNix {
+    src = ./.;
+  })).pkgs;
+
+  # Grab the compiler name from stack-to-nix output.
+  # compiler = (stack-pkgs.extras {}).compiler.nix-name;
+  compiler = "ghc865";  # fixme
+
   pkgSet = { gpl ? true }: mkStackPkgSet {
-    stack-pkgs = (importAndFilterProject (callStackToNix {
-      src = ./.;
-    })).pkgs;
+    inherit stack-pkgs;
     pkg-def-extras = [];
     modules = [
       # Musl libc fully static build
@@ -72,7 +79,7 @@ in
 
     passthru = {
       # Attributes used for debugging with nix repl
-      inherit pkgSet buildPackages;
+      inherit pkgSet buildPackages stack-pkgs;
       pandoc-gmp = packagesGmp.pandoc.components.exes.pandoc;
       pandoc-integer-simple = packagesIntegerSimple.pandoc.components.exes.pandoc;
     };

--- a/test/fully-static/stack.yaml
+++ b/test/fully-static/stack.yaml
@@ -1,0 +1,6 @@
+resolver: lts-13.26
+
+extra-deps:
+  - pandoc-2.7.3
+  - hslua-module-system-0.2.1
+  - ipynb-0.1


### PR DESCRIPTION
It uses the musl libc. To try it, use:

```
   nix-build test/fully-static/cross.nix -A pandoc-gmp
```

This includes the GMP library (linked statically). To build one without GMP:

```
   nix-build test/fully-static/cross.nix -A pandoc-integer-simple
```

Unfortunately, the latter doesn't work (it says "ghc" command not found).