### PR TITLE
Exclude .source-repository-packages from plan nix

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -235,7 +235,9 @@ let
       chmod +w -R $out/.source-repository-packages
       rm -rf $out/.source-repository-packages
     fi
-    find $out -type f ! -name '*.nix' -exec rm "{}" \;
+    find $out -type f ! -name '*.nix' -delete
+    # Remove empty dirs
+    find $out -type d -empty -delete
 
     # move pkgs.nix to default.nix ensure we can just nix `import` the result.
     mv $out/pkgs.nix $out/default.nix

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -231,6 +231,10 @@ let
     # Remove the non nix files ".project" ".cabal" "package.yaml" files
     # as they should not be in the output hash (they may change slightly
     # without affecting the nix).
+    if [ -d $out/.source-repository-packages ]; then
+      chmod +w -R $out/.source-repository-packages
+      rm -rf $out/.source-repository-packages
+    fi
     find $out -type f ! -name '*.nix' -exec rm "{}" \;
 
     # move pkgs.nix to default.nix ensure we can just nix `import` the result.


### PR DESCRIPTION
This prevents error messages when we try to delete
the read only `.cabal` files in the directory.