### PR TITLE
Patch singletons to use modified Uniq type

### DIFF
--- a/patches/ghc862/default.nix
+++ b/patches/ghc862/default.nix
@@ -7,4 +7,5 @@
   packages.time.patches = [ ({ version, revision }: if version == "1.8.0.2" && revision == 0 then ./time-1.8.0.2.patch else null) ];
   packages.transformers.patches = [ ({ version, revision }: if version == "0.5.5.0" && revision == 0 then ./transformers-0.5.5.0.patch else null) ];
   packages.unix.patches = [ ({ version, revision }: if version == "2.7.2.2" && revision == 0 then ./unix-2.7.2.2.patch else null) ];
+  packages.singletons.patches = [ ({ version, revision }: if version == "2.5.1" && revision == 0 then ./singletons-2.5.1.patch else null) ];
 }

--- a/patches/ghc862/singletons-2.5.1.patch
+++ b/patches/ghc862/singletons-2.5.1.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Data/Singletons/Util.hs b/src/Data/Singletons/Util.hs
+index 0f8f788..0ada2fe 100644
+--- a/src/Data/Singletons/Util.hs
++++ b/src/Data/Singletons/Util.hs
+@@ -96,7 +96,7 @@ qNewUnique :: DsMonad q => q Int
+ qNewUnique = do
+   Name _ flav <- qNewName "x"
+   case flav of
+-    NameU n -> return n
++    NameU n -> return (fromInteger n)
+     _       -> error "Internal error: `qNewName` didn't return a NameU"
+ 
+ checkForRep :: Quasi q => [Name] -> q ()

--- a/patches/ghc863/default.nix
+++ b/patches/ghc863/default.nix
@@ -7,4 +7,5 @@
   packages.time.patches = [ ({ version, revision }: if version == "1.8.0.2" && revision == 0 then ./time-1.8.0.2.patch else null) ];
   packages.transformers.patches = [ ({ version, revision }: if version == "0.5.5.0" && revision == 0 then ./transformers-0.5.5.0.patch else null) ];
   packages.unix.patches = [ ({ version, revision }: if version == "2.7.2.2" && revision == 0 then ./unix-2.7.2.2.patch else null) ];
+  packages.singletons.patches = [ ({ version, revision }: if version == "2.5.1" && revision == 0 then ./singletons-2.5.1.patch else null) ];
 }

--- a/patches/ghc863/singletons-2.5.1.patch
+++ b/patches/ghc863/singletons-2.5.1.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Data/Singletons/Util.hs b/src/Data/Singletons/Util.hs
+index 0f8f788..0ada2fe 100644
+--- a/src/Data/Singletons/Util.hs
++++ b/src/Data/Singletons/Util.hs
+@@ -96,7 +96,7 @@ qNewUnique :: DsMonad q => q Int
+ qNewUnique = do
+   Name _ flav <- qNewName "x"
+   case flav of
+-    NameU n -> return n
++    NameU n -> return (fromInteger n)
+     _       -> error "Internal error: `qNewName` didn't return a NameU"
+ 
+ checkForRep :: Quasi q => [Name] -> q ()

--- a/patches/ghc864/default.nix
+++ b/patches/ghc864/default.nix
@@ -4,4 +4,5 @@
   packages.hpc.patches = [ ({ version, revision }: if version == "0.6.0.3" && revision == 0 then ./hpc-0.6.0.3.patch else null) ];
   packages.parsec.patches = [ ({ version, revision }: if version == "3.1.13.0" && revision == 0 then ./parsec-3.1.13.0.patch else null) ];
   packages.unix.patches = [ ({ version, revision }: if version == "2.7.2.2" && revision == 0 then ./unix-2.7.2.2.patch else null) ];
+  packages.singletons.patches = [ ({ version, revision }: if version == "2.5.1" && revision == 0 then ./singletons-2.5.1.patch else null) ];
 }

--- a/patches/ghc864/singletons-2.5.1.patch
+++ b/patches/ghc864/singletons-2.5.1.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Data/Singletons/Util.hs b/src/Data/Singletons/Util.hs
+index 0f8f788..0ada2fe 100644
+--- a/src/Data/Singletons/Util.hs
++++ b/src/Data/Singletons/Util.hs
+@@ -96,7 +96,7 @@ qNewUnique :: DsMonad q => q Int
+ qNewUnique = do
+   Name _ flav <- qNewName "x"
+   case flav of
+-    NameU n -> return n
++    NameU n -> return (fromInteger n)
+     _       -> error "Internal error: `qNewName` didn't return a NameU"
+ 
+ checkForRep :: Quasi q => [Name] -> q ()

--- a/patches/ghc865/default.nix
+++ b/patches/ghc865/default.nix
@@ -4,4 +4,5 @@
   packages.hpc.patches = [ ({ version, revision }: if version == "0.6.0.3" && revision == 0 then ./hpc-0.6.0.3.patch else null) ];
   packages.parsec.patches = [ ({ version, revision }: if version == "3.1.13.0" && revision == 0 then ./parsec-3.1.13.0.patch else null) ];
   packages.unix.patches = [ ({ version, revision }: if version == "2.7.2.2" && revision == 0 then ./unix-2.7.2.2.patch else null) ];
+  packages.singletons.patches = [ ({ version, revision }: if version == "2.5.1" && revision == 0 then ./singletons-2.5.1.patch else null) ];
 }

--- a/patches/ghc865/singletons-2.5.1.patch
+++ b/patches/ghc865/singletons-2.5.1.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Data/Singletons/Util.hs b/src/Data/Singletons/Util.hs
+index 0f8f788..0ada2fe 100644
+--- a/src/Data/Singletons/Util.hs
++++ b/src/Data/Singletons/Util.hs
+@@ -96,7 +96,7 @@ qNewUnique :: DsMonad q => q Int
+ qNewUnique = do
+   Name _ flav <- qNewName "x"
+   case flav of
+-    NameU n -> return n
++    NameU n -> return (fromInteger n)
+     _       -> error "Internal error: `qNewName` didn't return a NameU"
+ 
+ checkForRep :: Quasi q => [Name] -> q ()


### PR DESCRIPTION
The reinstallableLibGhc patch changes the type of `Uniq` from `Int` to `Integer`. Since, `singletons` depends on `Uniq` this patch is needed to compile `singletons`.