### PR TITLE
Patch gcc version fix on macOS

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -68,6 +68,7 @@ self: super: {
                 ++ self.lib.optional (version == "8.6.5")                             ./patches/ghc/ghc-8.6.5-reinstallable-lib-ghc.patch
                 ++ self.lib.optional (version == "8.6.4")                             ./patches/ghc/ghc-8.6.4-better-plusSimplCountErrors.patch
                 ++ self.lib.optional (versionAtLeast "8.6.4" && self.stdenv.isDarwin) ./patches/ghc/ghc-macOS-loadArchive-fix.patch
+                ++ self.lib.optional (versionAtLeast "8.4.4" && self.stdenv.isDarwin) ./patches/ghc/ghc-darwin-gcc-version-fix.patch
                 ;
         in ({
             ghc844 = self.callPackage ../compiler/ghc {

--- a/overlays/patches/ghc/ghc-darwin-gcc-version-fix.patch
+++ b/overlays/patches/ghc/ghc-darwin-gcc-version-fix.patch
@@ -1,0 +1,11 @@
+--- a/aclocal.m4
++++ b/aclocal.m4
+@@ -1285,7 +1285,7 @@ AC_CACHE_CHECK([version of gcc], [fp_cv_gcc_version],
+ [
+     # Be sure only to look at the first occurrence of the "version " string;
+     # Some Apple compilers emit multiple messages containing this string.
+-    fp_cv_gcc_version="`$CC -v 2>&1 | sed -n -e '1,/version /s/.*version [[^0-9]]*\([[0-9.]]*\).*/\1/p'`"
++    fp_cv_gcc_version="`$CC -v 2>&1 | sed -n -e '1,/version /s/.*version [[^0-9]]*\([[0-9.]]*\).*/\1/p' | head -n 1`"
+     FP_COMPARE_VERSIONS([$fp_cv_gcc_version], [-lt], [4.4],
+                         [AC_MSG_ERROR([Need at least gcc version 4.4 (4.7+ recommended)])])
+     FP_COMPARE_VERSIONS([$fp_cv_gcc_version], [-lt], [4.6], GccLT46=YES)


### PR DESCRIPTION
I am afraid but #350 was not fully merged into #349 as said as https://github.com/input-output-hk/haskell.nix/pull/350#issuecomment-562430928 .
And #330 is still unfixed.

This is PR includes the diff of what was not merged.

@hamishmack Please take a look.