### PR TITLE
Add selectProjectPackages

### DIFF
--- a/builder/hspkg-builder.nix
+++ b/builder/hspkg-builder.nix
@@ -65,4 +65,5 @@ in rec {
   inherit (package) identifier detailLevel isLocal;
   inherit setup cabalFile;
   isHaskell = true;
+  inherit src;
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -74,6 +74,11 @@ with haskellLib;
   isLocalPackage = p: p.isLocal or false;
   selectLocalPackages = ps: lib.filterAttrs (n: p: p != null && isLocalPackage p) ps;
 
+  # if it's a project package it has a src attribute set with an origSubDir attribute.
+  # project packages are a subset of localPackages
+  isProjectPackage = p: p ? src && p.src ? origSubDir;
+  selectProjectPackages = ps: lib.filterAttrs (n: p: p != null && isLocalPackage p && isProjectPackage p) ps;
+
   # Format a componentId as it should appear as a target on the
   # command line of the setup script.
   componentTarget = componentId:


### PR DESCRIPTION
We have `isLocalPackage` and `selectLocalPackages`. This should give us really just the packages relative to the project?