### PR TITLE
Move all of haskell.nix into `haskell-nix`

### DIFF
--- a/README.org
+++ b/README.org
@@ -25,7 +25,7 @@ For =cabal.project= project add a =default.nix=:
 }:
   pkgs.haskell-nix.cabalProject {
     src = pkgs.haskell-nix.haskellLib.cleanGit { src = ./.; };
-    ghc = pkgs.buildPackages.pkgs.haskell.compiler.${haskellCompiler};
+    ghc = pkgs.buildPackages.pkgs.haskell-nix.compiler.${haskellCompiler};
   }
 #+end_src
 

--- a/builder/default.nix
+++ b/builder/default.nix
@@ -35,8 +35,9 @@ let
 
   hoogleLocal = let
     nixpkgsHoogleLocal = import (pkgs.path + /pkgs/development/haskell-modules/hoogle.nix);
-  in { packages ? [], hoogle ? pkgs.haskellPackages.hoogle }:
+  in { packages ? [], hoogle ? pkgs.haskell-nix.haskellPackages.hoogle.components.exes.hoogle }:
     haskellLib.weakCallPackage pkgs nixpkgsHoogleLocal {
+      ghc = pkgs.haskell-nix.ghc;
       inherit packages hoogle;
     };
 

--- a/ci.nix
+++ b/ci.nix
@@ -46,11 +46,11 @@ in
                 (ghc-extra-packages.ghc865.remote-iserv.components.exes).remote-iserv;
 
       };
-      haskell.compiler = {
+      haskell-nix.compiler = {
         x86_64-linux = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-linux"; }));
-            haskell.compiler;
+            haskell-nix.compiler;
         x86_64-darwin = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-darwin";}));
-            haskell.compiler;
+            haskell-nix.compiler;
       };
       tests = {
         x86_64-linux = (import ./test { nixpkgs = nixpkgsSrc; nixpkgsArgs = { system = "x86_64-linux"; }; });

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -90,7 +90,7 @@ If your project has a `cabal.project` you can add a `default.nix` like this:
 }:
   pkgs.haskell-nix.cabalProject {
     src = pkgs.haskell-nix.haskellLib.cleanGit { src = ./.; };
-    ghc = pkgs.buildPackages.pkgs.haskell.compiler.${haskellCompiler};
+    ghc = pkgs.buildPackages.pkgs.haskell-nix.compiler.${haskellCompiler};
     # pkg-def-extras = [
     #   # Additional packages ontop of all those listed in `cabal.project`
     # ];

--- a/docs/user-guide/cabal-projects.md
+++ b/docs/user-guide/cabal-projects.md
@@ -31,7 +31,7 @@ If all goes well, you should now have the file
 
 !!! tip "Specifying the GHC version"
     To use a specific compiler version, replace `haskellPackages.ghc`
-    with something like `haskell.compiler.ghc865`. The given compiler
+    with something like `haskell-nix.compiler.ghc865`. The given compiler
     must exist in your Nixpkgs version, of course. See also the
     [Nixpkgs Manual][compiler].
 

--- a/modules/hackage.nix
+++ b/modules/hackage.nix
@@ -66,13 +66,13 @@ in {
     # this should allow us to use `config` overrides
     # in the nixpkgs setup, and properly override the
     # complier as needed.
-    default = pkgs.buildPackages.haskell.compiler.${config.compiler.nix-name} or (throw ''
+    default = pkgs.buildPackages.haskell-nix.compiler.${config.compiler.nix-name} or (throw ''
       This version of Nixpkgs does not contain GHC ${config.compiler.version} 
       (or it is not present at attribute '${config.compiler.nix-name})').
       Either switch to a version of Nixpkgs which does have this version, or use a version
       of GHC which the current version of Nixpkgs contains.
     '');
-    defaultText = "pkgs.buildPackages.haskell.compiler.\${config.compiler.nix-name}";
+    defaultText = "pkgs.buildPackages.haskell-nix.compiler.\${config.compiler.nix-name}";
   };
 
   options.hackage.db = lib.mkOption {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,4 +1,7 @@
 [
+    # Hide nixpkgs haskell and haskellPackages from the haskell-nix overlays.
+    # This should prevent us inadvertantly depending on them.
+    (_: super: { haskell = {}; haskellPackages = {}; haskell-nix-super = super; })
     (import ./release-19.03.nix)
     #(import ./ghcjs-asterius-triple.nix)
     #(import ./python.nix)
@@ -8,4 +11,6 @@
     (import ./ghc-packages.nix)
     (import ./windows.nix)
     (import ./armv6l-linux.nix)
+    # Restore nixpkgs haskell and haskellPackages
+    (_: super: { inherit (super.haskell-nix-super) haskell haskellPackages; })
 ]

--- a/overlays/ghc-packages.nix
+++ b/overlays/ghc-packages.nix
@@ -6,7 +6,7 @@ let
       EOF
     '';
   callCabalSdist = name: src: self.runCommand "${name}-sdist.tar.gz" {
-      nativeBuildInputs = [ self.cabal-install ];
+      nativeBuildInputs = [ self.haskell-nix.cabal-install ];
     } ''
       tmp=$(mktemp -d)
       cp -r ${src}/* $tmp
@@ -65,7 +65,7 @@ in rec {
   ghc-boot-packages = builtins.mapAttrs
     (name: value: builtins.mapAttrs
       (pkgName: dir: importCabal "${name}-${pkgName}" "${value.passthru.configured-src}/${dir}") ghc-extra-pkgs)
-    self.buildPackages.haskell.compiler;
+    self.buildPackages.haskell-nix.compiler;
 
   ghc-extra-pkgs-cabal-projects = builtins.mapAttrs (name: value: let package-locs = builtins.mapAttrs (_: dir: "${value.passthru.configured-src}/${dir}") ghc-extra-pkgs; in
     self.writeTextFile {
@@ -79,13 +79,13 @@ in rec {
                      ghci +ghci,
                      libiserv +network
       '';
-    }) self.buildPackages.haskell.compiler;
+    }) self.buildPackages.haskell-nix.compiler;
 
   ghc-extra-projects = builtins.mapAttrs (name: proj: self.haskell-nix.cabalProject' {
       name = "ghc-extra-packages";
       src = proj;
       index-state = "2019-10-31T00:00:00Z";
-      ghc = self.buildPackages.haskell.compiler.${name};
+      ghc = self.buildPackages.haskell-nix.compiler.${name};
     })
     ghc-extra-pkgs-cabal-projects;
 

--- a/overlays/ghc.nix
+++ b/overlays/ghc.nix
@@ -9,7 +9,7 @@ self: super: with super;
         hardeningDisable = (drv.hardeningDisable or []) ++ [ "stackprotector" "format" ];
       };
    in {
-   haskell = let
+   haskell-nix = let
      # These patches (ghcPkgOverrides and ghcDrvOverrides) only apply to vanilla source ghcs.
      # Not ghcjs or binary distributions.
      # We also ignore ghc82. And are only concerned with ghc84+
@@ -24,8 +24,8 @@ self: super: with super;
      overrideCompiler = compiler:
        (compiler.override ghcPkgOverrides).overrideAttrs ghcDrvOverrides;
    in
-     lib.recursiveUpdate super.haskell {
+     lib.recursiveUpdate super.haskell-nix {
        compiler = lib.mapAttrs (_name: overrideCompiler)
-         (lib.filterAttrs (name: _value: needsPatches name) super.haskell.compiler);
+         (lib.filterAttrs (name: _value: needsPatches name) super.haskell-nix.compiler);
      };
    }

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -142,8 +142,7 @@ self: super: {
             inherit (self) pkgs lib symlinkJoin makeWrapper
                            git nix nix-prefetch-git;
             inherit (self.haskell-nix) fetchExternal cleanSourceHaskell mkCabalProjectPkgSet;
-            hpack = self.haskell.lib.justStaticExecutables
-                (self.haskellPackages.hpack);
+            hpack = null; # nix-tools does not use hpack project files
         };
         # While `nix-tools-cross-compiled` may be cross compiled,
         # getting it from `buildPackages` we should get
@@ -258,7 +257,8 @@ self: super: {
             inherit (self.buildPackages.haskell-nix) dotCabal nix-tools haskellLib;
             pkgs = self.buildPackages.pkgs;
             inherit (self.buildPackages.haskell-nix.haskellPackages.hpack.components.exes) hpack;
-            inherit (self.buildPackages.pkgs) runCommand cabal-install ghc symlinkJoin cacert;
+            inherit (self.buildPackages.haskell-nix) cabal-install ghc;
+            inherit (self.buildPackages.pkgs) runCommand symlinkJoin cacert;
         };
 
         # Loads a plan and filters the package directories using cleanSourceWith
@@ -351,10 +351,10 @@ self: super: {
         # are tested and cached.
         haskellNixRoots = self.recurseIntoAttrs (builtins.mapAttrs (_: self.recurseIntoAttrs) {
           inherit (self.haskell-nix) nix-tools source-pins;
-          bootstap-nix-tools = self.bootstrap.haskell.packages.nix-tools;
-          alex-plan-nix = withInputs self.bootstrap.haskell.packages.alex-project.plan-nix;
-          happy-plan-nix = withInputs self.bootstrap.haskell.packages.happy-project.plan-nix;
-          hscolour-plan-nix = withInputs self.bootstrap.haskell.packages.hscolour-project.plan-nix;
+          bootstap-nix-tools = self.haskell-nix.bootstrap.packages.nix-tools;
+          alex-plan-nix = withInputs self.haskell-nix.bootstrap.packages.alex-project.plan-nix;
+          happy-plan-nix = withInputs self.haskell-nix.bootstrap.packages.happy-project.plan-nix;
+          hscolour-plan-nix = withInputs self.haskell-nix.bootstrap.packages.hscolour-project.plan-nix;
           ghc-extra-projects = builtins.mapAttrs (_: proj: self.recurseIntoAttrs (withInputs proj.plan-nix))
             (self.lib.filterAttrs (n: _: n != "ghc844" && n != "ghc861" && n != "ghc862") self.ghc-extra-projects);
         });

--- a/test/fully-static/default.nix
+++ b/test/fully-static/default.nix
@@ -45,7 +45,7 @@ let
       in {
         # Select a non-GMP compiler, usually for software licensing reasons.
         ghc.package = mkIf (stdenv.hostPlatform.isMusl && !gpl)
-            buildPackages.haskell.compiler.integer-simple.${compiler};
+            buildPackages.haskell-nix.compiler.integer-simple.${compiler};
 
         # Add GHC flags and libraries for fully static build
         packages.pandoc.components.exes.pandoc = withFullyStatic;

--- a/test/regen.nix
+++ b/test/regen.nix
@@ -11,7 +11,7 @@ writeScript "regen-tests.sh" ''
 
   set -euo pipefail
 
-  export PATH="${lib.makeBinPath [ coreutils glibc haskell-nix.nix-tools cabal-install haskell.compiler.ghc865 ]}"
+  export PATH="${lib.makeBinPath [ coreutils glibc haskell-nix.nix-tools cabal-install haskell-nix.compiler.ghc865 ]}"
 
   cabal_configure() {
     cabal new-configure \


### PR DESCRIPTION
Currently the haskell.nix overlays replace `haskell` and
`haskellPackages` in the root of pkgs with versions that have just a
fraction of what nixpkgs provides.
Although `haskell-nix.haskellPackages` could be used to provide a much
more complete set there are subtle differences that are likely to cause
issues (and nixpkgs has patches for many haskell packages).

To make it possible for haskell.nix and nixpkgs haskell to coexist,
we need to move the remaining parts of haskell.nix outside of the
`haskell-nix` attribute into `haskell-nix`.

```
  ghc                        -> haskell-nix.ghc
  cabal-install              -> haskell-nix.cabal-install
  haskell.compiler           -> haskell-nix.compiler
  haskell.packages           -> haskell-nix.packages
  bootstrap.haskell.compiler -> haskell-nix.bootstrap.compiler
  bootstrap.haskell.packages -> haskell-nix.bootstrap.packages
```

The following `haskellPackages` have been removed and instead the
nixpkgs versions will now be in `haskellPackages`.  User code should
be updated if the nixpkgs versions are not desired:

```
  haskellPackages.hoogle
    -> haskell-nix.haskellPackages.hoogle.components.exes.hoogle
  haskellPackages.happy
    -> haskell-nix.haskellPackages.happy.components.exes.happy
  haskellPackages.alex
    -> haskell-nix.haskellPackages.alex.components.exes.alex;
```

Guard code has been added to overlays/defaults.nix to prevent us
inadvertently depending on the nixpkgs `haskell` or `haskellPackages`
inside the haskell.nix code base.