### PR TITLE
mkStackPkgSet: filter out $locals package

### DIFF
--- a/test/ghc-options/stack.nix
+++ b/test/ghc-options/stack.nix
@@ -8,6 +8,11 @@ let
   };
   packages = project.hsPkgs;
 
+  # Get the names of all packages. This is a test to see
+  # whether there is a broken "$locals" package present.
+  hasIdentifier = p: p != null && p ? identifier;
+  packageNames = mapAttrsToList (name: p: p.identifier.name) (filterAttrs (name: hasIdentifier) packages);
+
 in recurseIntoAttrs {
   ifdInputs = {
     inherit (project) stack-nix;
@@ -19,7 +24,7 @@ in recurseIntoAttrs {
       printf "checking whether executable runs... " >& 2
       cat ${haskellLib.check packages.test-ghc-options.components.exes.test-ghc-options-exe}
 
-      touch $out
+      echo '${concatStringsSep " " packageNames}' > $out
     '';
 
     meta.platforms = platforms.all;

--- a/test/ghc-options/stack.yaml
+++ b/test/ghc-options/stack.yaml
@@ -5,3 +5,5 @@ packages:
 
 ghc-options:
   test-ghc-options: -DTEST_GHC_OPTION
+  # See https://github.com/ndmitchell/weeder/issues/53
+  $locals: -ddump-to-file -ddump-hi


### PR DESCRIPTION
I found that if I added this to my `stack.yaml`:

    ghc-options:
      $locals: -ddump-to-file -ddump-hi

As specified in https://docs.haskellstack.org/en/stable/yaml_configuration/#ghc-options

Then my build would fail to evaluate with:

    error: The option `packages."\$locals".package.identifier.name' is used but not defined.

So to fix it, we filter out these special package globs in `mkStackPkgSet`.

This commit also adds a regression test for that configuration option.