### PR TITLE
Make it easy to use one of the pinned nixpkgs

### DIFF
--- a/README.org
+++ b/README.org
@@ -20,7 +20,7 @@ For the documentation, see https://input-output-hk.github.io/haskell.nix/.
 For =cabal.project= project add a =default.nix=:
 
 #+begin_src sh
-{ pkgs ? import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz + "/nixpkgs") {}
+{ pkgs ? (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz)).nixpkgs {}
 , haskellCompiler ? "ghc865"
 }:
   pkgs.haskell-nix.cabalProject {
@@ -32,7 +32,7 @@ For =cabal.project= project add a =default.nix=:
 For a =stack.yaml= project add a =default.nix=:
 
 #+begin_src sh
-{ pkgs ? import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz + "/nixpkgs") {}
+{ pkgs ? (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz)).nixpkgs {}
 }:
   pkgs.haskell-nix.stackProject {
     src = pkgs.haskell-nix.haskellLib.cleanGit { src = ./.; };

--- a/README.org
+++ b/README.org
@@ -20,7 +20,7 @@ For the documentation, see https://input-output-hk.github.io/haskell.nix/.
 For =cabal.project= project add a =default.nix=:
 
 #+begin_src sh
-{ pkgs ? import <nixpkgs> (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz))
+{ pkgs ? import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz + "/nixpkgs") {}
 , haskellCompiler ? "ghc865"
 }:
   pkgs.haskell-nix.cabalProject {
@@ -32,7 +32,7 @@ For =cabal.project= project add a =default.nix=:
 For a =stack.yaml= project add a =default.nix=:
 
 #+begin_src sh
-{ pkgs ? import <nixpkgs> (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz))
+{ pkgs ? import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz + "/nixpkgs") {}
 }:
   pkgs.haskell-nix.stackProject {
     src = pkgs.haskell-nix.haskellLib.cleanGit { src = ./.; };

--- a/README.org
+++ b/README.org
@@ -20,7 +20,8 @@ For the documentation, see https://input-output-hk.github.io/haskell.nix/.
 For =cabal.project= project add a =default.nix=:
 
 #+begin_src sh
-{ pkgs ? (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz)).nixpkgs {}
+{ haskellNix ? import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz)
+, pkgs ? import haskellNix.defaultNixpkgs haskellNix.nixpkgsArgs
 , haskellCompiler ? "ghc865"
 }:
   pkgs.haskell-nix.cabalProject {
@@ -32,7 +33,8 @@ For =cabal.project= project add a =default.nix=:
 For a =stack.yaml= project add a =default.nix=:
 
 #+begin_src sh
-{ pkgs ? (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz)).nixpkgs {}
+{ haskellNix ? import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz)
+, pkgs ? import haskellNix.defaultNixpkgs haskellNix.nixpkgsArgs
 }:
   pkgs.haskell-nix.stackProject {
     src = pkgs.haskell-nix.haskellLib.cleanGit { src = ./.; };

--- a/build.nix
+++ b/build.nix
@@ -3,7 +3,7 @@
 # It is separate from default.nix because that file is the public API
 # of Haskell.nix, which shouldn't have tests, etc.
 
-{ nixpkgs ? ./nixpkgs
+{ nixpkgs ? (import ./.).nixpkgs
 # Provide args to the nixpkgs instantiation.
 , system ? builtins.currentSystem
 , crossSystem ? null
@@ -12,8 +12,8 @@
 }:
 
 let
-  haskellNixArgs = import ./default.nix;
-  pkgs = import nixpkgs ({
+  haskellNixArgs = (import ./.).nixpkgsArgs;
+  pkgs = nixpkgs ({
     config   = haskellNixArgs.config // config;
     overlays = haskellNixArgs.overlays ++
       [(self: super: {

--- a/build.nix
+++ b/build.nix
@@ -3,7 +3,7 @@
 # It is separate from default.nix because that file is the public API
 # of Haskell.nix, which shouldn't have tests, etc.
 
-{ nixpkgs ? (import ./.).nixpkgs
+{ nixpkgs ? (import ./.).defaultNixpkgs
 # Provide args to the nixpkgs instantiation.
 , system ? builtins.currentSystem
 , crossSystem ? null
@@ -13,7 +13,7 @@
 
 let
   haskellNixArgs = (import ./.).nixpkgsArgs;
-  pkgs = nixpkgs ({
+  pkgs = import nixpkgs ({
     config   = haskellNixArgs.config // config;
     overlays = haskellNixArgs.overlays ++
       [(self: super: {

--- a/ci.nix
+++ b/ci.nix
@@ -4,17 +4,17 @@
 
 let
   nixpkgs-pins = [
-    # "release-18.09"
-    "release-19.03"
-    # "release-19.09"
+    # "18.09"
+    "19.03"
+    # "19.09"
   ];
-  defaultNixpkgs = (import ./.).nixpkgs {};
+  defaultNixpkgs = import (import ./.).defaultNixpkgs (import ./.).nixpkgsArgs;
   recRecurseIntoAttrs = with defaultNixpkgs; pred: x: if pred x then recurseIntoAttrs (lib.mapAttrs (n: v: if n == "buildPackages" then v else recRecurseIntoAttrs pred v) x) else x;
 in
   recRecurseIntoAttrs (x: with defaultNixpkgs; lib.isAttrs x && !lib.isDerivation x) (
     defaultNixpkgs.lib.genAttrs nixpkgs-pins (nixpkgs-pin: with (import ./nixpkgs { inherit nixpkgs-pin; });
       let
-        nixpkgs = (import ./.).nixpkgs-pins.${nixpkgs-pin};
+        nixpkgs = args: import (import ./.).nixpkgs-pins.${nixpkgs-pin} ((import ./.).nixpkgsArgs // args);
       in {
       x86_64-linux = {
             hello = with nixpkgs { system = "x86_64-linux"; };

--- a/ci.nix
+++ b/ci.nix
@@ -8,50 +8,50 @@ let
     "release-19.03"
     # "release-19.09"
   ];
-  defaultNixpkgs = import ./nixpkgs { nixpkgs-pin = "release-19.03"; };
+  defaultNixpkgs = (import ./.).nixpkgs {};
   recRecurseIntoAttrs = with defaultNixpkgs; pred: x: if pred x then recurseIntoAttrs (lib.mapAttrs (n: v: if n == "buildPackages" then v else recRecurseIntoAttrs pred v) x) else x;
 in
   recRecurseIntoAttrs (x: with defaultNixpkgs; lib.isAttrs x && !lib.isDerivation x) (
     defaultNixpkgs.lib.genAttrs nixpkgs-pins (nixpkgs-pin: with (import ./nixpkgs { inherit nixpkgs-pin; });
       let
-        haskellNixArgs = { inherit nixpkgs-pin; };
+        nixpkgs = (import ./.).nixpkgs-pins.${nixpkgs-pin};
       in {
       x86_64-linux = {
-            hello = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; }));
+            hello = with nixpkgs { system = "x86_64-linux"; };
                 (haskell-nix.hackage-package { name = "hello"; version = "1.0.0.2";}).components.exes.hello;
-            x86_64-pc-mingw32-hello = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; }));
+            x86_64-pc-mingw32-hello = with nixpkgs { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; };
                 (haskell-nix.hackage-package { name = "hello"; version = "1.0.0.2";}).components.exes.hello;
 
-            iserv-proxy = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; }));
+            iserv-proxy = with nixpkgs { system = "x86_64-linux"; };
                 (ghc-extra-packages.ghc865.iserv-proxy.components.exes).iserv-proxy;
 
-            x86_64-pc-mingw32-iserv-proxy = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; }));
+            x86_64-pc-mingw32-iserv-proxy = with nixpkgs { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; };
                 (buildPackages.ghc-extra-packages.ghc865.iserv-proxy.components.exes).iserv-proxy;
 
-            x86_64-pc-mingw32-remote-iserv = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; }));
+            x86_64-pc-mingw32-remote-iserv = with nixpkgs { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; };
                 (ghc-extra-packages.ghc865.remote-iserv.components.exes).remote-iserv;
 
       };
       x86_64-darwin = {
-            hello = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; }));
+            hello = with nixpkgs { system = "x86_64-darwin"; };
                 (haskell-nix.hackage-package { name = "hello"; version = "1.0.0.2";}).components.exes.hello;
-            x86_64-pc-mingw32-hello = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; }));
+            x86_64-pc-mingw32-hello = with nixpkgs { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; };
                 (haskell-nix.hackage-package { name = "hello"; version = "1.0.0.2";}).components.exes.hello;
 
-            iserv-proxy = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; }));
+            iserv-proxy = with nixpkgs { system = "x86_64-darwin"; };
                 (ghc-extra-packages.ghc865.iserv-proxy.components.exes).iserv-proxy;
 
-            x86_64-pc-mingw32-iserv-proxy = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; }));
+            x86_64-pc-mingw32-iserv-proxy = with nixpkgs { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; };
                 (buildPackages.ghc-extra-packages.ghc865.iserv-proxy.components.exes).iserv-proxy;
 
-            x86_64-pc-mingw32-remote-iserv = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; }));
+            x86_64-pc-mingw32-remote-iserv = with nixpkgs { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; };
                 (ghc-extra-packages.ghc865.remote-iserv.components.exes).remote-iserv;
 
       };
       haskell-nix.compiler = {
-        x86_64-linux = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; }));
+        x86_64-linux = with nixpkgs { system = "x86_64-linux"; };
             haskell-nix.compiler;
-        x86_64-darwin = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin";}));
+        x86_64-darwin = with nixpkgs { system = "x86_64-darwin";};
             haskell-nix.compiler;
       };
       tests = {
@@ -65,48 +65,48 @@ in
       in {
         x86_64-linux = {
                 # cardano-sl
-                cardano-sl = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; }));
+                cardano-sl = with nixpkgs { system = "x86_64-linux"; };
                     (lib.filterAttrs (k: _: builtins.elem k cardano-sl-args.pkgs)
                         (haskell-nix.stackProject cardano-sl-args));
-                x86_64-pc-mingw32-cardano-sl = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; }));
+                x86_64-pc-mingw32-cardano-sl = with nixpkgs { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; };
                     (lib.filterAttrs (k: _: builtins.elem k cardano-sl-args.pkgs)
                         (haskell-nix.stackProject cardano-sl-args));
 
                 # cardano-wallet
-                cardano-wallet = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; }));
+                cardano-wallet = with nixpkgs { system = "x86_64-linux"; };
                     (lib.filterAttrs (k: _: builtins.elem k cardano-wallet-args.pkgs)
                         (haskell-nix.stackProject cardano-wallet-args));
-                x86_64-pc-mingw32-cardano-wallet = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; }));
+                x86_64-pc-mingw32-cardano-wallet = with nixpkgs { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; };
                     (lib.filterAttrs (k: _: builtins.elem k cardano-wallet-args.pkgs)
                         (haskell-nix.stackProject cardano-wallet-args));
-                plutus = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; }));
+                plutus = with nixpkgs { system = "x86_64-linux"; };
                     (lib.filterAttrs (k: _: builtins.elem k plutus-args.pkgs)
                         (haskell-nix.stackProject plutus-args));
-                x86_64-pc-mingw32-plutus = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; }));
+                x86_64-pc-mingw32-plutus = with nixpkgs { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; };
                     (lib.filterAttrs (k: _: builtins.elem k plutus-args.pkgs)
                         (haskell-nix.stackProject plutus-args));
 
         };
         x86_64-darwin = {
                 # cardano-sl
-                cardano-sl = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; }));
+                cardano-sl = with nixpkgs { system = "x86_64-darwin"; };
                     (lib.filterAttrs (k: _: builtins.elem k cardano-sl-args.pkgs)
                         (haskell-nix.stackProject cardano-sl-args));
-                x86_64-pc-mingw32-cardano-sl = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; }));
+                x86_64-pc-mingw32-cardano-sl = with nixpkgs { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; };
                     (lib.filterAttrs (k: _: builtins.elem k cardano-sl-args.pkgs)
                         (haskell-nix.stackProject cardano-sl-args));
 
                 # cardano-wallet
-                cardano-wallet = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; }));
+                cardano-wallet = with nixpkgs { system = "x86_64-darwin"; };
                     (lib.filterAttrs (k: _: builtins.elem k cardano-wallet-args.pkgs)
                         (haskell-nix.stackProject cardano-wallet-args));
-                x86_64-pc-mingw32-cardano-wallet = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; }));
+                x86_64-pc-mingw32-cardano-wallet = with nixpkgs { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; };
                     (lib.filterAttrs (k: _: builtins.elem k cardano-wallet-args.pkgs)
                         (haskell-nix.stackProject cardano-wallet-args));
-                plutus = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; }));
+                plutus = with nixpkgs { system = "x86_64-darwin"; };
                     (lib.filterAttrs (k: _: builtins.elem k plutus-args.pkgs)
                         (haskell-nix.stackProject plutus-args));
-                x86_64-pc-mingw32-plutus = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; }));
+                x86_64-pc-mingw32-plutus = with nixpkgs { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; };
                     (lib.filterAttrs (k: _: builtins.elem k plutus-args.pkgs)
                         (haskell-nix.stackProject plutus-args));
         };
@@ -114,9 +114,9 @@ in
 
 # Don't build (all of) stackage on linux for now.
 #    stackage = {
-#        x86_64-linux = (with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; }));
+#        x86_64-linux = (with nixpkgs { system = "x86_64-linux"; };
 #            haskell-nix.snapshots."lts-13.29");
-#        # x86_64-darwin = (with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; }));
+#        # x86_64-darwin = (with nixpkgs { system = "x86_64-darwin"; };
 #        #     haskell-nix.snapshots."lts-13.29");
 #    };
 

--- a/ci.nix
+++ b/ci.nix
@@ -3,58 +3,60 @@
 # - https://github.com/NixOS/nixpkgs/pull/68398
 
 let
-  nixpkgsVersions = {
-#   "release-18.09" = builtins.fetchTarball "https://github.com/input-output-hk/nixpkgs/archive/7e4dcacbf066a8e2d12693a9de1fb30c77081c5d.tar.gz";
-    "release-19.03" = builtins.fetchTarball "https://github.com/input-output-hk/nixpkgs/archive/a8f81dc037a5977414a356dd068f2621b3c89b60.tar.gz";
-    # "release-19.09" = builtins.fetchTarball "https://github.com/input-output-hk/nixpkgs/archive/3d623a406cec9052ae0a16a79ce3ce9de11236bb.tar.gz";
-  };
-  haskellNixArgs = import ./.;
-  defaultNixpkgs = import (nixpkgsVersions."release-19.03") {};
+  nixpkgs-pins = [
+    # "release-18.09"
+    "release-19.03"
+    # "release-19.09"
+  ];
+  defaultNixpkgs = import ./nixpkgs { nixpkgs-pin = "release-19.03"; };
   recRecurseIntoAttrs = with defaultNixpkgs; pred: x: if pred x then recurseIntoAttrs (lib.mapAttrs (n: v: if n == "buildPackages" then v else recRecurseIntoAttrs pred v) x) else x;
 in
   recRecurseIntoAttrs (x: with defaultNixpkgs; lib.isAttrs x && !lib.isDerivation x) (
-    builtins.mapAttrs (nixpkgsName: nixpkgsSrc: with (import nixpkgsSrc {}); {
+    defaultNixpkgs.lib.genAttrs nixpkgs-pins (nixpkgs-pin: with (import ./nixpkgs { inherit nixpkgs-pin; });
+      let
+        haskellNixArgs = { inherit nixpkgs-pin; };
+      in {
       x86_64-linux = {
-            hello = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-linux"; }));
+            hello = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; }));
                 (haskell-nix.hackage-package { name = "hello"; version = "1.0.0.2";}).components.exes.hello;
-            x86_64-pc-mingw32-hello = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; }));
+            x86_64-pc-mingw32-hello = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; }));
                 (haskell-nix.hackage-package { name = "hello"; version = "1.0.0.2";}).components.exes.hello;
 
-            iserv-proxy = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-linux"; }));
+            iserv-proxy = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; }));
                 (ghc-extra-packages.ghc865.iserv-proxy.components.exes).iserv-proxy;
 
-            x86_64-pc-mingw32-iserv-proxy = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; }));
+            x86_64-pc-mingw32-iserv-proxy = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; }));
                 (buildPackages.ghc-extra-packages.ghc865.iserv-proxy.components.exes).iserv-proxy;
 
-            x86_64-pc-mingw32-remote-iserv = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; }));
+            x86_64-pc-mingw32-remote-iserv = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; }));
                 (ghc-extra-packages.ghc865.remote-iserv.components.exes).remote-iserv;
 
       };
       x86_64-darwin = {
-            hello = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-darwin"; }));
+            hello = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; }));
                 (haskell-nix.hackage-package { name = "hello"; version = "1.0.0.2";}).components.exes.hello;
-            x86_64-pc-mingw32-hello = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; }));
+            x86_64-pc-mingw32-hello = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; }));
                 (haskell-nix.hackage-package { name = "hello"; version = "1.0.0.2";}).components.exes.hello;
 
-            iserv-proxy = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-darwin"; }));
+            iserv-proxy = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; }));
                 (ghc-extra-packages.ghc865.iserv-proxy.components.exes).iserv-proxy;
 
-            x86_64-pc-mingw32-iserv-proxy = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; }));
+            x86_64-pc-mingw32-iserv-proxy = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; }));
                 (buildPackages.ghc-extra-packages.ghc865.iserv-proxy.components.exes).iserv-proxy;
 
-            x86_64-pc-mingw32-remote-iserv = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; }));
+            x86_64-pc-mingw32-remote-iserv = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; }));
                 (ghc-extra-packages.ghc865.remote-iserv.components.exes).remote-iserv;
 
       };
       haskell-nix.compiler = {
-        x86_64-linux = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-linux"; }));
+        x86_64-linux = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; }));
             haskell-nix.compiler;
-        x86_64-darwin = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-darwin";}));
+        x86_64-darwin = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin";}));
             haskell-nix.compiler;
       };
       tests = {
-        x86_64-linux = (import ./test { nixpkgs = nixpkgsSrc; nixpkgsArgs = { system = "x86_64-linux"; }; });
-        # x86_64-darwin = (import ./test { nixpkgs = nixpkgsSrc; nixpkgsArgs = { system = "x86_64-darwin"; }; });
+        x86_64-linux = (import ./test { nixpkgsArgs = { inherit nixpkgs-pin; system = "x86_64-linux"; }; });
+        # x86_64-darwin = (import ./test { nixpkgsArgs = { inherit nixpkgs-pin; system = "x86_64-darwin"; }; });
       };
       examples = let
         cardano-sl-args = import ./examples/cardano-sl-args.nix;
@@ -63,48 +65,48 @@ in
       in {
         x86_64-linux = {
                 # cardano-sl
-                cardano-sl = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-linux"; }));
+                cardano-sl = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; }));
                     (lib.filterAttrs (k: _: builtins.elem k cardano-sl-args.pkgs)
                         (haskell-nix.stackProject cardano-sl-args));
-                x86_64-pc-mingw32-cardano-sl = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; }));
+                x86_64-pc-mingw32-cardano-sl = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; }));
                     (lib.filterAttrs (k: _: builtins.elem k cardano-sl-args.pkgs)
                         (haskell-nix.stackProject cardano-sl-args));
 
                 # cardano-wallet
-                cardano-wallet = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-linux"; }));
+                cardano-wallet = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; }));
                     (lib.filterAttrs (k: _: builtins.elem k cardano-wallet-args.pkgs)
                         (haskell-nix.stackProject cardano-wallet-args));
-                x86_64-pc-mingw32-cardano-wallet = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; }));
+                x86_64-pc-mingw32-cardano-wallet = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; }));
                     (lib.filterAttrs (k: _: builtins.elem k cardano-wallet-args.pkgs)
                         (haskell-nix.stackProject cardano-wallet-args));
-                plutus = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-linux"; }));
+                plutus = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; }));
                     (lib.filterAttrs (k: _: builtins.elem k plutus-args.pkgs)
                         (haskell-nix.stackProject plutus-args));
-                x86_64-pc-mingw32-plutus = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; }));
+                x86_64-pc-mingw32-plutus = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; crossSystem.config = "x86_64-pc-mingw32"; }));
                     (lib.filterAttrs (k: _: builtins.elem k plutus-args.pkgs)
                         (haskell-nix.stackProject plutus-args));
 
         };
         x86_64-darwin = {
                 # cardano-sl
-                cardano-sl = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-darwin"; }));
+                cardano-sl = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; }));
                     (lib.filterAttrs (k: _: builtins.elem k cardano-sl-args.pkgs)
                         (haskell-nix.stackProject cardano-sl-args));
-                x86_64-pc-mingw32-cardano-sl = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; }));
+                x86_64-pc-mingw32-cardano-sl = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; }));
                     (lib.filterAttrs (k: _: builtins.elem k cardano-sl-args.pkgs)
                         (haskell-nix.stackProject cardano-sl-args));
 
                 # cardano-wallet
-                cardano-wallet = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-darwin"; }));
+                cardano-wallet = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; }));
                     (lib.filterAttrs (k: _: builtins.elem k cardano-wallet-args.pkgs)
                         (haskell-nix.stackProject cardano-wallet-args));
-                x86_64-pc-mingw32-cardano-wallet = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; }));
+                x86_64-pc-mingw32-cardano-wallet = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; }));
                     (lib.filterAttrs (k: _: builtins.elem k cardano-wallet-args.pkgs)
                         (haskell-nix.stackProject cardano-wallet-args));
-                plutus = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-darwin"; }));
+                plutus = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; }));
                     (lib.filterAttrs (k: _: builtins.elem k plutus-args.pkgs)
                         (haskell-nix.stackProject plutus-args));
-                x86_64-pc-mingw32-plutus = with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; }));
+                x86_64-pc-mingw32-plutus = with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; crossSystem.config = "x86_64-pc-mingw32"; }));
                     (lib.filterAttrs (k: _: builtins.elem k plutus-args.pkgs)
                         (haskell-nix.stackProject plutus-args));
         };
@@ -112,10 +114,10 @@ in
 
 # Don't build (all of) stackage on linux for now.
 #    stackage = {
-#        x86_64-linux = (with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-linux"; }));
+#        x86_64-linux = (with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-linux"; }));
 #            haskell-nix.snapshots."lts-13.29");
-#        # x86_64-darwin = (with (import nixpkgsSrc (haskellNixArgs // { system = "x86_64-darwin"; }));
+#        # x86_64-darwin = (with (import ./nixpkgs (haskellNixArgs // { system = "x86_64-darwin"; }));
 #        #     haskell-nix.snapshots."lts-13.29");
 #    };
 
-}) nixpkgsVersions)
+}))

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,7 @@
 rec {
+  # Make error given when using haskell.nix the old way clear
+  _Update_Haskell_Nix_See_PR_307_ = "https://github.com/input-output-hk/haskell.nix/pull/307";
+  
   # nixpkgsArgs is designed to be passed directly nixpkgs with something like:
   #   import <nixpkgs> (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz)).nixpkgsArgs
   nixpkgsArgs = {

--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,7 @@ rec {
 
   # nixpkgs allows you to import haskell.nix with the default pinned nixpkgs
   #   (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz)).nixpkgs {}
-  defaultNixpkgs = nixpkgs-pins."19.09";
+  defaultNixpkgs = nixpkgs-pins.default;
   
   # nixpkgs-pins allows you to import haskell.nix with one of the pinned nixpkgs
   #   (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz)).nixpkgs-pins."release-19.03" {}
@@ -20,5 +20,14 @@ rec {
       "18.09" = "release-18.09";
       "19.03" = "release-19.03";
       "19.09" = "release-19.09";
+      default = "release-19.09";
     };  
+
+  # Make it easier to get the pins with default nixpkgsArgs
+  #   import X.nixpkgs-pins.Y (X.nixpkgsArgs)
+  # becomes
+  #   X.nixpkgs.Y
+  nixpkgs = builtins.mapAttrs
+    (_: nixpkgs-pin: import nixpkgs-pin nixpkgsArgs)
+      nixpkgs-pins;  
 }

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 rec {
   # Make error given when using haskell.nix the old way clear
-  _Update_Haskell_Nix_See_PR_307_ = "https://github.com/input-output-hk/haskell.nix/pull/307";
+  _Use_nixpkgsArgs_See_Haskell_Nix_PR_307_ = "https://github.com/input-output-hk/haskell.nix/pull/307";
   
   # nixpkgsArgs is designed to be passed directly nixpkgs with something like:
   #   import <nixpkgs> (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz)).nixpkgsArgs

--- a/default.nix
+++ b/default.nix
@@ -1,15 +1,4 @@
-let
-  # Names nixpkgs pins (corrisponds to names of the nixpkgs/*.json files)
-  nixpkgs-names = ["release-18.08" "release-19.03" "release-19.09"];
-
-  # Name of the default nixpkgs-pin
-  default-nixpkgs-name = "release-19.09";
-
-  # These are from lib.attrset but we don't want to have to import a nixpkgs just to get them
-  nameValuePair = name: value: { inherit name value; };
-  genAttrs = names: f: builtins.listToAttrs (builtins.map (n: nameValuePair n (f n)) names);
-
-in {
+rec {
   # nixpkgsArgs is designed to be passed directly nixpkgs with something like:
   #   import <nixpkgs> (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz)).nixpkgsArgs
   nixpkgsArgs = {
@@ -17,14 +6,16 @@ in {
     overlays = import ./overlays;
   };
 
-  inherit default-nixpkgs-name;
-  
   # nixpkgs allows you to import haskell.nix with the default pinned nixpkgs
   #   (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz)).nixpkgs {}
-  nixpkgs = args: import ./nixpkgs (args // { nixpkgs-pin = default-nixpkgs-name; });
+  defaultNixpkgs = nixpkgs-pins."19.09";
   
   # nixpkgs-pins allows you to import haskell.nix with one of the pinned nixpkgs
   #   (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz)).nixpkgs-pins."release-19.03" {}
-  nixpkgs-pins = (genAttrs nixpkgs-names
-      (nixpkgs-name: args: import ./nixpkgs (args // { nixpkgs-pin = nixpkgs-name; })));
+  nixpkgs-pins = builtins.mapAttrs
+    (_: nixpkgs-name: import ./nixpkgs { nixpkgs-pin = nixpkgs-name; }) {
+      "18.09" = "release-18.09";
+      "19.03" = "release-19.03";
+      "19.09" = "release-19.09";
+    };  
 }

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,30 @@
-# This default.nix is designed to be passed directly nixpkgs with something like:
-#   import <nixpkgs> (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz))
-{ config   = import ./config.nix;
-  overlays = import ./overlays;
+let
+  # Names nixpkgs pins (corrisponds to names of the nixpkgs/*.json files)
+  nixpkgs-names = ["release-18.08" "release-19.03" "release-19.09"];
+
+  # Name of the default nixpkgs-pin
+  default-nixpkgs-name = "release-19.09";
+
+  # These are from lib.attrset but we don't want to have to import a nixpkgs just to get them
+  nameValuePair = name: value: { inherit name value; };
+  genAttrs = names: f: builtins.listToAttrs (builtins.map (n: nameValuePair n (f n)) names);
+
+in {
+  # nixpkgsArgs is designed to be passed directly nixpkgs with something like:
+  #   import <nixpkgs> (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz)).nixpkgsArgs
+  nixpkgsArgs = {
+    config   = import ./config.nix;
+    overlays = import ./overlays;
+  };
+
+  inherit default-nixpkgs-name;
+  
+  # nixpkgs allows you to import haskell.nix with the default pinned nixpkgs
+  #   (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz)).nixpkgs {}
+  nixpkgs = args: import ./nixpkgs (args // { nixpkgs-pin = default-nixpkgs-name; });
+  
+  # nixpkgs-pins allows you to import haskell.nix with one of the pinned nixpkgs
+  #   (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz)).nixpkgs-pins."release-19.03" {}
+  nixpkgs-pins = (genAttrs nixpkgs-names
+      (nixpkgs-name: args: import ./nixpkgs (args // { nixpkgs-pin = nixpkgs-name; })));
 }

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -77,6 +77,15 @@ The easiest way to get a hold of [Haskell.nix][] is with
 [`fetchTarball`](https://nixos.org/nix/manual/#ssec-builtins).
 
 ```nix
+import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz + "/nixpkgs")
+  { nixpkgs-pin = "release-19.03"; }
+```
+The `nixpkgs-pin` argument is optional and specifies which of the nixpkgs versions.
+The supported options are `release-18.09`, `release-19.03` and `release-19.09` (the default).
+
+To use a different version of nixpkgs:
+
+```nix
 import <nixpkgs> (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz))
 ```
 
@@ -85,7 +94,7 @@ import <nixpkgs> (import (builtins.fetchTarball https://github.com/input-output-
 If your project has a `cabal.project` you can add a `default.nix` like this:
 
 ```nix
-{ pkgs ? import <nixpkgs> (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz))
+{ pkgs ? import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz + "/nixpkgs") {}
 , haskellCompiler ? "ghc865"
 }:
   pkgs.haskell-nix.cabalProject {
@@ -154,7 +163,7 @@ or one of the constraints in your local `.cabal` files).
 If your project has a `stack.yaml` you can add a `default.nix` like this:
 
 ```nix
-{ pkgs ? import <nixpkgs> (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz))
+{ pkgs ? import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz + "/nixpkgs") {}
 }:
   pkgs.haskell-nix.stackProject {
     src = pkgs.haskell-nix.haskellLib.cleanGit { src = ./.; };
@@ -243,14 +252,15 @@ these Git repositories correspond to the actual Hackage and Stackage.
 [stackage.nix]: https://github.com/input-output-hk/stackage.nix
 
 ```nix
-{ pkgs ? import <nixpkgs> (haskellNixArgs // { overlays = haskellNixArgs.overlays ++ [
+{ pkgs ? import (haskellNix + "/nixpkgs") (haskellNixArgs // { overlays = haskellNixArgs.overlays ++ [
   (self: super: {
     haskell-nix = super.haskell-nix // {
       hackageSourceJSON  = ./hackage-src.json;
       stackageSourceJSON = ./stackage-src.json;
     };
   })]; })
-, haskellNixArgs ? import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz)
+, haskellNix ? builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz
+, haskellNixArgs = import haskellNix
 }:
   pkgs
 ```
@@ -262,9 +272,8 @@ attrsets and try examples.
 
 ```
 # example.nix
-{ nixpkgs ? <nixpkgs> }:
 rec {
-  haskell = import nixpkgs (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz));
+  haskell = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz + "/nixpkgs") {};
   pkgNames = haskell.pkgs.lib.attrNames haskell.haskell-nix.snapshots."lts-13.18";
 }
 ```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -83,7 +83,7 @@ let haskellNix = import (builtins.fetchTarball https://github.com/input-output-h
 in import haskellNix.defaultNixpkgs haskellNix.nixpkgsArgs
 ```
 
-To specify the pinned nixpkgs (out of `release-18.09`, `release-19.03` and `release-19.09`) use:
+To specify the pinned nixpkgs (out of `18.09`, `19.03` and `19.09`) use:
 
 ```nix
 let haskellNix = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz);

--- a/docs/user-guide/projects.md
+++ b/docs/user-guide/projects.md
@@ -22,7 +22,7 @@ expression (see the links bellow). The following file then produces a package se
 # default.nix
 let
   # Import the Haskell.nix library,
-  pkgs = import <nixpkgs> (import builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz);
+  pkgs = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz + "/nixpkgs") {};
 
   # Import the file you will create in the stack-to-nix or cabal-to-nix step.
   my-pkgs = import ./pkgs.nix;

--- a/docs/user-guide/projects.md
+++ b/docs/user-guide/projects.md
@@ -23,7 +23,7 @@ expression (see the links bellow). The following file then produces a package se
 let
   # Import the Haskell.nix library,
   haskellNix = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz);
-  pkgs = haskellNix.nixpkgs {};
+  pkgs = import haskellNix.defaultNixpkgs haskellNix.nixpkgsArgs;
 
   # Import the file you will create in the stack-to-nix or cabal-to-nix step.
   my-pkgs = import ./pkgs.nix;

--- a/docs/user-guide/projects.md
+++ b/docs/user-guide/projects.md
@@ -22,7 +22,8 @@ expression (see the links bellow). The following file then produces a package se
 # default.nix
 let
   # Import the Haskell.nix library,
-  pkgs = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz + "/nixpkgs") {};
+  haskellNix = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz);
+  pkgs = haskellNix.nixpkgs {};
 
   # Import the file you will create in the stack-to-nix or cabal-to-nix step.
   my-pkgs = import ./pkgs.nix;

--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -1,5 +1,5 @@
 # see ../docs/dev/nixpkgs-pin.md
-{ nixpkgs-pin ? (import ../.).default-nixpkgs-name, ... }@args:
+{ nixpkgs-pin }:
 let
   fetch = jsonFile:
     with builtins;
@@ -9,5 +9,4 @@ let
       inherit (spec) sha256;
       url = "${spec.url}/archive/${spec.rev}.tar.gz";
     };
-in import (fetch (./. + "/${nixpkgs-pin}.json"))
-  ((import ../.).nixpkgsArgs // (builtins.removeAttrs args [ "nixpkgs-pin" ]))
+in fetch (./. + "/${nixpkgs-pin}.json")

--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -9,4 +9,5 @@ let
       inherit (spec) sha256;
       url = "${spec.url}/archive/${spec.rev}.tar.gz";
     };
-in import (fetch (./. + "/${nixpkgs-pin}.json")) (builtins.removeAttrs args [ "nixpkgs-pin" ])
+in import (fetch (./. + "/${nixpkgs-pin}.json"))
+  ((import ../.) // (builtins.removeAttrs args [ "nixpkgs-pin" ]))

--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -1,5 +1,5 @@
 # see ../docs/dev/nixpkgs-pin.md
-{ nixpkgs-pin }:
+{ nixpkgs-pin ? "release-19.09" }:
 let
   fetch = jsonFile:
     with builtins;

--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -1,5 +1,5 @@
 # see ../docs/dev/nixpkgs-pin.md
-{ nixpkgs-pin ? "github", ... }@args:
+{ nixpkgs-pin ? (import ../.).default-nixpkgs-name, ... }@args:
 let
   fetch = jsonFile:
     with builtins;
@@ -10,4 +10,4 @@ let
       url = "${spec.url}/archive/${spec.rev}.tar.gz";
     };
 in import (fetch (./. + "/${nixpkgs-pin}.json"))
-  ((import ../.) // (builtins.removeAttrs args [ "nixpkgs-pin" ]))
+  ((import ../.).nixpkgsArgs // (builtins.removeAttrs args [ "nixpkgs-pin" ]))

--- a/nixpkgs/github.json
+++ b/nixpkgs/github.json
@@ -1,7 +1,0 @@
-{
-  "url": "https://github.com/input-output-hk/nixpkgs",
-  "rev": "a8f81dc037a5977414a356dd068f2621b3c89b60",
-  "date": "2019-10-17T21:54:56+08:00",
-  "sha256": "01z13axll5g5yl00lz9adr2jw2bs12g9skhbb1vxy8p7fjjbhhhm",
-  "fetchSubmodules": false
-}

--- a/nixpkgs/github.json
+++ b/nixpkgs/github.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/nixpkgs",
-  "rev": "3d623a406cec9052ae0a16a79ce3ce9de11236bb",
-  "date": "2019-10-18T17:51:24+13:00",
-  "sha256": "1a4yd980ylh1ygvmws15wldifz7jxjy8z07vc914kam1p25yjpj1",
+  "rev": "a8f81dc037a5977414a356dd068f2621b3c89b60",
+  "date": "2019-10-17T21:54:56+08:00",
+  "sha256": "01z13axll5g5yl00lz9adr2jw2bs12g9skhbb1vxy8p7fjjbhhhm",
   "fetchSubmodules": false
 }

--- a/nixpkgs/release-18.09.json
+++ b/nixpkgs/release-18.09.json
@@ -1,7 +1,7 @@
 {
-  "url": "https://github.com/nixos/nixpkgs",
-  "rev": "68b3bff32da3fadb16d5fdcbca2b4b69f6b97eb6",
-  "date": "2019-07-29T20:46:01-04:00",
-  "sha256": "129w6rk6brdmq0m8l2py5qkpzzzy7zwd1h03cqlbjq2ff6zh49nc",
+  "url": "https://github.com/input-output-hk/nixpkgs",
+  "rev": "7e4dcacbf066a8e2d12693a9de1fb30c77081c5d",
+  "date": "2019-10-18T18:05:22+13:00",
+  "sha256": "1my0gvl4gz4l2j24irvrx3ir698lcbwy06nnz7996dr64x9anaw1",
   "fetchSubmodules": false
 }

--- a/nixpkgs/release-19.03.json
+++ b/nixpkgs/release-19.03.json
@@ -1,7 +1,7 @@
 {
-  "url": "https://github.com/nixos/nixpkgs",
-  "rev": "49ac77d07eb9757244b776e35b9eb68d63943b12",
-  "date": "2019-07-30T15:46:41+02:00",
-  "sha256": "0xsmh17z5bl17dnpwf23m53a432651ylvk8qnjlmj43blxgiwrs5",
+  "url": "https://github.com/input-output-hk/nixpkgs",
+  "rev": "a8f81dc037a5977414a356dd068f2621b3c89b60",
+  "date": "2019-10-17T21:54:56+08:00",
+  "sha256": "01z13axll5g5yl00lz9adr2jw2bs12g9skhbb1vxy8p7fjjbhhhm",
   "fetchSubmodules": false
 }

--- a/nixpkgs/release-19.09.json
+++ b/nixpkgs/release-19.09.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/input-output-hk/nixpkgs",
+  "rev": "3d623a406cec9052ae0a16a79ce3ce9de11236bb",
+  "date": "2019-10-18T17:51:24+13:00",
+  "sha256": "1a4yd980ylh1ygvmws15wldifz7jxjy8z07vc914kam1p25yjpj1",
+  "fetchSubmodules": false
+}

--- a/release.nix
+++ b/release.nix
@@ -1,10 +1,10 @@
-{ supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
+{ supportedSystems ? [ "x86_64-darwin" ]
 , scrubJobs ? true
 , haskell-nix ? { outPath = ./.; rev = "abcdef"; }
 , nixpkgsArgs ? {}
 }:
 
-let fixedNixpkgs = import ./nixpkgs {}; in
+let fixedNixpkgs = (import ./.).nixpkgs {}; in
 with fixedNixpkgs.lib;
 with (import (fixedNixpkgs.path + "/pkgs/top-level/release-lib.nix") {
   inherit supportedSystems scrubJobs nixpkgsArgs;

--- a/release.nix
+++ b/release.nix
@@ -4,7 +4,7 @@
 , nixpkgsArgs ? {}
 }:
 
-let fixedNixpkgs = (import ./.).nixpkgs {}; in
+let fixedNixpkgs = import (import ./.).defaultNixpkgs (import ./.).nixpkgsArgs; in
 with fixedNixpkgs.lib;
 with (import (fixedNixpkgs.path + "/pkgs/top-level/release-lib.nix") {
   inherit supportedSystems scrubJobs nixpkgsArgs;

--- a/release.nix
+++ b/release.nix
@@ -4,7 +4,11 @@
 , nixpkgsArgs ? {}
 }:
 
-let fixedNixpkgs = import ./nixpkgs {}; in
+# Just checking hydra (TODO delete this and put arg back)
+let fixedNixpkgs = import (builtins.fetchTarball {
+    url = "https://github.com/input-output-hk/haskell.nix/archive/1c85c0561ab93bcd16616ff0b32ee59689d0344d.tar.gz";
+    sha256 = "0vqd12kv4gwzc49i7rmii6ixlfrdwnbjvmibcj4yr64k1sspcgbn";
+  } + "/nixpkgs") {}; in
 with fixedNixpkgs.lib;
 with (import (fixedNixpkgs.path + "/pkgs/top-level/release-lib.nix") {
   inherit supportedSystems scrubJobs nixpkgsArgs;

--- a/release.nix
+++ b/release.nix
@@ -4,11 +4,7 @@
 , nixpkgsArgs ? {}
 }:
 
-# Just checking hydra (TODO delete this and put arg back)
-let fixedNixpkgs = import (builtins.fetchTarball {
-    url = "https://github.com/input-output-hk/haskell.nix/archive/1c85c0561ab93bcd16616ff0b32ee59689d0344d.tar.gz";
-    sha256 = "0vqd12kv4gwzc49i7rmii6ixlfrdwnbjvmibcj4yr64k1sspcgbn";
-  } + "/nixpkgs") {}; in
+let fixedNixpkgs = import ./nixpkgs {}; in
 with fixedNixpkgs.lib;
 with (import (fixedNixpkgs.path + "/pkgs/top-level/release-lib.nix") {
   inherit supportedSystems scrubJobs nixpkgsArgs;

--- a/release.nix
+++ b/release.nix
@@ -1,4 +1,4 @@
-{ supportedSystems ? [ "x86_64-darwin" ]
+{ supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
 , scrubJobs ? true
 , haskell-nix ? { outPath = ./.; rev = "abcdef"; }
 , nixpkgsArgs ? {}

--- a/test/default.nix
+++ b/test/default.nix
@@ -1,5 +1,5 @@
-{ pkgs ? nixpkgs nixpkgsArgs
-, nixpkgs ? (import ../.).nixpkgs
+{ pkgs ? import nixpkgs ((import ../.).nixpkgsArgs // nixpkgsArgs)
+, nixpkgs ? (import ../.).defaultNixpkgs
 , nixpkgsArgs ? { }
 }:
 

--- a/test/default.nix
+++ b/test/default.nix
@@ -1,5 +1,5 @@
-{ pkgs ? import nixpkgs ((import ../.) // nixpkgsArgs)
-, nixpkgs ? ../nixpkgs
+{ pkgs ? nixpkgs nixpkgsArgs
+, nixpkgs ? (import ../.).nixpkgs
 , nixpkgsArgs ? { }
 }:
 


### PR DESCRIPTION
* Makes ./nixpkgs/default.nix add the haskell.nix `overlays`
  and `config` arguments by default

* Updates `release.X.Y` json files for 18.09, 19.03 and 19.09

* Updates the docs and adds instructions on using `nixpkgs-pin`

* Updates `ci.nix` to use `./nixpkgs`