### PR TITLE
Pin the index-state used by ghc dependencies

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -1,5 +1,6 @@
 { dotCabal, pkgs, runCommand, nix-tools, cabal-install, ghc, hpack, symlinkJoin, cacert, index-state-hashes, haskellLib }@defaults:
-{ src
+{ name          ? null # optional name for better error messages
+, src
 , index-state   ? null
 , index-sha256  ? null
 , cabalProject  ? null
@@ -49,7 +50,9 @@ let
     then index-state
     else if rawCabalProject != null
       then parseIndexState rawCabalProject
-      else null;
+      else
+        builtins.trace ("Using latest index state" + (if name == null then "" else " for " + name) + "!")
+          (pkgs.lib.last (builtins.attrNames index-state-hashes));
 
   # Lookup hash for the index state we found
   index-sha256-found = if index-sha256 != null
@@ -161,7 +164,9 @@ let
     export GIT_SSL_CAINFO=${cacert}/etc/ssl/certs/ca-bundle.crt
     HOME=${dotCabal {
       inherit cabal-install nix-tools;
-      index-state = index-state-found;
+      index-state =
+        builtins.trace ("Using index-state: ${index-state-found}" + (if name == null then "" else " for " + name))
+          index-state-found;
       sha256 = index-sha256-found; }} cabal new-configure \
         --with-ghc=${ghc.targetPrefix}ghc \
         --with-ghc-pkg=${ghc.targetPrefix}ghc-pkg \

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -48,11 +48,15 @@ let
 
   index-state-found = if index-state != null
     then index-state
-    else if rawCabalProject != null
-      then parseIndexState rawCabalProject
-      else
-        builtins.trace ("Using latest index state" + (if name == null then "" else " for " + name) + "!")
-          (pkgs.lib.last (builtins.attrNames index-state-hashes));
+    else
+      let cabalProjectIndexState = if rawCabalProject != null
+        then parseIndexState rawCabalProject
+        else null;
+      in
+        if cabalProjectIndexState != null
+          then cabalProjectIndexState
+          else builtins.trace ("Using latest index state" + (if name == null then "" else " for " + name) + "!")
+            (pkgs.lib.last (builtins.attrNames index-state-hashes));
 
   # Lookup hash for the index state we found
   index-sha256-found = if index-sha256 != null

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -269,17 +269,20 @@ self: super: rec {
                     inherit ghc;
                     inherit (bootstrap.haskell.packages) cabal-install nix-tools hpack;
                     name = "alex"; version = "3.2.4";
+                    index-state = "2019-10-20T00:00:00Z";
                 }).components.exes.alex;
                 happy = (hackage-package {
                     inherit ghc;
                     inherit (bootstrap.haskell.packages) cabal-install nix-tools hpack;
                     name = "happy"; version = "1.19.11";
+                    index-state = "2019-10-20T00:00:00Z";
                 }).components.exes.happy;
 
                 hscolour = (hackage-package {
                     inherit ghc;
                     inherit (bootstrap.haskell.packages) cabal-install nix-tools hpack;
                     name = "hscolour"; version = "1.24.4";
+                    index-state = "2019-10-20T00:00:00Z";
                 }).components.exes.HsColour;
             };
         };

--- a/overlays/ghc-packages.nix
+++ b/overlays/ghc-packages.nix
@@ -82,6 +82,7 @@ in rec {
     }) self.buildPackages.haskell.compiler;
 
   ghc-extra-packages = builtins.mapAttrs (name: proj: self.haskell-nix.cabalProject {
+      name = "ghc-extra-packages";
       src = proj;
       ghc = self.buildPackages.haskell.compiler.${name};
     })

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -260,7 +260,6 @@ self: super: {
         hackage-project =
             { name
             , version
-            , index-state ? builtins.trace "Using latest index state!"  self.lib.last (builtins.attrNames (import indexStateHashesPath))
             , ... }@args:
             let tarball = self.pkgs.fetchurl {
                 url = "mirror://hackage/${name}-${version}.tar.gz";
@@ -271,15 +270,12 @@ self: super: {
                 tar xzf ${tarball}
                 mv "${name}-${version}" $out
                 '';
-            in cabalProject (builtins.removeAttrs args [ "name" "version" ] // { inherit index-state src; });
+            in cabalProject (builtins.removeAttrs args [ "version" ] // { inherit src; });
 
         cabalProject' =
-            { index-state ? builtins.trace "Using latest index state!"  self.lib.last (builtins.attrNames (import indexStateHashesPath))
+            { name ? null
             , ... }@args:
-            let plan = (importAndFilterProject
-                        (callCabalProjectToNix
-                         (builtins.trace "Using index-state: ${index-state}"
-                          (args // { inherit index-state; }))));
+            let plan = importAndFilterProject (callCabalProjectToNix args);
             in let pkg-set = mkCabalProjectPkgSet
                 { plan-pkgs = plan.pkgs;
                   pkg-def-extras = args.pkg-def-extras or [];


### PR DESCRIPTION
Currently when a new hackage index-state is available (every day on
haskell.nix/master branch) the index-state used alex, happy and hscolour
is in the bootPkgs is updates to that latest one.  This results in a
rebuild of GHC (even though the build plans are likely unchanged).

By pinning the index state for these bootPkgs nix will be able to
reuse GHC.  The only down side is that if we need to get new versions
of alex, happy and hscolour into bootPkgs we will likely need to bump
the index-state attributes as well as the version.