### PR TITLE
Patch macos gcc version

### DIFF
--- a/compiler/old-ghc-nix/old-ghc-nix.json
+++ b/compiler/old-ghc-nix/old-ghc-nix.json
@@ -1,7 +1,5 @@
 {
-  "url": "https://github.com/angerman/old-ghc-nix",
-  "rev": "cda937215e85ef5f8064a9f97fc5dce948d028a2",
-  "date": "2019-07-26T23:00:31+08:00",
-  "sha256": "00zgkmd7g2rafa2gfz7nx3ahv89qf2jwr8i8r4g7bvykxvh8ga8v",
-  "fetchSubmodules": false
+  "url": "https://github.com/kayhide/old-ghc-nix",
+  "rev": "c76fa93e8cf092608c122be2a2ebc9aad5e4a308",
+  "sha256": "15ry46m8slab9d18wpk5zavxfjvfcva6ywrhfl2vi217kfw77vi3"
 }

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -68,6 +68,7 @@ self: super: {
                 ++ self.lib.optional (version == "8.6.5")                             ./patches/ghc/ghc-8.6.5-reinstallable-lib-ghc.patch
                 ++ self.lib.optional (version == "8.6.4")                             ./patches/ghc/ghc-8.6.4-better-plusSimplCountErrors.patch
                 ++ self.lib.optional (versionAtLeast "8.6.4" && self.stdenv.isDarwin) ./patches/ghc/ghc-macOS-loadArchive-fix.patch
+                ++ self.lib.optional (versionAtLeast "8.4.4" && self.stdenv.isDarwin) ./patches/ghc/ghc-darwin-gcc-version-fix.patch
                 ;
         in ({
             ghc844 = self.callPackage ../compiler/ghc {

--- a/overlays/patches/ghc/ghc-darwin-gcc-version-fix.patch
+++ b/overlays/patches/ghc/ghc-darwin-gcc-version-fix.patch
@@ -1,0 +1,11 @@
+--- a/aclocal.m4
++++ b/aclocal.m4
+@@ -1285,7 +1285,7 @@ AC_CACHE_CHECK([version of gcc], [fp_cv_gcc_version],
+ [
+     # Be sure only to look at the first occurrence of the "version " string;
+     # Some Apple compilers emit multiple messages containing this string.
+-    fp_cv_gcc_version="`$CC -v 2>&1 | sed -n -e '1,/version /s/.*version [[^0-9]]*\([[0-9.]]*\).*/\1/p'`"
++    fp_cv_gcc_version="`$CC -v 2>&1 | sed -n -e '1,/version /s/.*version [[^0-9]]*\([[0-9.]]*\).*/\1/p' | head -n 1`"
+     FP_COMPARE_VERSIONS([$fp_cv_gcc_version], [-lt], [4.4],
+                         [AC_MSG_ERROR([Need at least gcc version 4.4 (4.7+ recommended)])])
+     FP_COMPARE_VERSIONS([$fp_cv_gcc_version], [-lt], [4.6], GccLT46=YES)


### PR DESCRIPTION
This PR:

- Changes reference of `old-ghc-nix` repo where bootstrapping ghc is patched
- Applys a patch to ghc-8.4.4 or greater only on darwin

I tested this with ghc-8.4.4 and ghc-8.6.5.

Fix #330