### PR TITLE
Fix cleanGit for submodules of submodules

### DIFF
--- a/lib/clean-git.nix
+++ b/lib/clean-git.nix
@@ -108,7 +108,7 @@ then
                               # and use that to filter directory tree here
         ||
           lib.any (i: (lib.hasSuffix i path)) [
-            ".gitmodules" ".git/config" ".git/index" ".git/HEAD" ".git/objects" ".git/refs" ] ||
+            "/.git" ".gitmodules" ".git/config" ".git/index" ".git/HEAD" ".git/objects" ".git/refs" ] ||
           (lib.strings.hasInfix ".git/modules/" path &&
             lib.any (i: (lib.hasSuffix i path)) [
               "config" "index" "HEAD" "objects" "refs" ]);


### PR DESCRIPTION
Repos that have submodules with submodules will have a `.git` file
that references the relative location of the submodules dir in the
`.git/modules`.  Without this file the contents of submodules of
submodules are excluded from the `cleanGit` output.