### PR TITLE
Add ghcOptions on packages

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -88,6 +88,8 @@ let
       ++ component.configureFlags
     );
 
+  setupGhcOptions = lib.optional (package.ghcOptions != null) '' --ghc-options="${package.ghcOptions}"'';
+
   executableToolDepends =
     (lib.concatMap (c: if c.isHaskell or false
       then builtins.attrValues (c.components.exes or {})
@@ -190,7 +192,7 @@ stdenv.mkDerivation ({
   buildPhase = ''
     runHook preBuild
     # https://gitlab.haskell.org/ghc/ghc/issues/9221
-    $SETUP_HS build -j$(($NIX_BUILD_CORES > 4 ? 4 : $NIX_BUILD_CORES)) ${lib.concatStringsSep " " component.setupBuildFlags}
+    $SETUP_HS build -j$(($NIX_BUILD_CORES > 4 ? 4 : $NIX_BUILD_CORES)) ${lib.concatStringsSep " " (component.setupBuildFlags ++ setupGhcOptions)}
     runHook postBuild
   '';
 
@@ -211,7 +213,7 @@ stdenv.mkDerivation ({
       "--html" \
       ${lib.optionalString doHoogle "--hoogle"} \
       ${lib.optionalString hyperlinkSource "--hyperlink-source"} \
-      ${lib.concatStringsSep " " component.setupHaddockFlags}
+      ${lib.concatStringsSep " " (component.setupHaddockFlags ++ setupGhcOptions)}
 
     html="dist/doc/html/${componentId.cname}"
 

--- a/docs/user-guide/projects.md
+++ b/docs/user-guide/projects.md
@@ -27,6 +27,7 @@ let
     modules = [
       # specific package overrides would go here
       # example:
+      #  packages.cbors.package.ghcOptions = "-Werror";
       #  packages.cbors.patches = [ ./one.patch ];
       #  packages.cbors.flags.optimize-gmp = false;
       # It may be better to set flags in stack.yaml instead (overrides will
@@ -41,6 +42,7 @@ let
     modules = [
       # specific package overrides would go here
       # example:
+      #  packages.cbors.package.ghcOptions = "-Werror";
       #  packages.cbors.patches = [ ./one.patch ];
       # To override a flag you will need to use mkOverride to make
       # it clear that you wish to replace the value found in the

--- a/modules/package.nix
+++ b/modules/package.nix
@@ -131,6 +131,11 @@ in {
         type = bool;
         default = false;
       };
+
+      ghcOptions = mkOption {
+        type = nullOr str;
+        default = null;
+      };
     };
 
     components = let

--- a/nix-tools/nix-tools-src.json
+++ b/nix-tools/nix-tools-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/nix-tools",
-  "rev": "5d4649a833cb8b963266cea016d5a12a30022266",
-  "date": "2019-10-11T14:24:33+13:00",
-  "sha256": "1xf3llli08axrhhda80hx95nmbwmdcz0y4r2vmgfhi3lqbcww8vk",
+  "rev": "87d97c50a53e421ed016d4c9a1dc41f9e6edda53",
+  "date": "2019-10-12T14:56:33+08:00",
+  "sha256": "1zvk13haiiyb6mcmypjn20i6vcx98y8zp5ipj0vpbflpg7f6rldm",
   "fetchSubmodules": false
 }

--- a/test/default.nix
+++ b/test/default.nix
@@ -24,6 +24,8 @@ in pkgs.recurseIntoAttrs {
   buildable = haskell.callPackage ./buildable {};
   project-flags-cabal = haskell.callPackage ./project-flags/cabal.nix {};
   project-flags-stack = haskell.callPackage ./project-flags/stack.nix {};
+  ghc-options-cabal = haskell.callPackage ./ghc-options/cabal.nix {};
+  ghc-options-stack = haskell.callPackage ./ghc-options/stack.nix {};
 
   # Run unit tests with: nix-instantiate --eval --strict -A unit.tests
   # An empty list means success.

--- a/test/ghc-options/.gitignore
+++ b/test/ghc-options/.gitignore
@@ -1,0 +1,2 @@
+.stack-work/
+*~

--- a/test/ghc-options/Setup.hs
+++ b/test/ghc-options/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/test/ghc-options/app/Main.hs
+++ b/test/ghc-options/app/Main.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE CPP #-}
+module Main where
+
+import Lib
+
+#ifdef TEST_GHC_OPTION
+main :: IO ()
+main = someFunc
+#endif

--- a/test/ghc-options/cabal.nix
+++ b/test/ghc-options/cabal.nix
@@ -1,0 +1,36 @@
+{ stdenv, mkCabalProjectPkgSet, callCabalProjectToNix, importAndFilterProject }:
+
+with stdenv.lib;
+
+let
+  plan = (importAndFilterProject (callCabalProjectToNix {
+      index-state = "2019-04-30T00:00:00Z";
+      src = ./.;
+    }));
+  pkgSet = mkCabalProjectPkgSet {
+    plan-pkgs = plan.pkgs;
+    # TODO find a way to get the ghc-options into plan.json so we can use it in plan-to-nix
+    modules = [ { packages.test-ghc-options.package.ghcOptions = "-DTEST_GHC_OPTION"; } ];
+  };
+  packages = pkgSet.config.hsPkgs;
+in
+  stdenv.mkDerivation {
+    name = "call-cabal-project-to-nix-test";
+
+    buildCommand = ''
+      exe="${packages.test-ghc-options.components.exes.test-ghc-options-exe}/bin/test-ghc-options-exe"
+
+      printf "checking whether executable runs... " >& 2
+      $exe
+
+      touch $out
+    '';
+
+    meta.platforms = platforms.all;
+
+    passthru = {
+      # Attributes used for debugging with nix repl
+      inherit pkgSet packages;
+      plan-nix = plan.nix;
+    };
+  }

--- a/test/ghc-options/cabal.project
+++ b/test/ghc-options/cabal.project
@@ -1,0 +1,4 @@
+packages: .
+
+package test-ghc-options
+  ghc-options: -DTEST_GHC_OPTION

--- a/test/ghc-options/src/Lib.hs
+++ b/test/ghc-options/src/Lib.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE CPP #-}
+module Lib
+    ( someFunc
+    ) where
+
+#ifdef TEST_GHC_OPTION
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"
+#endif

--- a/test/ghc-options/stack.nix
+++ b/test/ghc-options/stack.nix
@@ -1,0 +1,33 @@
+{ stdenv, mkStackPkgSet, callStackToNix, importAndFilterProject }:
+
+with stdenv.lib;
+
+let
+  stack = (importAndFilterProject (callStackToNix {
+    src = ./.;
+  }));
+  pkgSet = mkStackPkgSet {
+    stack-pkgs = stack.pkgs;
+  };
+  packages = pkgSet.config.hsPkgs;
+in
+  stdenv.mkDerivation {
+    name = "callStackToNix-test";
+
+    buildCommand = ''
+      exe="${packages.test-ghc-options.components.exes.test-ghc-options-exe}/bin/test-ghc-options-exe"
+
+      printf "checking whether executable runs... " >& 2
+      $exe
+
+      touch $out
+    '';
+
+    meta.platforms = platforms.all;
+
+    passthru = {
+      # Attributes used for debugging with nix repl
+      inherit pkgSet packages;
+      stack-nix = stack.nix;
+    };
+  }

--- a/test/ghc-options/stack.yaml
+++ b/test/ghc-options/stack.yaml
@@ -1,0 +1,7 @@
+resolver: lts-13.19
+
+packages:
+- .
+
+ghc-options:
+  test-ghc-options: -DTEST_GHC_OPTION

--- a/test/ghc-options/test-ghc-options.cabal
+++ b/test/ghc-options/test-ghc-options.cabal
@@ -1,0 +1,20 @@
+cabal-version:       >=1.10
+name:                test-ghc-options
+version:             0.1.0.0
+license:             PublicDomain
+author:              Hamish Mackenzie
+maintainer:          Hamish.Mackenzie@iohk.io
+build-type:          Simple
+
+library
+  build-depends:     base >=4.7 && <5
+  exposed-modules:   Lib
+  hs-source-dirs:    src
+  default-language:  Haskell2010
+
+executable test-ghc-options-exe
+  main-is:           Main.hs
+  build-depends:     base >=4.7 && <5, test-ghc-options
+  hs-source-dirs:    app
+  ghc-options:       -threaded -rtsopts -with-rtsopts=-N
+  default-language:  Haskell2010


### PR DESCRIPTION
This adds `ghcOptions` to the package and uses it during the build.  We can set the `ghcOptions` explicitly with `packages.x.package.ghcOptions`, but `stack-to-nix` will also set it based on the `stack.yaml` (`plan-to-nix` does not support this yet).