### PR TITLE
Fix ranlib issue on macOS

### DIFF
--- a/compiler/old-ghc-nix/old-ghc-nix.json
+++ b/compiler/old-ghc-nix/old-ghc-nix.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/angerman/old-ghc-nix",
-  "rev": "c7c381f3ec5fb80e807271271f9df75ab7127f57",
-  "date": "2019-12-06T12:34:44+08:00",
-  "sha256": "0j1jwxfhcdz6h9qpvzz39kllhz6wb2bvgyy5irj6iav9ykp6xjin",
+  "rev": "32310a584c3e06c1c1b34769fe49c411edaeb6b5",
+  "date": "2019-12-08T20:07:35+13:00",
+  "sha256": "0ywvyjvyw9vm0qbf0a7k6zpsrzcz5wa7y16rfcs3wfv36plj3qd5",
   "fetchSubmodules": false
 }

--- a/compiler/old-ghc-nix/old-ghc-nix.json
+++ b/compiler/old-ghc-nix/old-ghc-nix.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/angerman/old-ghc-nix",
-  "rev": "32310a584c3e06c1c1b34769fe49c411edaeb6b5",
-  "date": "2019-12-08T20:07:35+13:00",
+  "rev": "ee5e7181f681522f075e01a1875228188b03cc8c",
+  "date": "2019-12-08T20:24:29+08:00",
   "sha256": "0ywvyjvyw9vm0qbf0a7k6zpsrzcz5wa7y16rfcs3wfv36plj3qd5",
   "fetchSubmodules": false
 }

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -160,6 +160,7 @@ let
     nativeBuildInputs = [ nix-tools ghc hpack cabal-install pkgs.rsync pkgs.git ];
     # Needed or stack-to-nix will die on unicode inputs
     LANG = "en_US.UTF-8";
+    meta.platforms = pkgs.lib.platforms.all;
     preferLocalBuild = false;
   } // (if plan-sha256 == null
     then {}

--- a/nix-tools/default.nix
+++ b/nix-tools/default.nix
@@ -53,6 +53,7 @@ in
     name = "nix-tools";
     paths = builtins.attrValues hsPkgs.nix-tools.components.exes;
     buildInputs = [ makeWrapper ];
+    meta.platforms = lib.platforms.all;
     # We wrap the -to-nix executables with the executables from `tools` (e.g. nix-prefetch-git)
     # so that consumers of `nix-tools` won't have to provide those tools.
     postBuild = ''

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -390,6 +390,7 @@ self: super: {
               (filterSupportedGhc self.ghc-extra-projects));
           } // self.lib.optionalAttrs (ifdLevel > 1) {
             # Things that require two levels of IFD to build (inputs should be in level 1)
+            self.haskell-nix.nix-tools;
             ghc-extra-packages = self.recurseIntoAttrs
               (filterSupportedGhc self.ghc-extra-packages);
           });

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -390,7 +390,7 @@ self: super: {
               (filterSupportedGhc self.ghc-extra-projects));
           } // self.lib.optionalAttrs (ifdLevel > 1) {
             # Things that require two levels of IFD to build (inputs should be in level 1)
-            self.haskell-nix.nix-tools;
+            inherit (self.haskell-nix) nix-tools;
             ghc-extra-packages = self.recurseIntoAttrs
               (filterSupportedGhc self.ghc-extra-packages);
           });

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -165,7 +165,7 @@ self: super: {
         # TODO perhaps there is a cleaner way to get a suitable nix-tools.
 
             # Produce a fixed output derivation from a moving target (hackage index tarball)
-        hackageTarball = { index-state, sha256, nix-tools ? self.nix-tools, ... }:
+        hackageTarball = { index-state, sha256, nix-tools ? self.haskell-nix.nix-tools, ... }:
             assert sha256 != null;
             self.fetchurl {
                 name = "01-index.tar.gz-at-${builtins.replaceStrings [":"] [""] index-state}";

--- a/release.nix
+++ b/release.nix
@@ -2,7 +2,7 @@
 , scrubJobs ? true
 , haskell-nix ? { outPath = ./.; rev = "abcdef"; }
 , nixpkgsArgs ? {}
-, ifdLevel ? 3
+, ifdLevel ? 0
 }:
 
 let defaultNixpkgs = import ./nixpkgs {}; in

--- a/release.nix
+++ b/release.nix
@@ -2,7 +2,7 @@
 , scrubJobs ? true
 , haskell-nix ? { outPath = ./.; rev = "abcdef"; }
 , nixpkgsArgs ? {}
-, ifdLevel ? 0
+, ifdLevel ? 3
 }:
 
 let defaultNixpkgs = import ./nixpkgs {}; in

--- a/release.nix
+++ b/release.nix
@@ -2,7 +2,7 @@
 , scrubJobs ? true
 , haskell-nix ? { outPath = ./.; rev = "abcdef"; }
 , nixpkgsArgs ? {}
-, ifdLevel ? 0
+, ifdLevel ? 1
 }:
 
 let defaultNixpkgs = import ./nixpkgs {}; in

--- a/release.nix
+++ b/release.nix
@@ -2,7 +2,7 @@
 , scrubJobs ? true
 , haskell-nix ? { outPath = ./.; rev = "abcdef"; }
 , nixpkgsArgs ? {}
-, ifdLevel ? 1
+, ifdLevel ? 3
 }:
 
 let defaultNixpkgs = import ./nixpkgs {}; in


### PR DESCRIPTION
Because we `meta.platforms` was not set in `nix-tools/default.nix` we
were not testing or caching `nix-tools` for macOS.  As a result
we missed that there was a need for the ranlib fix on `macOS`.

This enables hydra builds of nix-tools on all platforms and fixes
the resulting issue with `ranlib` in the `old-ghc-nix` version
of ghc 8.4.4.
