### PR TITLE
Updated the haskell.nix imports to overlay style

### DIFF
--- a/docs/user-guide/cabal-projects.md
+++ b/docs/user-guide/cabal-projects.md
@@ -81,7 +81,9 @@ instantiate a package set.
 # default.nix
 let
   # Import the Haskell.nix library,
-  haskell = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz);
+  src = builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz;
+  nixpkgs = import (src + "/nixpkgs") (import src);
+  haskell = nixpkgs.haskell-nix;
 
   # Instantiate a package set using the generated file.
   pkgSet = haskell.mkCabalProjectPkgSet {

--- a/docs/user-guide/cabal-projects.md
+++ b/docs/user-guide/cabal-projects.md
@@ -81,7 +81,7 @@ instantiate a package set.
 # default.nix
 let
   # Import the Haskell.nix library,
-  haskell = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz) {};
+  haskell = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz);
 
   # Instantiate a package set using the generated file.
   pkgSet = haskell.mkCabalProjectPkgSet {

--- a/docs/user-guide/development.md
+++ b/docs/user-guide/development.md
@@ -108,7 +108,9 @@ selects packages from the larger package set.
 ```nix
 # shell.nix
 let
-  haskell = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz);
+  src = builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz;
+  nixpkgs = import (src + "/nixpkgs") (import src);
+  haskell = nixpkgs.haskell-nix;
 in
   haskell.haskellPackages.ghcWithPackages (ps: with ps;
     [ lens conduit conduit-extra ])
@@ -125,7 +127,9 @@ project.
 
 ```nix
 let
-  haskell = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz);
+  src = builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz;
+  nixpkgs = import (src + "/nixpkgs") (import src);
+  haskell = nixpkgs.haskell-nix;
 in
   haskell.snapshots."lts-13.18".alex.components.exes.alex
 ```

--- a/docs/user-guide/development.md
+++ b/docs/user-guide/development.md
@@ -108,7 +108,7 @@ selects packages from the larger package set.
 ```nix
 # shell.nix
 let
-  haskell = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz) {};
+  haskell = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz);
 in
   haskell.haskellPackages.ghcWithPackages (ps: with ps;
     [ lens conduit conduit-extra ])
@@ -125,7 +125,7 @@ project.
 
 ```nix
 let
-  haskell = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz) {};
+  haskell = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz);
 in
   haskell.snapshots."lts-13.18".alex.components.exes.alex
 ```

--- a/docs/user-guide/stack-projects.md
+++ b/docs/user-guide/stack-projects.md
@@ -43,7 +43,9 @@ instantiate a package set.
 # default.nix
 let
   # Import the Haskell.nix library,
-  haskell = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz);
+  src = builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz;
+  nixpkgs = import (src + "/nixpkgs") (import src);
+  haskell = nixpkgs.haskell-nix;
 
   # Instantiate a package set using the generated file.
   pkgSet = haskell.mkStackPkgSet {

--- a/docs/user-guide/stack-projects.md
+++ b/docs/user-guide/stack-projects.md
@@ -43,7 +43,7 @@ instantiate a package set.
 # default.nix
 let
   # Import the Haskell.nix library,
-  haskell = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz) {};
+  haskell = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz);
 
   # Instantiate a package set using the generated file.
   pkgSet = haskell.mkStackPkgSet {


### PR DESCRIPTION
Some of the examples in the documentation were still passing an empty
set to the haskell.nix imports but this is no longer valid because the
import now results in a set rather than a function.

(This is confusing for new users.)