### PR TITLE
Add subDir argument to cleanGit

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -110,7 +110,7 @@ in the local `.git` directory.  This is extremely useful as it avoids
 unwanted builds (for instance when the contents of `dist-newstyle` are
 modified by cabal).  It is important that `src` is the root directory
 of the repo (so `cleanGit` can find the `.git` directory).  If the project
-is not at the root of the git also pass `subDir` to `cleanGit` with the
+is not at the root of the repo, then also pass `subDir` to `cleanGit` with the
 location of the project relative to `src` as a string. For example:
 
 ```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -115,7 +115,7 @@ location of the project relative to `src` as a string. For example:
 
 ```
   src = pkgs.haskell-nix.haskellLib.cleanGit
-    { src = ./.; srcDir = "subdir/another-subdir"; };
+    { src = ./.; subDir = "subdir/another-subdir"; };
 ```
 
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -108,7 +108,16 @@ If your project has a `cabal.project` you can add a `default.nix` like this:
 Note: The `cleanGit` call will exclude any files not in the index file
 in the local `.git` directory.  This is extremely useful as it avoids
 unwanted builds (for instance when the contents of `dist-newstyle` are
-modified by cabal).
+modified by cabal).  It is important that `src` is the root directory
+of the repo (so `cleanGit` can find the `.git` directory).  If the project
+is not at the root of the git also pass `subDir` to `cleanGit` with the
+location of the project relative to `src` as a string. For example:
+
+```
+  src = pkgs.haskell-nix.haskellLib.cleanGit
+    { src = ./.; srcDir = "subdir/another-subdir"; };
+```
+
 
 You can build a component from your project with `nix-build` (in this
 case the `hello` executable in a `helloworld` package):

--- a/lib/clean-git.nix
+++ b/lib/clean-git.nix
@@ -1,6 +1,6 @@
 # From https://github.com/NixOS/nix/issues/2944
 { lib, runCommand, git, cleanSourceWith }:
-{ src }:
+{ src, subDir ? "" }:
 
 # The function call
 #
@@ -90,12 +90,12 @@ then
     filter = filter_from_list src whitelist;
   in
     cleanSourceWith {
-      inherit src filter;
+      inherit src subDir filter;
     }
 
 else
   trace "gitSource.nix: ${toString src} does not seem to be a git repository,\nassuming it is a clean checkout." (
     cleanSourceWith {
-      inherit src;
+      inherit src subDir;
     }
   )


### PR DESCRIPTION
Avoids an additional call to `haskell-nix.cleanSourceWith`.  I've also added some docs.