### PR TITLE
Add haskellNixRoots and withInputs to help caching

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -27,7 +27,7 @@ let
   haskell = pkgs.haskell-nix;
 
 in {
-  inherit (haskell) nix-tools source-pins;
+  inherit (haskell) haskellNixRoots;
   tests = import ./test/default.nix { inherit nixpkgs nixpkgsArgs; };
 
   # Scripts for keeping Hackage and Stackage up to date, and CI tasks.

--- a/overlays/ghc-packages.nix
+++ b/overlays/ghc-packages.nix
@@ -81,10 +81,12 @@ in rec {
       '';
     }) self.buildPackages.haskell.compiler;
 
-  ghc-extra-packages = builtins.mapAttrs (name: proj: self.haskell-nix.cabalProject {
+  ghc-extra-projects = builtins.mapAttrs (name: proj: self.haskell-nix.cabalProject' {
       name = "ghc-extra-packages";
       src = proj;
       ghc = self.buildPackages.haskell.compiler.${name};
     })
     ghc-extra-pkgs-cabal-projects;
+
+  ghc-extra-packages = builtins.mapAttrs (_: proj: proj.hsPkgs) ghc-extra-projects;
 }

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -339,7 +339,7 @@ self: super: {
         #   project = cabalProject' {...};
         # In your tests module add something that is effectively
         #   testProjectPlan = withInputs project.plan-nix;
-        withInputs = derivation: {
+        withInputs = derivation: pkgs.recurseIntoAttrs {
           inherit derivation;
           inputs = builtins.listToAttrs (
             builtins.concatMap (i: if i == null then [] else [
@@ -350,7 +350,7 @@ self: super: {
         # Add this to your tests to make all the dependencies of haskell.nix
         # are tested and cached.
         haskellNixRoots = self.recurseIntoAttrs {
-          inherit (self) nix-tools source-pins;
+          inherit (self.haskell-nix) nix-tools source-pins;
           bootstap-nix-tools = self.bootstrap.haskell.packages.nix-tools;
           alex-plan-nix = withInputs self.bootstrap.haskell.packages.alex-project.plan-nix;
           happy-plan-nix = withInputs self.bootstrap.haskell.packages.happy-project.plan-nix;

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -355,7 +355,8 @@ self: super: {
           alex-plan-nix = withInputs self.bootstrap.haskell.packages.alex-project.plan-nix;
           happy-plan-nix = withInputs self.bootstrap.haskell.packages.happy-project.plan-nix;
           hscolour-plan-nix = withInputs self.bootstrap.haskell.packages.hscolour-project.plan-nix;
-          ghc-extra-projects = builtins.mapAttrs (_: proj: self.recurseIntoAttrs (withInputs proj.plan-nix)) self.ghc-extra-projects;
+          ghc-extra-projects = builtins.mapAttrs (_: proj: self.recurseIntoAttrs (withInputs proj.plan-nix))
+            (builtins.filterAttrs (n: n != "ghc844" && n != "ghc861" && n != "ghc862") self.ghc-extra-projects);
         });
     };
 }

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -349,7 +349,7 @@ self: super: {
   
         # Add this to your tests to make all the dependencies of haskell.nix
         # are tested and cached.
-        haskellNixRoots = {
+        haskellNixRoots = self.recurseIntoAttrs {
           inherit (self) nix-tools source-pins;
           bootstap-nix-tools = self.bootstrap.haskell.packages.nix-tools;
           alex-plan-nix = withInputs self.bootstrap.haskell.packages.alex-project.plan-nix;

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -356,7 +356,7 @@ self: super: {
           happy-plan-nix = withInputs self.bootstrap.haskell.packages.happy-project.plan-nix;
           hscolour-plan-nix = withInputs self.bootstrap.haskell.packages.hscolour-project.plan-nix;
           ghc-extra-projects = builtins.mapAttrs (_: proj: self.recurseIntoAttrs (withInputs proj.plan-nix))
-            (builtins.filterAttrs (n: n != "ghc844" && n != "ghc861" && n != "ghc862") self.ghc-extra-projects);
+            (self.lib.filterAttrs (n: _: n != "ghc844" && n != "ghc861" && n != "ghc862") self.ghc-extra-projects);
         });
     };
 }

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -339,7 +339,7 @@ self: super: {
         #   project = cabalProject' {...};
         # In your tests module add something that is effectively
         #   testProjectPlan = withInputs project.plan-nix;
-        withInputs = derivation: pkgs.recurseIntoAttrs {
+        withInputs = derivation: builtins.mapAttrs (_: self.recurseIntoAttrs) {
           inherit derivation;
           inputs = builtins.listToAttrs (
             builtins.concatMap (i: if i == null then [] else [
@@ -349,13 +349,13 @@ self: super: {
   
         # Add this to your tests to make all the dependencies of haskell.nix
         # are tested and cached.
-        haskellNixRoots = self.recurseIntoAttrs {
+        haskellNixRoots = self.recurseIntoAttrs (builtins.mapAttrs (_: self.recurseIntoAttrs) {
           inherit (self.haskell-nix) nix-tools source-pins;
           bootstap-nix-tools = self.bootstrap.haskell.packages.nix-tools;
           alex-plan-nix = withInputs self.bootstrap.haskell.packages.alex-project.plan-nix;
           happy-plan-nix = withInputs self.bootstrap.haskell.packages.happy-project.plan-nix;
           hscolour-plan-nix = withInputs self.bootstrap.haskell.packages.hscolour-project.plan-nix;
           ghc-extra-projects = builtins.mapAttrs (_: proj: withInputs proj.plan-nix) self.ghc-extra-projects;
-        };
+        });
     };
 }

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -333,7 +333,7 @@ self: super: {
             in pkg-set.config.hsPkgs;
 
         # The functions that return a plan-nix often have a lot of dependencies
-        # that could be GCed and also well not make it into hydra cache.
+        # that could be GCed and also will not make it into hydra cache.
         # Use this `withInputs` function to make sure your tests include
         # the dependencies needed explicitly.  For example, if you have:
         #   project = cabalProject' {...};

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -355,7 +355,7 @@ self: super: {
           alex-plan-nix = withInputs self.bootstrap.haskell.packages.alex-project.plan-nix;
           happy-plan-nix = withInputs self.bootstrap.haskell.packages.happy-project.plan-nix;
           hscolour-plan-nix = withInputs self.bootstrap.haskell.packages.hscolour-project.plan-nix;
-          ghc-extra-projects = builtins.mapAttrs (_: proj: withInputs proj.plan-nix) self.ghc-extra-projects;
+          ghc-extra-projects = builtins.mapAttrs (_: proj: self.recurseIntoAttrs (withInputs proj.plan-nix)) self.ghc-extra-projects;
         });
     };
 }


### PR DESCRIPTION
Now that haskell.nix relies on IFD internally it is helpful to have
the nativeBuildInputs of the IFDs built and cached.