### PR TITLE
Add LOCALE_ARCHIVE to haskellLib.check derivations

### DIFF
--- a/lib/check.nix
+++ b/lib/check.nix
@@ -39,4 +39,6 @@ in stdenv.mkDerivation ({
   '';
 } // haskellLib.optionalHooks {
   inherit (component) preCheck postCheck;
-})
+}
+// lib.optionalAttrs (drv ? LOCALE_ARCHIVE) { inherit (drv) LOCALE_ARCHIVE; }
+)


### PR DESCRIPTION
This fixes errors like this
```
bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
...
    de1lg7wtbech32-test: <stdout>: commitBuffer: invalid argument (invalid character)
```