### PR TITLE
Discuss custom source filters in user guide

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -127,6 +127,16 @@ on using cleanGit](clean-git.md)). For example:
     { src = ./.; subDir = "subdir/another-subdir"; };
 ```
 
+If you want to use a custom filtering function, don't use the built-in nix `filterSource` function.
+Due to some technicalities about how filtering and the nix store work, it will cause all components in
+your project to be rebuilt any time any part of the project source changes. Use `cleanSourceWith` instead:
+
+```
+  src = pkgs.haskell-nix.haskellLib.cleanSourceWith
+    { src = ./.; filter = myFilterFunction; };
+```
+
+Note that `cleanSourceWith` will also take the `subDir` argument.
 
 You can build a component from your project with `nix-build` (in this
 case the `hello` executable in a `helloworld` package):


### PR DESCRIPTION
I ran into a case where every component in my very large monorepo would rebuild if any part of the monorepo changed. The issue turned out to be that I was using `builtins.filterSource` to filter my repo with a custom filtering function before passing it as the `src` argument to `stackProject`. Here I add to the user guide. discussing how and why to use `cleanSourceWith` from `haskell-nix.haskellLib` instead, as it composes nicely with the built-in source filtering, and allows for different source directories for each package.