### PR TITLE
Fix error with specifying rev to builtins.fetchGit when creating cache

### DIFF
--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -247,12 +247,10 @@ self: super: {
                 # It doesn't make sense to specify sha256 on a private repo
                 # because it is not used by buitins.fetchGit.
                 assert isNull sha256;
-                builtins.fetchGit {
-                  url = url;
-                  rev = rev;
-                } // self.buildPackages.lib.optionalAttrs (ref != null) {
-                  ref = ref;
-                }
+                builtins.fetchGit
+                  ({ inherit url rev; } //
+                      self.buildPackages.lib.optionalAttrs (ref != null) { inherit ref; }
+                  )
               else
                 # Non-private repos must have sha256 set.
                 assert sha256 != null;
@@ -324,8 +322,10 @@ self: super: {
                       src =
                         if is-private
                         then
-                          builtins.fetchGit { inherit url rev; }
-                            // self.buildPackages.lib.optionalAttrs (ref != null) { inherit ref; }
+                          builtins.fetchGit
+                            ({ inherit url rev; } //
+                              self.buildPackages.lib.optionalAttrs (ref != null) { inherit ref; }
+                            )
                         else
                           self.buildPackages.pkgs.fetchgit { inherit url rev sha256; };
                     } // self.buildPackages.lib.optionalAttrs (subdir != null) { postUnpack = "sourceRoot+=/${subdir}; echo source root reset to $sourceRoot"; };


### PR DESCRIPTION
In https://github.com/input-output-hk/haskell.nix/pull/348 I added support to the cache machinery to be able to use `bulitins.fetchGit` for working with private git repositories.

The cache got a new argument `rev` (among others) that can be used for specifying a different branch to use (other than `master` or `HEAD`).

However, there was a logic error for specifying `rev`.  I missed parenthesis around the record I was constructing.

This PR fixes this logic error.