### PR TITLE
Fix cleanGit when using a worktree

### DIFF
--- a/lib/clean-git.nix
+++ b/lib/clean-git.nix
@@ -54,34 +54,35 @@ in
 if builtins.pathExists (toString src + "/.git")
 then
   let
-    git_dir =
-      if builtins.pathExists (toString src + "/.git/index")
-      then (toString src + "/.git")
-      else # likely a git worktree, so follow the indirection
-        let
-          git_content = lines (readFile (toString src + "/.git"));
-          first_line = head git_content;
-          prefix = "gitdir: ";
-          ok = length git_content == 1 && has_prefix prefix first_line;
-        in
-          if ok
-          then /. + remove_prefix prefix first_line
-          else abort "gitSource.nix: Cannot parse ${toString src + "/.git"}";
-
-    gitFiles = cleanSourceWith {
-      inherit src;
+    gitDir = cleanSourceWith {
+      src = if builtins.pathExists (toString src + "/.git/index")
+        then (toString src + "/.git")
+        else # likely a git worktree, so follow the indirection
+          let
+            git_content = lines (readFile (toString src + "/.git"));
+            first_line = head git_content;
+            prefix = "gitdir: ";
+            ok = length git_content == 1 && has_prefix prefix first_line;
+          in
+            if ok
+            then /. + remove_prefix prefix first_line
+            else abort "gitSource.nix: Cannot parse ${toString src + "/.git"}";
       filter = path: type:
         type == "directory" ||
         lib.any (i: (lib.hasSuffix i path)) [
-          ".gitmodules" ".git/config" ".git/index" ".git/HEAD" ".git/objects" ".git/refs" ] ||
-        (lib.strings.hasInfix ".git/modules/" path &&
+          "/config" "/index" "/HEAD" ]) ||
+        (lib.strings.hasInfix "modules/" path &&
           lib.any (i: (lib.hasSuffix i path)) [
-            "config" "index" "HEAD" "objects" "refs" ]);
+            "/config" "/index" "/HEAD" "/objects" "/refs" ]);
     };
 
     whitelist_file =
       runCommand "git-ls-files" {envVariable = true;} ''
-        cd ${gitFiles}
+        tmp=$(mktemp -d)
+        cd $tmp
+        cp -r ${gitDir} .git
+        chmod +w -R .git
+        mkdir -p .git/objects .git/refs
         ${git}/bin/git ls-files --recurse-submodules > $out
       '';
 


### PR DESCRIPTION
Joachim's original version had logic to handle git worktree's but
it was not wired into the updated version that uses cleanSourceWith.