### PR TITLE
filter out nulls in dependency calculation

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -87,7 +87,7 @@ let
       (if dontStrip then "--disable-executable-stripping" else "--enable-executable-stripping")
       (if dontStrip then "--disable-library-stripping"    else "--enable-library-stripping")
       (if enableLibraryProfiling    then "--enable-library-profiling"    else "--disable-library-profiling" )
-      (if enableExecutableProfiling then "--enable-executable-profiling" else "--disable-executable-profiling" )
+      (if enableExecutableProfiling then "--enable-profiling" else "--disable-profiling" )
     ] ++ lib.optional enableSeparateDataOutput "--datadir=$data/share/${ghc.name}"
       ++ lib.optional doHaddock' "--docdir=${docdir "$doc"}"
       ++ lib.optional (enableLibraryProfiling || enableExecutableProfiling) "--profiling-detail=${profilingDetail}"

--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -213,6 +213,7 @@ stdenv.mkDerivation ({
   buildPhase = ''
     runHook preBuild
     # https://gitlab.haskell.org/ghc/ghc/issues/9221
+    export LD_LIBRARY_PATH=${lib.makeLibraryPath component.libs}
     $SETUP_HS build ${haskellLib.componentTarget componentId} -j$(($NIX_BUILD_CORES > 4 ? 4 : $NIX_BUILD_CORES)) ${lib.concatStringsSep " " (component.setupBuildFlags ++ setupGhcOptions)}
     runHook postBuild
   '';

--- a/builder/make-config-files.nix
+++ b/builder/make-config-files.nix
@@ -102,7 +102,7 @@ in { identifier, component, fullName, flags ? {} }:
     package-db $out/package.conf.d
     EOF
 
-    ${lib.concatMapStringsSep "\n" catPkgEnvDep component.depends}
+    ${lib.concatMapStringsSep "\n" catPkgEnvDep (builtins.filter (v: !isNull v) component.depends)}
     ${lib.concatMapStringsSep "\n" catGhcPkgEnvDep (lib.remove "ghc" nonReinstallablePkgs)}
   '' + lib.optionalString component.doExactConfig ''
     echo "--exact-configuration" >> $out/configure-flags

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -112,7 +112,7 @@ with haskellLib;
       #
       # which indicates that the package.Win32 is missing and not defined.
       getKey = x: if x ? "outPath" then "${x}" else (throw x.identifier.name);
-      makePairs = map (p: rec { key=getKey val; val=(p.components.library or p); });
+      makePairs = vals: map (p: rec { key=getKey val; val=(p.components.library or p); }) (builtins.filter (v: !(isNull v)) vals);
       closure = builtins.genericClosure {
         startSet = makePairs component.depends;
         operator = {val,...}: makePairs val.config.depends;

--- a/modules/component-driver.nix
+++ b/modules/component-driver.nix
@@ -60,7 +60,7 @@ in
       # "ghci" "haskeline"
       "hpc"
       "mtl" "parsec" "process" "text" "time" "transformers"
-      "unix" "xhtml"
+      "unix" "xhtml" "terminfo"
       # "stm" "terminfo"
     ];
 


### PR DESCRIPTION
The package `ghc` (the GHC API) has a listed dependency of `ghc-heap`, but that mysterious package is not on hackage, does not appear in the `hackage` argument to `pkg-def-extras`, and so trying to get a build with the `ghc` package available would fail because something is null (presumably `ghc-heap`). This patch makes it work.