### PR TITLE
fix #269.  Apply fix to mkStackPkgSet

### DIFF
--- a/test/stack-simple/pkgs.nix
+++ b/test/stack-simple/pkgs.nix
@@ -7,6 +7,6 @@
         stack-simple = ./stack-simple.nix;
         };
       };
-  resolver = "lts-13.26";
+  resolver = "lts-14.13";
   modules = [ ({ lib, ... }: { packages = {}; }) { packages = {}; } ];
   }

--- a/test/stack-simple/stack.yaml
+++ b/test/stack-simple/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-13.26
+resolver: lts-14.13
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
First fix only fixed `haskell-nix.snapshot` by applying the fix also
to mkStackPkgSet stack.yaml based projects should work with lts 14