### PR TITLE
Fix `data-dir:` when cleaning components

### DIFF
--- a/lib/clean-cabal-component.nix
+++ b/lib/clean-cabal-component.nix
@@ -69,8 +69,7 @@ in
                 ++ package.extraSrcFiles
                 ++ component.extraSrcFiles
                 ++ package.extraDocFiles
-                ++ builtins.map (f:
-                  dataDir + (if dataDir == "" then "" else "/") + f) package.dataFiles
+                ++ builtins.map (f: dataDir + f) package.dataFiles
                 ++ otherSourceFiles))
             || traceReason "cabal package definition" (lib.strings.hasSuffix ".cabal" rPath)
             || traceReason "hpack package defintion" (rPath == "package.yaml")


### PR DESCRIPTION
`normalizeRelativeDir` adds a slash on to the end of `dataDir`.
Adding another one here results in `//` and files are left out by
mistake.