### PR TITLE
Change LLVM versions for ghc-8.6 to LLVM 6

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 This file contains a summary of changes to Haskell.nix and `nix-tools`
 that will impact users.
 
+## December 27, 2019
+* Fix overlays/bootstrap.nix to provide LLVM 6, not LLVM 5, to ghc-8.6.X compilers.
+
 ## November 18, 2019
   * Changed the `cleanSourceHaskell` to accept an attrset of `src` and
     (optional) `name` parameters. This allows you to keep the source

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -124,8 +124,8 @@ in {
 
                 inherit bootPkgs sphinx installDeps;
 
-                buildLlvmPackages = self.buildPackages.llvmPackages_5;
-                llvmPackages = self.llvmPackages_5;
+                buildLlvmPackages = self.buildPackages.llvmPackages_6;
+                llvmPackages = self.llvmPackages_6;
 
                 src-spec = rec {
                     version = "8.6.1";
@@ -140,8 +140,8 @@ in {
 
                 inherit bootPkgs sphinx installDeps;
 
-                buildLlvmPackages = self.buildPackages.llvmPackages_5;
-                llvmPackages = self.llvmPackages_5;
+                buildLlvmPackages = self.buildPackages.llvmPackages_6;
+                llvmPackages = self.llvmPackages_6;
 
                 src-spec = rec {
                     version = "8.6.2";
@@ -157,8 +157,8 @@ in {
 
                 inherit bootPkgs sphinx installDeps;
 
-                buildLlvmPackages = self.buildPackages.llvmPackages_5;
-                llvmPackages = self.llvmPackages_5;
+                buildLlvmPackages = self.buildPackages.llvmPackages_6;
+                llvmPackages = self.llvmPackages_6;
 
                 src-spec = rec {
                     version = "8.6.3";
@@ -174,8 +174,8 @@ in {
 
                 inherit bootPkgs sphinx installDeps;
 
-                buildLlvmPackages = self.buildPackages.llvmPackages_5;
-                llvmPackages = self.llvmPackages_5;
+                buildLlvmPackages = self.buildPackages.llvmPackages_6;
+                llvmPackages = self.llvmPackages_6;
 
                 src-spec = rec {
                     version = "8.6.4";
@@ -191,8 +191,8 @@ in {
 
                 inherit bootPkgs sphinx installDeps;
 
-                buildLlvmPackages = self.buildPackages.llvmPackages_5;
-                llvmPackages = self.llvmPackages_5;
+                buildLlvmPackages = self.buildPackages.llvmPackages_6;
+                llvmPackages = self.llvmPackages_6;
 
                 src-spec = rec {
                     version = "8.6.5";


### PR DESCRIPTION
The LLVM versions specified for the ghc-8.6 series compilers in `overlays/bootstrap.nix` was LLVM 5, but these compilers state on the download page that they require LLVM 6. This resulted in a warning about a wrong LLVM version for every module compiled with the LLVM backend (e,g, when cross-compiling.) This PR updates the LLVM versions for these compilers to LLVM 6.

Note: ghc-8.8.1 (and presumably future ghcs in the 8.8 series) requires LLVM 7. However it appears haskell.nix does not yet support ghc-8.8.1.