### PR TITLE
Update default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,4 +2,8 @@
 #   import <nixpkgs> (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz))
 { config   = import ./config.nix;
   overlays = import ./overlays;
+  # convenience function. To make it possible to call
+  #   import <nixpkgs> (import (...).withArgs { system = builtins.currentSystem; crossSystem = null; config = { ... }; overlays = [...]; }
+  # instead of having this convoluted args reshuffling in the client code.
+  withArgs = args: args // { config = config // args.config; overlays = overlays ++ args.overlays; };
 }


### PR DESCRIPTION
I'm always annoyed when wrting code like this:

```nix
{ system ? builtins.currentSystem
, crossSystem ? null
, config ? {}
, overlays ? []
# nixpkgs-19.09-darwin as of Jan 16th 2020
, nixpkgs ? import (builtins.fetchTarball https://github.com/NixOS/nixpkgs-channels/archive/f69a5b2.tar.gz)
# haskell.nix as of Jan 16th 2020
, haskell-nix ? import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/e68599b.tar.gz)

# pkgs is nixpkgs with the haskell-nix as agument. But we'll extend haskell-nix to allow adding additional overlays and config values.
, pkgs ? nixpkgs (haskell-nix // {
    inherit system crossSystem;
    overlays = (haskell-nix.overlays or []) ++ overlays;
    config = (haskell-nix.config or {}) // config;
  })
```
I'd much rather write
```nix
{ system ? builtins.currentSystem
, crossSystem ? null
, config ? {}
, overlays ? []
# nixpkgs-19.09-darwin as of Jan 16th 2020
, nixpkgs ? import (builtins.fetchTarball https://github.com/NixOS/nixpkgs-channels/archive/f69a5b2.tar.gz)
# haskell.nix as of Jan 16th 2020
, haskell-nix ? import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/e68599b.tar.gz)

# pkgs is nixpkgs with the haskell-nix as agument. But we'll extend haskell-nix to allow adding additional overlays and config values.
, pkgs ? nixpkgs (haskell-nix.withArgs { inherit system crossSystem config overlays; })
```