### PR TITLE
Fix using local stack snapshots

### DIFF
--- a/test/default.nix
+++ b/test/default.nix
@@ -16,6 +16,7 @@ in pkgs.recurseIntoAttrs {
   with-packages = haskell-nix.callPackage ./with-packages { inherit util; };
   builder-haddock = haskell-nix.callPackage ./builder-haddock {};
   stack-simple = haskell-nix.callPackage ./stack-simple {};
+  stack-local-resolver = haskell-nix.callPackage ./stack-local-resolver {};
   snapshots = haskell-nix.callPackage ./snapshots {};
   shell-for = haskell-nix.callPackage ./shell-for {};
   shell-for-setup-deps = haskell-nix.callPackage ./shell-for-setup-deps {};

--- a/test/stack-local-resolver/.gitignore
+++ b/test/stack-local-resolver/.gitignore
@@ -1,0 +1,2 @@
+/.stack-work/
+/*.cabal

--- a/test/stack-local-resolver/default.nix
+++ b/test/stack-local-resolver/default.nix
@@ -1,0 +1,9 @@
+{ stackProject }:
+
+let
+  project = stackProject {
+    src = ./.;
+  };
+in
+
+project.stack-local-resolver

--- a/test/stack-local-resolver/package.yaml
+++ b/test/stack-local-resolver/package.yaml
@@ -1,0 +1,7 @@
+name: stack-local-resolver
+
+dependencies:
+- base
+
+library:
+  source-dirs: src

--- a/test/stack-local-resolver/snapshot.yaml
+++ b/test/stack-local-resolver/snapshot.yaml
@@ -1,0 +1,4 @@
+name: local-snapshot
+resolver: lts-14.13
+
+packages: []

--- a/test/stack-local-resolver/src/Lib.hs
+++ b/test/stack-local-resolver/src/Lib.hs
@@ -1,0 +1,6 @@
+module Lib
+    ( someFunc
+    ) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/test/stack-local-resolver/stack.yaml
+++ b/test/stack-local-resolver/stack.yaml
@@ -1,0 +1,4 @@
+resolver: snapshot.yaml
+
+packages:
+- .


### PR DESCRIPTION
Used to be part of #334. I added a test for this and made a bunch of little tweaks here and there to make sure that it _actually works_ 🙄.

The newly added test now passes, but, for some reason, it produces the following warnings, I have no clue why:

```
substituteStream(): WARNING: pattern '/nix/store/<hash>-stack-local-resolver' doesn't match anything in file '/nix/store/<hash>-stack-to-nix-pkgs/stack-local-resolver.nix'
substituteStream(): WARNING: pattern '/nix/store/<hash>-stack-local-resolver' doesn't match anything in file '/nix/store/<hash>-stack-to-nix-pkgs/default.nix'
substituteStream(): WARNING: pattern '/nix/store/<hash>-stack-local-resolver' doesn't match anything in file '/nix/store/<hash.-stack-to-nix-pkgs/pkgs.nix'
```

cc @balsoft