### PR TITLE
Check ghc used is haskell-nix.compiler one

### DIFF
--- a/builder/hspkg-builder.nix
+++ b/builder/hspkg-builder.nix
@@ -18,6 +18,10 @@
 , ...
 }@config:
 
+assert (if ghc.isHaskellNixCompiler or false then true
+  else throw ("It is likely you used `haskell.compiler.X` instead of `haskell-nix.compiler.X`"
+    + pkgs.lib.optionalString (name != null) (" for " + name)));
+
 let
   cabalFile = if revision == null || revision == 0 then null else
     fetchurl {

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -310,6 +310,9 @@ in stdenv.mkDerivation (rec {
     haskellCompilerName = "ghc-${version}";
 
     configured-src = configured-src;
+
+    # Used to detect non haskell-nix compilers (accedental use of nixpkgs compilers can lead to unexpected errors)
+    isHaskellNixCompiler = true;
   } // extra-passthru;
 
   meta = {

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -16,6 +16,11 @@
 assert (if (builtins.compareVersions cabal-install.version "2.4.0.0") < 0
          then throw "cabal-install (current version: ${cabal-install.version}) needs to be at least 2.4 for plan-to-nix to work without cabal-to-nix"
          else true);
+
+assert (if ghc.isHaskellNixCompiler or false then true
+  else throw ("It is likely you used `haskell.compiler.X` instead of `haskell-nix.compiler.X`"
+    + pkgs.lib.optionalString (name != null) (" for " + name)));
+
 let
   maybeCleanedSource =
     if haskellLib.canCleanSource src

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -229,7 +229,10 @@ self: super: {
         #      this is not ideal!
         # get binary compilers for bootstrapping.  We'll put the eventual proper
         # compilers into the same place where nix expects them.
-        compiler = import ../compiler/old-ghc-nix { pkgs = self; };
+        # We mark these compilers as boot compilers to make sure they are only used
+        # where a boot compiler is expected.
+        compiler = builtins.mapAttrs (_: v: v // { isHaskellNixBootCompiler = true; })
+          (import ../compiler/old-ghc-nix { pkgs = self; });
 
         packages = {
             # cabal has it's own bootstrap script which we'll use.
@@ -246,7 +249,8 @@ self: super: {
             # disable hpack support during bootstrap
             hpack = null;
             nix-tools = nix-tools.override {
-                inherit ghc;
+                # Only a boot compiler is suitable here
+                ghc = ghc // { isHaskellNixCompiler = ghc.isHaskellNixBootCompiler; };
                 inherit (bootstrap.packages) hpack;
             };
 
@@ -256,7 +260,8 @@ self: super: {
             # need to use the boot strap compiler as we need them
             # to build ghcs from source.
             alex-project = hackage-project {
-                inherit ghc;
+                # Only a boot compiler is suitable here
+                ghc = ghc // { isHaskellNixCompiler = ghc.isHaskellNixBootCompiler; };
                 inherit (bootstrap.packages) cabal-install nix-tools hpack;
                 name = "alex"; version = "3.2.4";
                 index-state = "2019-10-20T00:00:00Z";
@@ -264,7 +269,8 @@ self: super: {
             };
             alex = bootstrap.packages.alex-project.alex.components.exes.alex;
             happy-project = hackage-project {
-                inherit ghc;
+                # Only a boot compiler is suitable here
+                ghc = ghc // { isHaskellNixCompiler = ghc.isHaskellNixBootCompiler; };
                 inherit (bootstrap.packages) cabal-install nix-tools hpack;
                 name = "happy"; version = "1.19.11";
                 index-state = "2019-10-20T00:00:00Z";
@@ -272,7 +278,8 @@ self: super: {
             };
             happy = bootstrap.packages.happy-project.happy.components.exes.happy;
             hscolour-project = hackage-project {
-                inherit ghc;
+                # Only a boot compiler is suitable here
+                ghc = ghc // { isHaskellNixCompiler = ghc.isHaskellNixBootCompiler; };
                 inherit (bootstrap.packages) cabal-install nix-tools hpack;
                 name = "hscolour"; version = "1.24.4";
                 index-state = "2019-10-20T00:00:00Z";


### PR DESCRIPTION
It is easy to mistakenly pass in a `haskell.compiler.ghcXXX` compiler
instead of a `haskell-nix.compiler.ghcXXX` one.  This leads to subtle
bugs (for instance missing Cabal library patch).