### PR TITLE
Keep source for component builds

### DIFF
--- a/lib/check.nix
+++ b/lib/check.nix
@@ -12,7 +12,7 @@ in stdenv.mkDerivation ({
 
   # Useing `srcOnly` (rather than getting the `src` via a `drv.passthru`)
   # should correctly apply the patches from `drv` (if any).
-  src = srcOnly drv;
+  src = drv.source or (srcOnly drv);
 
   passthru = {
     inherit (drv) identifier config configFiles executableToolDepends cleanSrc env;
@@ -31,6 +31,7 @@ in stdenv.mkDerivation ({
   '';
 
   checkPhase = ''
+    cd $src
     runHook preCheck
 
     ${toString component.testWrapper} ${drv}/${drv.installedExe} ${lib.concatStringsSep " " component.testFlags} | tee $out

--- a/lib/check.nix
+++ b/lib/check.nix
@@ -18,7 +18,7 @@ in stdenv.mkDerivation ({
     inherit (drv) identifier config configFiles executableToolDepends cleanSrc env;
   };
 
-  inherit (drv) meta LANG LC_ALL;
+  inherit (drv) meta LANG LC_ALL buildInputs nativeBuildInputs;
 
   inherit (component) doCheck doCrossCheck;
 

--- a/lib/check.nix
+++ b/lib/check.nix
@@ -22,15 +22,13 @@ in stdenv.mkDerivation ({
 
   inherit (component) doCheck doCrossCheck;
 
-  phases = ["unpackPhase" "buildPhase" "checkPhase"];
+  phases = ["unpackPhase" "buildPhase"];
 
   # If doCheck or doCrossCheck are false we may still build this
   # component and we want it to quietly succeed.
   buildPhase = ''
     touch $out
-  '';
 
-  checkPhase = ''
     runHook preCheck
 
     ${toString component.testWrapper} ${drv}/${drv.installedExe} ${lib.concatStringsSep " " component.testFlags} | tee $out

--- a/lib/check.nix
+++ b/lib/check.nix
@@ -22,7 +22,7 @@ in stdenv.mkDerivation ({
 
   inherit (component) doCheck doCrossCheck;
 
-  phases = ["buildPhase" "checkPhase"];
+  phases = ["unpackPhase" "buildPhase" "checkPhase"];
 
   # If doCheck or doCrossCheck are false we may still build this
   # component and we want it to quietly succeed.
@@ -31,7 +31,6 @@ in stdenv.mkDerivation ({
   '';
 
   checkPhase = ''
-    cd $src
     runHook preCheck
 
     ${toString component.testWrapper} ${drv}/${drv.installedExe} ${lib.concatStringsSep " " component.testFlags} | tee $out

--- a/modules/plan.nix
+++ b/modules/plan.nix
@@ -153,6 +153,11 @@ let
       default = (def.profilingDetail or "exported-functions");
     };
 
+    keepSource = mkOption {
+      type = bool;
+      default = (def.keepSource or false);
+      description = "Keep component source in the store in a `source` output";
+    };
   };
   packageOptions = def: componentOptions def // {
     preUnpack = mkOption {


### PR DESCRIPTION
This fixes and issue with TH functions like `makeRelativeToProject`
that can be used to keep a reference to source files.  If they are in
a temporary location that can result in surprising `file not found`
errors at run time.

It may also be useful for making debug symbols and the like refer to
real files.

There is a risk that keeping the source for all packages could expand
closure sizes (if for instance debug info is wanted, but you do not
want to keep the source in the store).  For that reason we have
made this an option that must be enabled.