### PR TITLE
Exclude pre/postCheck from `all` used by shellFor

### DIFF
--- a/modules/package.nix
+++ b/modules/package.nix
@@ -316,5 +316,12 @@ in {
   # this is relevant would be to switch from the bool type to
   # something like an anyBool type, which would merge definitions by
   # returning true if any is true.
-  config.components.all = lib.mkMerge (haskellLib.getAllComponents config);
+  config.components.all = lib.mkMerge (
+    builtins.map (c:
+      # Exclude attributes that are likely to have conflicting definitions
+      # (a common use case for `all` is in `shellFor` and it only has an
+      # install phase).
+      builtins.removeAttrs c ["preCheck" "postCheck"]
+    ) (haskellLib.getAllComponents config)
+  );
 }


### PR DESCRIPTION
Without this fix `shellFor` fails for packages where a component has
a `preCheck` or `postCheck` option set.  It should be safe to exclude
these because `shellFor` uses `phases = ["installPhase"]` and it seems
like a bad idea to use `all` for running tests (better to run the
individual `tests` components).