### PR TITLE
Add error message for empty src

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -170,6 +170,13 @@ let
   ) (''
     tmp=$(mktemp -d)
     cd $tmp
+    # if maybeCleanedSource is empty, this means it's a new
+    # project where the files haven't been added to the git
+    # repo yet. We fail early and provide a useful error
+    # message to prevent headaches (#290).
+    if [ -z "$(ls -A ${maybeCleanedSource})" ]; 
+      echo "cleaned source is empty. Did you forget to 'git add -A'?"; exit 1;
+    fi
     cp -r ${maybeCleanedSource}/* .
     chmod +w -R .
     ${fixedProject.makeFixedProjectFile}


### PR DESCRIPTION
When a project's source directory is empty (i.e. no files have been added to the project's corresponding git repo), a more friendly error message gets printed instead of erroring with a cp error.

Related: #290 