### PR TITLE
Use fixed output derivations for bootstrap plans

### DIFF
--- a/docs/reference/library.md
+++ b/docs/reference/library.md
@@ -208,6 +208,19 @@ needed for `importAndFilterProject`.
     })).pkgs;
 ```
 
+| Argument         | Type | Description         |
+|------------------|------|---------------------|
+| `name`          | String | Optional name for better error messages. |
+| `src`           | Path   | Location of the cabal project files. |
+| `index-state`   | Timestamp | Optional hackage index-state, eg. "2019-10-10T00:00:00Z". |
+| `index-sha256`  | Sha256 | Optional hash of the truncated hackage index-state. |
+| `plan-sha256`   | Sha256 | Optional hash of the plan-to-nix output (makes the plan-to-nix step a fixed output derivation). |
+| `cabalProject`  | Path   | Optional cabal project file (defaults to "${src}/cabal.project"). |
+| `ghc`           |        | Optional ghc to use |
+| `nix-tools`     |        | Optional nix-tools to use |
+| `hpack`         |        | Optional hpack to use |
+| `cabal-install` |        | Optional cabal-install to use |
+
 ## importAndFilterProject
 
 Imports from a derivation created by `callStackToNix`

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -1,10 +1,10 @@
 { dotCabal, pkgs, runCommand, nix-tools, cabal-install, ghc, hpack, symlinkJoin, cacert, index-state-hashes, haskellLib }@defaults:
 { name          ? null # optional name for better error messages
 , src
-, index-state   ? null
-, index-sha256  ? null
-, plan-sha256   ? null
-, cabalProject  ? null
+, index-state   ? null # Hackage index-state, eg. "2019-10-10T00:00:00Z"
+, index-sha256  ? null # The hash of the truncated hackage index-state
+, plan-sha256   ? null # The hash of the plan-to-nix output (makes the plan-to-nix step a fixed output derivation)
+, cabalProject  ? null # Cabal project file (when null uses "${src}/cabal.project")
 , ghc           ? defaults.ghc
 , nix-tools     ? defaults.nix-tools
 , hpack         ? defaults.hpack

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -271,6 +271,7 @@ self: super: rec {
                     inherit (bootstrap.haskell.packages) cabal-install nix-tools hpack;
                     name = "alex"; version = "3.2.4";
                     index-state = "2019-10-20T00:00:00Z";
+                    plan-sha256 = "086kd6aa5bir3y4aqb1wl5zkj6agz5q4wp4snvdnf6cidz5wra06";
                 };
                 alex = bootstrap.haskell.packages.alex-project.alex.components.exes.alex;
                 happy-project = hackage-project {
@@ -278,6 +279,7 @@ self: super: rec {
                     inherit (bootstrap.haskell.packages) cabal-install nix-tools hpack;
                     name = "happy"; version = "1.19.11";
                     index-state = "2019-10-20T00:00:00Z";
+                    plan-sha256 = "011bxlxdv239psgi80j00km2wcgb68j16sz3fng67d03sqf5i37w";
                 };
                 happy = bootstrap.haskell.packages.happy-project.happy.components.exes.happy;
                 hscolour-project = hackage-project {
@@ -285,6 +287,7 @@ self: super: rec {
                     inherit (bootstrap.haskell.packages) cabal-install nix-tools hpack;
                     name = "hscolour"; version = "1.24.4";
                     index-state = "2019-10-20T00:00:00Z";
+                    plan-sha256 = "021rwcmkshibc3mfr833ay5hfr19kq6k32lxyrrb6vp9vmihgw4b";
                 };
                 hscolour = bootstrap.haskell.packages.hscolour-project.hscolour.components.exes.HsColour;
             };


### PR DESCRIPTION
Currently when a dependency of cabal-install or plan-to-nix changes
the cabal new-configure and plan-to-nix have to be rebuilt in order
to recalculate the plan-nix for bootstrap packages alex, happy and
hscolour.  We have pinned the inputs such as hackage index-state
so that the plan generated should be the same.  Unfortunately it can
still result in a long wait.

Haskell.nix does cache the result via haskellNixRoots when built on
iohk's hydra server.  But if you use a different version of nixpkgs
it is unlikely to work.  If you have access to a CI that populates a
nix cache you can add haskellNixRoots to your CI build, but if not
you are kind of stuck.

One option to help with this would be to include the plan-to-nix output
in the haskell.nix git repository.  But intermediate files in git is
not nice.

Instead this PR adds just the hashes of the output to the derivations
that runs plan-to-nix.  Since the inputs are fixed or should have
no affect on the result (GCC version for instance), we should
be able to rely on them remaining constant.