### PR TITLE
`components.setup` is not a library

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -49,7 +49,7 @@ with haskellLib;
       buildableAttrs = lib.filterAttrs (n: comp: comp.buildable or true);
       libComp = if comps.library == null || !(comps.library.buildable or true)
         then {}
-        else lib.mapAttrs applyLibrary (removeAttrs comps (subComponentTypes ++ [ "all" ]));
+        else lib.mapAttrs applyLibrary (removeAttrs comps (subComponentTypes ++ [ "all" "setup" ]));
       subComps = lib.mapAttrs
         (ctype: attrs: lib.mapAttrs (applySubComp ctype) (buildableAttrs attrs))
         (builtins.intersectAttrs (lib.genAttrs subComponentTypes (_: null)) comps);


### PR DESCRIPTION
We added a setup component to allow overriding of the config used to
to build Setup.hs.  The code that deals with library components
was misidentifying this component as a library.