### PR TITLE
Fix `components.all` for exe only packages

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -242,6 +242,9 @@ stdenv.mkDerivation ({
   # Note 2: if a package contains multiple libs (lib + sublibs) SETUP register will generate a
   #         folder isntead of a file for the configuration.  Therfore if the result is a folder,
   #         we need to register each and every element of that folder.
+  #
+  # Note 3: if a package has no libs SETUP will not generate anything.  This can
+  #         happen when building the `all` component of a package.
   installPhase = ''
     runHook preInstall
     $SETUP_HS copy ${lib.concatStringsSep " " component.setupInstallFlags}

--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -252,7 +252,7 @@ stdenv.mkDerivation ({
         for pkg in ${name}.conf/*; do
           ${ghc.targetPrefix}ghc-pkg -v0 --package-db ${configFiles}/package.conf.d -f $out/package.conf.d register "$pkg"
         done
-      else
+      elif [ -e "${name}.conf" ]; then
         ${ghc.targetPrefix}ghc-pkg -v0 --package-db ${configFiles}/package.conf.d -f $out/package.conf.d register ${name}.conf
       fi
     ''}

--- a/test/default.nix
+++ b/test/default.nix
@@ -29,6 +29,7 @@ in pkgs.recurseIntoAttrs {
   fully-static = haskell-nix.callPackage ./fully-static { inherit (pkgs) buildPackages; };
   ghc-options-cabal = haskell-nix.callPackage ./ghc-options/cabal.nix {};
   ghc-options-stack = haskell-nix.callPackage ./ghc-options/stack.nix {};
+  exe-only = haskell-nix.callPackage ./exe-only { inherit util; };
 
   # Run unit tests with: nix-instantiate --eval --strict -A unit.tests
   # An empty list means success.

--- a/test/exe-only/Main.hs
+++ b/test/exe-only/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "Hello, Haskell!"

--- a/test/exe-only/Setup.hs
+++ b/test/exe-only/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/test/exe-only/default.nix
+++ b/test/exe-only/default.nix
@@ -1,0 +1,56 @@
+# Test a package set
+{ stdenv, util, haskell-nix }:
+
+with stdenv.lib;
+
+let
+  project = haskell-nix.cabalProject' {
+    name = "exe-only";
+    src = ./.;
+  };
+
+  packages = project.hsPkgs;
+
+in
+  stdenv.mkDerivation {
+    name = "exe-only-test";
+
+    buildCommand = ''
+      exe="${packages.exe-only.components.exes.exe-only}/bin/exe-only"
+
+      size=$(command stat --format '%s' "$exe")
+      printf "size of executable $exe is $size. \n" >& 2
+
+      # fixme: run on target platform when cross-compiled
+      printf "checking whether executable runs... " >& 2
+      $exe
+    '' + (if stdenv.hostPlatform.isMusl then ''
+        printf "checking that executable is statically linked... " >& 2
+        (ldd $exe 2>&1 || true) | grep -i "not a"
+      '' else ''
+        printf "checking that executable is dynamically linked to system libraries... " >& 2
+      '' + optionalString stdenv.isLinux ''
+        ldd $exe | grep libpthread
+      '' + optionalString stdenv.isDarwin ''
+        otool -L $exe |grep .dylib
+    '') + ''
+
+      printf "Checking that \"all\" component has the programs... " >& 2
+      all_exe="${packages.exe-only.components.all}/bin/exe-only"
+      test -f "$all_exe"
+      echo "$all_exe" >& 2
+
+      touch $out
+    '';
+
+    meta.platforms = platforms.all;
+
+    passthru = {
+      # Used for debugging with nix repl
+      inherit pkgSet packages;
+
+      # Used for testing externally with nix-shell (../tests.sh).
+      # This just adds cabal-install to the existing shells.
+      test-shell = util.addCabalInstall packages.exe-only.components.all;
+    };
+}

--- a/test/exe-only/exe-only.cabal
+++ b/test/exe-only/exe-only.cabal
@@ -1,0 +1,15 @@
+cabal-version:       >=1.10
+
+name:                exe-only
+version:             0.1.0.0
+license:             PublicDomain
+author:              Hamish Mackenzie
+maintainer:          Hamish.Mackenzie@iohk.io
+build-type:          Simple
+
+executable exe-only
+  main-is:             Main.hs
+  build-depends:       base
+                     , extra
+                     , optparse-applicative
+  default-language:    Haskell2010


### PR DESCRIPTION
Currently the builder tries and fails to register a non existent
library component.