### PR TITLE
Add `allExes` (like `all`)

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -50,7 +50,9 @@ let
 
   fullName = if haskellLib.isAll componentId
     then "${name}-all"
-    else "${name}-${componentId.ctype}-${componentId.cname}";
+    else if haskellLib.isAllExes componentId
+      then "${name}-allExes"
+      else "${name}-${componentId.ctype}-${componentId.cname}";
 
   configFiles = makeConfigFiles {
     inherit (package) identifier;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -30,6 +30,8 @@ with haskellLib;
 
   getAllComponents = foldComponents subComponentTypes (c: acc:
     lib.optional c.buildable c ++ acc) [];
+  getAllExeComponents = foldComponents ["exes"] (c: acc:
+    lib.optional c.buildable c ++ acc) [];
 
   componentPrefix = {
     # Are all of these right?
@@ -46,6 +48,7 @@ with haskellLib;
       applyLibrary = cname: f { cname = config.package.identifier.name; ctype = "lib"; };
       applySubComp = ctype: cname: f { inherit cname; ctype = componentPrefix.${ctype} or (throw "Missing component mapping for ${ctype}."); };
       applyAllComp = f { cname = config.package.identifier.name; ctype = "all"; };
+      applyAllExesComp = f { cname = config.package.identifier.name; ctype = "all"; };
       buildableAttrs = lib.filterAttrs (n: comp: comp.buildable or true);
       libComp = if comps.library == null || !(comps.library.buildable or true)
         then {}
@@ -54,7 +57,8 @@ with haskellLib;
         (ctype: attrs: lib.mapAttrs (applySubComp ctype) (buildableAttrs attrs))
         (builtins.intersectAttrs (lib.genAttrs subComponentTypes (_: null)) comps);
       allComp = { all = applyAllComp comps.all; };
-    in subComps // libComp // allComp;
+      allExesComp = { allExes = applyAllExesComp comps.allExes; };
+    in subComps // libComp // allComp // allExesComp;
 
   isLibrary = componentId: componentId.ctype == "lib";
   isAll = componentId: componentId.ctype == "all";

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -48,11 +48,11 @@ with haskellLib;
       applyLibrary = cname: f { cname = config.package.identifier.name; ctype = "lib"; };
       applySubComp = ctype: cname: f { inherit cname; ctype = componentPrefix.${ctype} or (throw "Missing component mapping for ${ctype}."); };
       applyAllComp = f { cname = config.package.identifier.name; ctype = "all"; };
-      applyAllExesComp = f { cname = config.package.identifier.name; ctype = "all"; };
+      applyAllExesComp = f { cname = config.package.identifier.name; ctype = "allExes"; };
       buildableAttrs = lib.filterAttrs (n: comp: comp.buildable or true);
       libComp = if comps.library == null || !(comps.library.buildable or true)
         then {}
-        else lib.mapAttrs applyLibrary (removeAttrs comps (subComponentTypes ++ [ "all" ]));
+        else lib.mapAttrs applyLibrary (removeAttrs comps (subComponentTypes ++ [ "all" "allExes" ]));
       subComps = lib.mapAttrs
         (ctype: attrs: lib.mapAttrs (applySubComp ctype) (buildableAttrs attrs))
         (builtins.intersectAttrs (lib.genAttrs subComponentTypes (_: null)) comps);
@@ -62,6 +62,7 @@ with haskellLib;
 
   isLibrary = componentId: componentId.ctype == "lib";
   isAll = componentId: componentId.ctype == "all";
+  isAllExes = componentId: componentId.ctype == "allExes";
   isTest = componentId: componentId.ctype == "test";
   isBenchmark = componentId: componentId.ctype == "bench";
 
@@ -73,7 +74,7 @@ with haskellLib;
   # Format a componentId as it should appear as a target on the
   # command line of the setup script.
   componentTarget = componentId:
-    if componentId.ctype == "all" then ""
+    if isAll componentId || isAllExes componentId then ""
     else "${componentId.ctype}:${componentId.cname}";
 
   # Remove null or empty values from an attrset.

--- a/modules/package.nix
+++ b/modules/package.nix
@@ -272,6 +272,15 @@ in {
         };
         description = "The merged dependencies of all other components";
       };
+      allExes = mkOption {
+        type = componentType;
+        apply = all: all // {
+          # TODO: Should this check for the entire component
+          # definition to match, rather than just the identifier?
+          depends = builtins.filter (p: p.identifier != config.package.identifier) all.depends;
+        };
+        description = "The merged dependencies of all other components";
+      };
     };
 
     name = mkOption {
@@ -317,4 +326,5 @@ in {
   # something like an anyBool type, which would merge definitions by
   # returning true if any is true.
   config.components.all = lib.mkMerge (haskellLib.getAllComponents config);
+  config.components.allExes = lib.mkMerge (haskellLib.getAllExeComponents config);
 }

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -270,6 +270,7 @@ self: super: rec {
                     inherit (bootstrap.haskell.packages) cabal-install nix-tools hpack;
                     name = "alex"; version = "3.2.4";
                     index-state = "2019-10-20T00:00:00Z";
+                    plan-sha256 = "086kd6aa5bir3y4aqb1wl5zkj6agz5q4wp4snvdnf6cidz5wra06";
                 };
                 alex = bootstrap.haskell.packages.alex-project.alex.components.exes.alex;
                 happy-project = hackage-project {
@@ -277,6 +278,7 @@ self: super: rec {
                     inherit (bootstrap.haskell.packages) cabal-install nix-tools hpack;
                     name = "happy"; version = "1.19.11";
                     index-state = "2019-10-20T00:00:00Z";
+                    plan-sha256 = "011bxlxdv239psgi80j00km2wcgb68j16sz3fng67d03sqf5i37w";
                 };
                 happy = bootstrap.haskell.packages.happy-project.happy.components.exes.happy;
                 hscolour-project = hackage-project {
@@ -284,6 +286,7 @@ self: super: rec {
                     inherit (bootstrap.haskell.packages) cabal-install nix-tools hpack;
                     name = "hscolour"; version = "1.24.4";
                     index-state = "2019-10-20T00:00:00Z";
+                    plan-sha256 = "021rwcmkshibc3mfr833ay5hfr19kq6k32lxyrrb6vp9vmihgw4b";
                 };
                 hscolour = bootstrap.haskell.packages.hscolour-project.hscolour.components.exes.HsColour;
             };

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -198,10 +198,8 @@ self: super: rec {
     cabal-install = self.buildPackages.bootstrap.haskell.packages.cabal-install;
 
     # see below
-    haskellPackages.hpack = null;
-    haskellPackages.hoogle = self.haskell-nix.haskellPackages.hoogle.components.exes.hoogle;
-    haskellPackages.happy = self.haskell-nix.haskellPackages.happy.components.exes.happy;
-    haskellPackages.alex = self.haskell-nix.haskellPackages.alex.components.exes.alex;
+    haskellPackages = builtins.mapAttrs (_: p: p.components.allExes)
+    	self.haskell-nix.haskellPackages;
 
     # WARN: The `import ../. {}` will prevent
     #       any cross to work, as we will loose
@@ -217,7 +215,7 @@ self: super: rec {
 
     # stub out lib stuff.
     haskell.lib = {
-        justStaticExecutables = x: x;
+        justStaticExecutables = x: if x ? components then x.components.allExes else x;
     };
 
     # NOTE: 8.6.5 prebuilt binaries on macOS, will yield:

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -198,8 +198,9 @@ self: super: rec {
     cabal-install = self.buildPackages.bootstrap.haskell.packages.cabal-install;
 
     # see below
-    haskellPackages = builtins.mapAttrs (_: p: p.components.allExes)
-    	self.haskell-nix.haskellPackages;
+    haskellPackages = (builtins.mapAttrs (_: p: p.components.allExes)
+    	self.haskell-nix.haskellPackages)
+    	// { hpack = null; };
 
     # WARN: The `import ../. {}` will prevent
     #       any cross to work, as we will loose

--- a/test/buildable/default.nix
+++ b/test/buildable/default.nix
@@ -4,6 +4,7 @@ with stdenv.lib;
 
 let
   plan = importAndFilterProject (callCabalProjectToNix {
+    name = "test-buildable";
     index-state = "2019-04-30T00:00:00Z";
     src = ./.;
   });

--- a/test/cabal-source-repo/default.nix
+++ b/test/cabal-source-repo/default.nix
@@ -5,6 +5,7 @@ with stdenv.lib;
 let
   pkgSet = mkCabalProjectPkgSet {
     plan-pkgs = (importAndFilterProject (callCabalProjectToNix {
+      name = "test-cabal-source-repo";
       index-state = "2019-04-30T00:00:00Z";
       # reuse the cabal-simple test project
       src = ./.;

--- a/test/call-cabal-project-to-nix/default.nix
+++ b/test/call-cabal-project-to-nix/default.nix
@@ -5,6 +5,7 @@ with stdenv.lib;
 let
   pkgSet = mkCabalProjectPkgSet {
     plan-pkgs = (importAndFilterProject (callCabalProjectToNix {
+      name = "test-call-cabal-project-to-nix";
       index-state = "2019-04-30T00:00:00Z";
       # reuse the cabal-simple test project
       src = ../cabal-simple;

--- a/test/ghc-options/cabal.nix
+++ b/test/ghc-options/cabal.nix
@@ -4,6 +4,7 @@ with stdenv.lib;
 
 let
   plan = (importAndFilterProject (callCabalProjectToNix {
+      name = "test-ghc-options";
       index-state = "2019-04-30T00:00:00Z";
       src = ./.;
     }));

--- a/test/project-flags/cabal.nix
+++ b/test/project-flags/cabal.nix
@@ -4,6 +4,7 @@ with stdenv.lib;
 
 let
   plan = (importAndFilterProject (callCabalProjectToNix {
+      name = "test-project-flags";
       index-state = "2019-04-30T00:00:00Z";
       src = ./.;
     }));

--- a/test/setup-deps/default.nix
+++ b/test/setup-deps/default.nix
@@ -5,6 +5,7 @@ with stdenv.lib;
 
 let
   project = haskell-nix.cabalProject' {
+    name = "test-setup-deps";
     src = ./.;
     modules = [{
       # Package has no exposed modules which causes

--- a/test/shell-for-setup-deps/default.nix
+++ b/test/shell-for-setup-deps/default.nix
@@ -4,6 +4,7 @@ with stdenv.lib;
 
 let
   plan = importAndFilterProject (callCabalProjectToNix {
+    name = "test-shell-for-setup-deps";
     src = ./.;
   });
   pkgSet = mkCabalProjectPkgSet {

--- a/test/unit.nix
+++ b/test/unit.nix
@@ -10,6 +10,7 @@ let
        sublibs = { };
        tests = { };
        all = "all";
+       allExes = "all";
     };
     package.identifier.name = "empty";
   };
@@ -23,6 +24,7 @@ let
        sublibs = { };
        tests = { ttt = "ttt"; };
        all = "all";
+       allExes = "all";
     };
     package.identifier.name = "nnn";
   };
@@ -38,7 +40,7 @@ lib.runTests {
   # map a component to its component name and check these are correct
   test-applyComponents-library = {
     expr = haskellLib.applyComponents (componentId: component: componentId.cname) emptyConfig;
-    expected = emptyConfig.components // { library = "empty"; all = "empty"; };
+    expected = emptyConfig.components // { library = "empty"; all = "empty"; allExes = "empty"; };
   };
 
   test-applyComponents-components = {


### PR DESCRIPTION
This will make pkgs.haskellPackages more like the existing nixpkgs
one.  However haskell-nix.haskellPackages will still point to the
full packages.