### PR TITLE
Move envDeps and exactDeps into lib and ghc

### DIFF
--- a/builder/make-config-files.nix
+++ b/builder/make-config-files.nix
@@ -47,7 +47,7 @@ let
   '';
 
   catPkgExactDep = p:
-    catExactDep (exactDep (packageDb p) p.identifier.name [ghc (p.components.library or p)]);
+    catExactDep ((p.components.library or p) + "/exactDep");
 
   catGhcPkgExactDep = p: catExactDep (exactDep "" p [ghc]);
 
@@ -63,7 +63,7 @@ let
   '';
 
   catPkgEnvDep = p:
-    catEnvDep (envDep (packageDb p) p.identifier.name [ghc (p.components.library or p)]);
+    catEnvDep ((p.components.library or p) + "/envDep");
 
   catGhcPkgEnvDep = p: catEnvDep (envDep "" p [ghc]);
 
@@ -87,7 +87,7 @@ in { identifier, component, fullName, flags ? {} }:
 
     ${lib.concatMapStringsSep "\n" (p: ''
       cp -f "${p}/package.conf.d/"*.conf $out/package.conf.d
-    '') (haskellLib.flatLibDepends component)}
+    '') (builtins.trace (toString (builtins.length (haskellLib.flatLibDepends component)) + " " + toString (builtins.length component.depends)) haskellLib.flatLibDepends component)}
 
     # Note: we pass `clear` first to ensure that we never consult the implicit global package db.
     ${flagsAndConfig "package-db" ["clear" "$out/package.conf.d"]}

--- a/builder/make-config-files.nix
+++ b/builder/make-config-files.nix
@@ -9,12 +9,17 @@ let
   target-pkg = "${ghc.targetPrefix}ghc-pkg";
 
   # This is a bit of a hack.  So we'll have a slightly longer explaination here:
+
+  # Every library component built with `comp-builder.nix` includes an `exactDep`
+  # and `envDep` directory with precomputed values used here.
+  # GHC derivations include `exactDep` and `envDep` derivations that have
+  # the same information for each of the built in packages.
+
   # exactDep will pass --exact-configuration to the `SETUP_HS confiugre` command.
   # This requires us to pass --dependency={dep name}={pkg id}.  The dependency
-  # name will usually be the name of the package `p`, which we can locate in the
-  # package-db, passed in via `pdbArg`.  Thus querying the package-db for the
-  # id field for package `p`, will unsually provide is with the right value.  Sublibs
-  # need a bit of special handling:
+  # name will usually be the name of the package `p`, that will have been located
+  # in the suitable package db when the dependency (along with `exactDep` and `envDep`)
+  # was built.  Sublibs need a bit of special handling:
   #
   # - Sublibs: if the dependency is a sublibrary of a package, we need to use
   #            the sublibrary's name for the dep name, and lookup the sublibraries

--- a/builder/make-config-files.nix
+++ b/builder/make-config-files.nix
@@ -85,9 +85,10 @@ in { identifier, component, fullName, flags ? {} }:
       find ${ghc}/lib/${ghc.name}/package.conf.d -name '${p}*.conf' -exec cp -f {} $out/package.conf.d \;
     '') nonReinstallablePkgs}
 
-    ${lib.concatMapStringsSep "\n" (p: ''
-      cp -f "${p}/package.conf.d/"*.conf $out/package.conf.d
-    '') (builtins.trace (toString (builtins.length (haskellLib.flatLibDepends component)) + " " + toString (builtins.length component.depends)) haskellLib.flatLibDepends component)}
+    ${lib.concatMapStringsSep "\n" (p: lib.optionalString (p ? components && p.components ? library) ''
+      cp -f "${p.components.library.configFiles}/package.conf.d/"*.conf $out/package.conf.d
+      cp -f "${p.components.library}/package.conf.d/"*.conf $out/package.conf.d
+    '') component.depends}
 
     # Note: we pass `clear` first to ensure that we never consult the implicit global package db.
     ${flagsAndConfig "package-db" ["clear" "$out/package.conf.d"]}

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -13,6 +13,8 @@
 
 , libiconv ? null, ncurses
 
+, exactDeps, envDeps
+
 , # GHC can be built with system libffi or a bundled one.
   libffi ? null
 
@@ -204,7 +206,7 @@ in let configured-src = stdenv.mkDerivation (rec {
         installPhase = "cp -r . $out";
     });
 
-in stdenv.mkDerivation (rec {
+  drv =stdenv.mkDerivation (rec {
   version = ghc-version;
   name = "${targetPrefix}ghc-${version}";
 
@@ -313,6 +315,10 @@ in stdenv.mkDerivation (rec {
 
     # Used to detect non haskell-nix compilers (accedental use of nixpkgs compilers can lead to unexpected errors)
     isHaskellNixCompiler = true;
+
+    # These are used in make-config-files.nix
+    exactDeps = exactDeps drv;
+    envDeps = envDeps drv;
   } // extra-passthru;
 
   meta = {
@@ -326,4 +332,6 @@ in stdenv.mkDerivation (rec {
   dontStrip = true;
   dontPatchELF = true;
   noAuditTmpdir = true;
-})
+});
+
+in drv

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -1,7 +1,7 @@
 self: super:
 let
     exactDeps = ghc: self.runCommand "ghc-exactdep-${ghc.version}" { nativeBuildInputs = [ ghc ]; } ''
-      for P in $(${ghc.targetPrefix}ghc-pkg list --simple-output | sed 's/-[0-9.]*//g'); do
+      for P in $(${ghc.targetPrefix}ghc-pkg list --simple-output | sed 's/-[0-9][0-9.]*//g'); do
         mkdir -p $out/$P
         touch $out/$P/configure-flags
         touch $out/$P/cabal.config

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -1,4 +1,36 @@
-self: super: {
+self: super:
+let
+    exactDeps = ghc: self.runCommand "ghc-exactdep-${ghc.version}" { nativeBuildInputs = [ ghc ]; } ''
+      for P in $(${ghc.targetPrefix}ghc-pkg list --simple-output | sed 's/-[0-9.]*//g'); do
+        mkdir -p $out/$P
+        touch $out/$P/configure-flags
+        touch $out/$P/cabal.config
+
+        if id=$(${ghc.targetPrefix}ghc-pkg field $P id --simple-output); then
+          echo "--dependency=$P=$id" >> $out/$P/configure-flags
+        elif id=$(${ghc.targetPrefix}ghc-pkg field "z-$P-z-*" id --simple-output); then
+          name=$(${ghc.targetPrefix}ghc-pkg field "z-$P-z-*" name --simple-output)
+          # so we are dealing with a sublib. As we build sublibs separately, the above
+          # query should be safe.
+          echo "--dependency=''${name#z-$P-z-}=$id" >> $out/$P/configure-flags
+        fi
+        if ver=$(${ghc.targetPrefix}ghc-pkg field $P version --simple-output); then
+          echo "constraint: $P == $ver" >> $out/$P/cabal.config
+          echo "constraint: $P installed" >> $out/$P/cabal.config
+        fi
+      done
+    '';
+
+    envDeps = ghc: self.runCommand "ghc-envdep-${ghc.version}" { nativeBuildInputs = [ ghc ]; } ''
+      mkdir -p $out
+      for P in $(${ghc.targetPrefix}ghc-pkg list --simple-output | sed 's/-[0-9.]*//g'); do
+        touch $out/$P
+        if id=$(${ghc.targetPrefix}ghc-pkg field $P id --simple-output); then
+          echo "package-id $id" >> $out/$P
+        fi
+      done
+    '';
+in {
   haskell-nix = super.haskell-nix // {
     # Use this to disable the existing haskell infra structure for testing purposes
     compiler =
@@ -73,7 +105,7 @@ self: super: {
             ghc844 = self.callPackage ../compiler/ghc {
                 extra-passthru = { buildGHC = self.buildPackages.haskell-nix.compiler.ghc844; };
 
-                inherit bootPkgs sphinx;
+                inherit bootPkgs sphinx exactDeps envDeps;
 
                 buildLlvmPackages = self.buildPackages.llvmPackages_5;
                 llvmPackages = self.llvmPackages_5;
@@ -91,7 +123,7 @@ self: super: {
             ghc861 = self.callPackage ../compiler/ghc {
                 extra-passthru = { buildGHC = self.buildPackages.haskell-nix.compiler.ghc861; };
 
-                inherit bootPkgs sphinx;
+                inherit bootPkgs sphinx exactDeps envDeps;
 
                 buildLlvmPackages = self.buildPackages.llvmPackages_5;
                 llvmPackages = self.llvmPackages_5;
@@ -107,7 +139,7 @@ self: super: {
             ghc862 = self.callPackage ../compiler/ghc {
                 extra-passthru = { buildGHC = self.buildPackages.haskell-nix.compiler.ghc862; };
 
-                inherit bootPkgs sphinx;
+                inherit bootPkgs sphinx exactDeps envDeps;
 
                 buildLlvmPackages = self.buildPackages.llvmPackages_5;
                 llvmPackages = self.llvmPackages_5;
@@ -124,7 +156,7 @@ self: super: {
             ghc863 = self.callPackage ../compiler/ghc {
                 extra-passthru = { buildGHC = self.buildPackages.haskell-nix.compiler.ghc863; };
 
-                inherit bootPkgs sphinx;
+                inherit bootPkgs sphinx exactDeps envDeps;
 
                 buildLlvmPackages = self.buildPackages.llvmPackages_5;
                 llvmPackages = self.llvmPackages_5;
@@ -141,7 +173,7 @@ self: super: {
             ghc864 = self.callPackage ../compiler/ghc {
                 extra-passthru = { buildGHC = self.buildPackages.haskell-nix.compiler.ghc864; };
 
-                inherit bootPkgs sphinx;
+                inherit bootPkgs sphinx exactDeps envDeps;
 
                 buildLlvmPackages = self.buildPackages.llvmPackages_5;
                 llvmPackages = self.llvmPackages_5;
@@ -158,7 +190,7 @@ self: super: {
             ghc865 = self.callPackage ../compiler/ghc {
                 extra-passthru = { buildGHC = self.buildPackages.haskell-nix.compiler.ghc865; };
 
-                inherit bootPkgs sphinx;
+                inherit bootPkgs sphinx exactDeps envDeps;
 
                 buildLlvmPackages = self.buildPackages.llvmPackages_5;
                 llvmPackages = self.llvmPackages_5;
@@ -231,7 +263,13 @@ self: super: {
         # compilers into the same place where nix expects them.
         # We mark these compilers as boot compilers to make sure they are only used
         # where a boot compiler is expected.
-        compiler = builtins.mapAttrs (_: v: v // { isHaskellNixBootCompiler = true; })
+        compiler = builtins.mapAttrs (_: v:
+            v // {
+              isHaskellNixBootCompiler = true;
+              exactDeps = exactDeps v;
+              envDeps = envDeps v;
+            }
+          )
           (import ../compiler/old-ghc-nix { pkgs = self; });
 
         packages = {

--- a/release.nix
+++ b/release.nix
@@ -2,7 +2,7 @@
 , scrubJobs ? true
 , haskell-nix ? { outPath = ./.; rev = "abcdef"; }
 , nixpkgsArgs ? {}
-, ifdLevel ? 3
+, ifdLevel ? 0
 }:
 
 let defaultNixpkgs = import ./nixpkgs {}; in

--- a/release.nix
+++ b/release.nix
@@ -2,7 +2,7 @@
 , scrubJobs ? true
 , haskell-nix ? { outPath = ./.; rev = "abcdef"; }
 , nixpkgsArgs ? {}
-, ifdLevel ? 2
+, ifdLevel ? 3
 }:
 
 let defaultNixpkgs = import ./nixpkgs {}; in

--- a/release.nix
+++ b/release.nix
@@ -2,7 +2,7 @@
 , scrubJobs ? true
 , haskell-nix ? { outPath = ./.; rev = "abcdef"; }
 , nixpkgsArgs ? {}
-, ifdLevel ? 0
+, ifdLevel ? 1
 }:
 
 let defaultNixpkgs = import ./nixpkgs {}; in

--- a/release.nix
+++ b/release.nix
@@ -2,7 +2,7 @@
 , scrubJobs ? true
 , haskell-nix ? { outPath = ./.; rev = "abcdef"; }
 , nixpkgsArgs ? {}
-, ifdLevel ? 1
+, ifdLevel ? 2
 }:
 
 let defaultNixpkgs = import ./nixpkgs {}; in


### PR DESCRIPTION
This change moves the work done to in `envDeps` and `exactDeps`
from `make-config-files.nix` into the library components and
the `ghc` compiler component (well `passthru` derivations on the
`ghc` component).

This greatly reduces the number of times `runCommand` is
used while nix is working out what to build.

This fixes a performance regression in #323 for builds where
little or no work needs to be done.  While maintaining the
performance improvement in #323 that resulted from reducing the
number of calls to `ghc-pkg` when significant work does need
to be done.