### PR TITLE
Give more control over the compilation of Setup.hs

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -9,6 +9,7 @@ let
   setup-builder = haskellLib.weakCallPackage pkgs ./setup-builder.nix {
     ghc = (ghc.passthru.buildGHC or ghc);
     hsPkgs = hsPkgs.buildPackages;
+    inherit buildPackages pkgconfig;
     inherit haskellLib nonReinstallablePkgs makeSetupConfigFiles;
   };
 

--- a/builder/hspkg-builder.nix
+++ b/builder/hspkg-builder.nix
@@ -39,7 +39,10 @@ let
   setup = if package.buildType == "Simple" && package.setup-depends == []
     then defaultSetup
     else setup-builder {
-      setup-depends = package.setup-depends;
+      component = components.setup // {
+        depends = components.setup.depends ++ package.setup-depends;
+        extraSrcFiles = components.setup.extraSrcFiles ++ [ "Setup.hs" "Setup.lhs" ];
+      };
       inherit package name src flags revision patches defaultSetupSrc;
       inherit (config) preUnpack postUnpack;
     };

--- a/modules/package.nix
+++ b/modules/package.nix
@@ -213,6 +213,27 @@ in {
         };
       };
     in {
+      setup = mkOption {
+        type = nullOr componentType;
+        default = {
+          depends = [];
+          libs = [];
+          frameworks = [];
+          doExactConfig = false;
+          # We have to set hsSourceDirs or cleanCabalComponent will
+          # include everything (and as a result all the components of
+          # the package will depend on eveything in the package).
+          # TODO find a better way
+          hsSourceDirs = ["setup-src"];
+          includeDirs = [];
+          asmSources = [];
+          cSources = [];
+          cmmSources = [];
+          cxxSources = [];
+          jsSources = [];
+          extraSrcFiles = [ "Setup.hs" "Setup.lhs" ];
+        };
+      };
       library = mkOption {
         type = nullOr componentType;
         default = null;


### PR DESCRIPTION
Allows adding of overrides through package.components.setup.
I need this to specify frameworks that Setup.hs needs on macOS.