### PR TITLE
Fix #269 by not looking for libiserv in hackage

### DIFF
--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -130,7 +130,7 @@ self: super: {
             };
 
         # Package sets for all stackage snapshots.
-        snapshots = import ../snapshots.nix { inherit (self) lib; inherit mkPkgSet stackage; };
+        snapshots = import ../snapshots.nix { inherit (self) lib ghc-boot-packages; inherit mkPkgSet stackage; };
         # Pick a recent LTS snapshot to be our "default" package set.
         haskellPackages = snapshots."lts-13.26";
 

--- a/snapshots.nix
+++ b/snapshots.nix
@@ -12,7 +12,7 @@ with lib;
 
 let
   mkSnapshot = name: pkg-def: (let pkgSet = mkPkgSet {
-    # Some boot packages are (libiserv) are in lts, but not in hackage,
+    # Some boot packages (libiserv) are in lts, but not in hackage,
     # so we should not try to get it from hackage based on the stackage
     # info.  Instead we can add ghc-boot-packages to `pkg-def-extras`.
     pkg-def = hackage:
@@ -23,6 +23,8 @@ let
         packages = lib.filterAttrs (n: _: lib.all (b: n != b) bootPkgNames)
           original.packages;
       };
+    # ghc-boot-packages are needed for the reinstallable ghc library and
+    # are constructed from the patched ghc source.
     pkg-def-extras = (pkg-def-extras name)
       ++ [(hackage: ghc-boot-packages.${(pkg-def hackage).compiler.nix-name})];
     modules = [


### PR DESCRIPTION
Also fixes packages like that depend on the `ghc` library.