### PR TITLE
comp-builder: changed attribute installedExe -> exeName

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -133,8 +133,8 @@ let
     && stdenv.hostPlatform == stdenv.buildPlatform;
 
   exeExt = lib.optionalString stdenv.hostPlatform.isWindows ".exe";
-  testExecutable = "dist/build/${componentId.cname}/${componentId.cname}${exeExt}";
-  installedExe = "bin/${componentId.cname}${exeExt}";
+  exeName = componentId.cname + exeExt;
+  testExecutable = "dist/build/${componentId.cname}/${exeName}";
 
 in stdenv.lib.fix (drv:
 
@@ -151,7 +151,7 @@ stdenv.mkDerivation ({
   passthru = {
     inherit (package) identifier;
     config = component;
-    inherit configFiles executableToolDepends cleanSrc installedExe;
+    inherit configFiles executableToolDepends cleanSrc exeName;
     env = shellWrappers;
 
     # The directory containing the haddock documentation.

--- a/lib/check.nix
+++ b/lib/check.nix
@@ -31,7 +31,7 @@ in stdenv.mkDerivation ({
 
     runHook preCheck
 
-    ${toString component.testWrapper} ${drv}/${drv.installedExe} ${lib.concatStringsSep " " component.testFlags} | tee $out
+    ${toString component.testWrapper} ${drv}/bin/${drv.exeName} ${lib.concatStringsSep " " component.testFlags} | tee $out
 
     runHook postCheck
   '';


### PR DESCRIPTION
The bare exe name is more useful downstream than something prepended with `bin/`.