### PR TITLE
Add information about the binary cache to README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -59,6 +59,15 @@ cabal new-build your-package-name
 cabal new-repl your-package-name:library:your-package-name
 #+end_src
 
+** Cache
+
+CI pushes to [[https://cachix.org][cachix]] so you can benefit from the cache
+if you pin a combination of =haskell.nix= and =nixpkgs= built by CI.
+
+You'll need to configure the [[nix-tools cachix][https://nix-tools.cachix.org]]
+as a =substituter= for =nix= and add the public key found at the url to
+=trusted-public-keys=.
+
 ** Related repos
 
 The =haskell.nix= repository contains the runtime system for building

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -71,6 +71,14 @@ cd haskell.nix
 nix build -f . haskell-nix.nix-tools --out-link nt
 ```
 
+## Setting up the Cachix binary cache
+
+CI pushes to [cachix](https://cachix.org) so you can benefit from the cache if
+you pin a combination of `haskell.nix` and `nixpkgs` built by CI. You'll need
+to configure the [nix-tools cachix](https://nix-tools.cachix.org) as a
+`substituter` for `nix` and add the public key found at the url to
+`trusted-public-keys`.
+
 ## Using [Haskell.nix][] with your project
 
 The easiest way to get a hold of [Haskell.nix][] is with


### PR DESCRIPTION
I learned about the cachix cache from the IRC channel. Figured it'd be more accessible if it's in the README.

Ideally I could add information about how to figure out these combinations of `haskell.nix` and `nixpkgs` that are cached but I haven't found a good way (checking `ci.nix` maybe?).