### PR TITLE
Make packages reinstallable if reinstallableLibGhc is true

### DIFF
--- a/modules/component-driver.nix
+++ b/modules/component-driver.nix
@@ -52,15 +52,17 @@ in
       "deepseq" "array" "ghc-boot-th" "pretty" "template-haskell"
       # ghcjs custom packages
       "ghcjs-prim" "ghcjs-th"
-"ghc" "Cabal" "Win32" "array" "base" "binary" "bytestring" "containers" "deepseq"
-"directory" "filepath" "ghc-boot" "ghc-compact" "ghc-prim"
-# "ghci" "haskeline"
-"hpc"
-"integer-gmp" "mtl" "parsec" "process" "template-haskell" "text" "time" "transformers"
-"unix" "xhtml"
-# "stm" "terminfo"
     ]
-    ++ lib.optionals (!config.reinstallableLibGhc) [ "ghc" "ghc-boot" ];
+    ++ lib.optionals (!config.reinstallableLibGhc) [
+      "ghc-boot"
+      "ghc" "Cabal" "Win32" "array" "binary" "bytestring" "containers"
+      "directory" "filepath" "ghc-boot" "ghc-compact" "ghc-prim"
+      # "ghci" "haskeline"
+      "hpc"
+      "mtl" "parsec" "process" "text" "time" "transformers"
+      "unix" "xhtml"
+      # "stm" "terminfo"
+    ];
 
   options.bootPkgs = lib.mkOption {
     type = lib.types.listOf lib.types.str;


### PR DESCRIPTION
This reverts the reinstallable packages to before PR #261 was merged and
only flags the additional non-reinstallable packages as
non-reinstallable if reinstallableLibGhc is `false`.