### PR TITLE
Use propagatedBuildInputs for framework deps

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -175,8 +175,9 @@ stdenv.mkDerivation ({
 
   enableParallelBuilding = true;
 
+  propagatedBuildInputs = component.frameworks;
+
   buildInputs = component.libs
-    ++ component.frameworks
     ++ builtins.concatLists component.pkgconfig
     # Note: This is a hack until we can fix properly. See:
     # https://github.com/haskell-gi/haskell-gi/issues/226

--- a/release.nix
+++ b/release.nix
@@ -2,7 +2,7 @@
 , scrubJobs ? true
 , haskell-nix ? { outPath = ./.; rev = "abcdef"; }
 , nixpkgsArgs ? {}
-, ifdLevel ? 3
+, ifdLevel ? 0
 }:
 
 let defaultNixpkgs = import ./nixpkgs {}; in

--- a/release.nix
+++ b/release.nix
@@ -2,7 +2,7 @@
 , scrubJobs ? true
 , haskell-nix ? { outPath = ./.; rev = "abcdef"; }
 , nixpkgsArgs ? {}
-, ifdLevel ? 2
+, ifdLevel ? 3
 }:
 
 let defaultNixpkgs = import ./nixpkgs {}; in

--- a/release.nix
+++ b/release.nix
@@ -2,7 +2,7 @@
 , scrubJobs ? true
 , haskell-nix ? { outPath = ./.; rev = "abcdef"; }
 , nixpkgsArgs ? {}
-, ifdLevel ? 0
+, ifdLevel ? 1
 }:
 
 let defaultNixpkgs = import ./nixpkgs {}; in

--- a/release.nix
+++ b/release.nix
@@ -2,7 +2,7 @@
 , scrubJobs ? true
 , haskell-nix ? { outPath = ./.; rev = "abcdef"; }
 , nixpkgsArgs ? {}
-, ifdLevel ? 1
+, ifdLevel ? 2
 }:
 
 let defaultNixpkgs = import ./nixpkgs {}; in


### PR DESCRIPTION
This seems to be required for packages that depend on packages
with framework dependencies and is consistent with [what nixpkgs does](https://github.com/NixOS/nixpkgs/blob/0b4139189061d88fd01384dd85556122345b1a8a/pkgs/development/haskell-modules/generic-builder.nix#L207).