### PR TITLE
Add nixpkgs 19.03 branch haskell.nix to cache

### DIFF
--- a/nixpkgs/github.json
+++ b/nixpkgs/github.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/nixpkgs",
-  "rev": "3d623a406cec9052ae0a16a79ce3ce9de11236bb",
-  "date": "2019-10-18T17:51:24+13:00",
-  "sha256": "1a4yd980ylh1ygvmws15wldifz7jxjy8z07vc914kam1p25yjpj1",
+  "rev": "a8f81dc037a5977414a356dd068f2621b3c89b60",
+  "date": "2019-10-17T21:54:56+08:00",
+  "sha256": "01z13axll5g5yl00lz9adr2jw2bs12g9skhbb1vxy8p7fjjbhhhm",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
Currently only 19.09 branch is built on hydra.  This PR will switch
back to 19.03.

We don't need to do this, the PR itself will cause hydra to run and add
stuff 19.03 to the cache.

[jobset](https://hydra.iohk.io/jobset/Cardano/haskell-nix-pr-291)