### PR TITLE
Fix iserv-proxy on GHC 8.4

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -73,6 +73,7 @@ in {
                 ++ self.lib.optional (versionOlder "8.6.4")                           ./patches/ghc/MR95--ghc-pkg-deadlock-fix.patch
 
                 # Patches for which we only know a lower bound.
+                ++ self.lib.optional (versionAtLeast "8.4" && versionOlder "8.6")     ./patches/ghc/iserv-proxy-cleanup-8.4.2.patch                       # same as below
                 ++ self.lib.optional (versionAtLeast "8.6")                           ./patches/ghc/iserv-proxy-cleanup.patch                             # https://gitlab.haskell.org/ghc/ghc/merge_requests/250  -- merged; ghc-8.8.1
                 ++ self.lib.optional (versionAtLeast "8.2")                           ./patches/ghc/MR545--ghc-pkg-databases.patch                        # https://gitlab.haskell.org/ghc/ghc/merge_requests/545  -- merged; ghc-8.8.1
                 ++ self.lib.optional (versionAtLeast "8.6")                           ./patches/ghc/outputtable-assert-8.6.patch

--- a/overlays/patches/ghc/iserv-proxy-cleanup-8.4.2.patch
+++ b/overlays/patches/ghc/iserv-proxy-cleanup-8.4.2.patch
@@ -1,0 +1,907 @@
+diff --git a/configure.ac b/configure.ac
+index b74938f7da..37af991bbd 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1308,7 +1308,7 @@ checkMake380() {
+ checkMake380 make
+ checkMake380 gmake
+ 
+-AC_CONFIG_FILES([mk/config.mk mk/install.mk mk/project.mk rts/rts.cabal compiler/ghc.cabal ghc/ghc-bin.cabal utils/runghc/runghc.cabal utils/gen-dll/gen-dll.cabal libraries/ghc-boot/ghc-boot.cabal libraries/ghc-boot-th/ghc-boot-th.cabal libraries/ghci/ghci.cabal settings docs/users_guide/ghc_config.py docs/index.html libraries/prologue.txt distrib/configure.ac])
++AC_CONFIG_FILES([mk/config.mk mk/install.mk mk/project.mk rts/rts.cabal compiler/ghc.cabal ghc/ghc-bin.cabal utils/iserv/iserv.cabal utils/iserv-proxy/iserv-proxy.cabal utils/remote-iserv/remote-iserv.cabal utils/runghc/runghc.cabal utils/gen-dll/gen-dll.cabal libraries/ghc-boot/ghc-boot.cabal libraries/ghc-boot-th/ghc-boot-th.cabal libraries/ghci/ghci.cabal libraries/libiserv/libiserv.cabal settings docs/users_guide/ghc_config.py docs/index.html libraries/prologue.txt distrib/configure.ac])
+ AC_OUTPUT
+ [
+ if test "$print_make_warning" = "true"; then
+diff --git a/docs/users_guide/ghci.rst b/docs/users_guide/ghci.rst
+index 7cda9460ff..5cf33e413a 100644
+--- a/docs/users_guide/ghci.rst
++++ b/docs/users_guide/ghci.rst
+@@ -3243,6 +3243,38 @@ dynamically-linked) from GHC itself.  So for example:
+ This feature is experimental in GHC 8.0.x, but it may become the
+ default in future releases.
+ 
++.. _external-interpreter-proxy:
++
++Running the interpreter on a different host
++-------------------------------------------
++
++When using the flag :ghc-flag:`-fexternal-interpreter` GHC will
++spawn and communicate with the separate process using pipes.  There
++are scenarios (e.g. when cross compiling) where it is favourable to
++have the communication happen over the network. GHC provides two
++utilities for this, which can be found in the ``utils`` directory.
++
++- ``remote-iserv`` needs to be built with the cross compiler to be
++  executed on the remote host. Or in the case of using it on the
++  same host the stage2 compiler will do as well.
++
++- ``iserv-proxy`` needs to be built on the build machine by the
++  build compiler.
++
++After starting ``remote-iserv ⟨tmp_dir⟩ ⟨port⟩`` on the target and
++providing it with a temporary folder (where it will copy the
++necessary libraries to load to) and port it will listen for
++the proxy to connect.
++
++Providing :ghc-flag:`-pgmi /path/to/iserv-proxy`, :ghc-flag:`-pgmo ⟨option⟩`
++and :ghc-flag:`-pgmo ⟨port⟩` in addition to :ghc-flag:`-fexternal-interpreter`
++will then make ghc go through the proxy instead.
++
++There are some limitations when using this. File and process IO
++will be executed on the target. As such packages like git-embed,
++file-embed and others might not behave as expected if the target
++and host do not share the same filesystem.
++
+ .. _ghci-faq:
+ 
+ FAQ and Things To Watch Out For
+diff --git a/libraries/libiserv/libiserv.cabal.in b/libraries/libiserv/libiserv.cabal.in
+new file mode 100644
+index 0000000000..31eaaeb838
+--- /dev/null
++++ b/libraries/libiserv/libiserv.cabal.in
+@@ -0,0 +1,43 @@
++-- WARNING: libiserv.cabal is automatically generated from libiserv.cabal.in by
++-- ../../configure.  Make sure you are editing libiserv.cabal.in, not
++-- libiserv.cabal.
++
++Name: libiserv
++Version: @ProjectVersionMunged@
++Copyright: XXX
++License: BSD3
++License-File: LICENSE
++Author: XXX
++Maintainer: XXX
++Synopsis: Provides shared functionality between iserv and iserv-proxy
++Description:
++Category: Development
++build-type: Simple
++cabal-version: >=1.10
++
++Flag network
++    Description:   Build libiserv with over-the-network support
++    Default:       False
++
++Library
++    Default-Language: Haskell2010
++    Hs-Source-Dirs: src
++    Exposed-Modules: Lib
++                   , GHCi.Utils
++    Build-Depends: base       >= 4   && < 5,
++                   binary     >= 0.7 && < 0.11,
++                   bytestring >= 0.10 && < 0.11,
++                   containers >= 0.5 && < 0.7,
++                   deepseq    >= 1.4 && < 1.5,
++                   ghci       == @ProjectVersionMunged@
++    if flag(network)
++       Exposed-Modules: Remote.Message
++                      , Remote.Slave
++       Build-Depends: network    >= 2.6 && < 2.7,
++                      directory  >= 1.3 && < 1.4,
++                      filepath   >= 1.4 && < 1.5
++
++    if os(windows)
++       Cpp-Options: -DWINDOWS
++   else
++       Build-Depends: unix   >= 2.7 && < 2.9
+diff --git a/libraries/libiserv/src/Lib.hs b/libraries/libiserv/src/Lib.hs
+index 57e65706c3..707966dc2d 100644
+--- a/libraries/libiserv/src/Lib.hs
++++ b/libraries/libiserv/src/Lib.hs
+@@ -10,25 +10,33 @@ import Control.Exception
+ import Control.Monad
+ import Data.Binary
+ 
++import Text.Printf
++import System.Environment (getProgName)
++
+ type MessageHook = Msg -> IO Msg
+ 
++trace :: String -> IO ()
++trace s = getProgName >>= \name -> printf "[%20s] %s\n" name s
++
+ serv :: Bool -> MessageHook -> Pipe -> (forall a .IO a -> IO a) -> IO ()
+ serv verbose hook pipe@Pipe{..} restore = loop
+  where
+   loop = do
++    when verbose $ trace "reading pipe..."
+     Msg msg <- readPipe pipe getMessage >>= hook
+-    discardCtrlC
+ 
+-    when verbose $ putStrLn ("iserv: " ++ show msg)
++    discardCtrlC verbose
++
++    when verbose $ trace ("msg: " ++ (show msg))
+     case msg of
+       Shutdown -> return ()
+-      RunTH st q ty loc -> wrapRunTH $ runTH pipe st q ty loc
+-      RunModFinalizers st qrefs -> wrapRunTH $ runModFinalizerRefs pipe st qrefs
++      RunTH st q ty loc -> wrapRunTH verbose $ runTH pipe st q ty loc
++      RunModFinalizers st qrefs -> wrapRunTH verbose $ runModFinalizerRefs pipe st qrefs
+       _other -> run msg >>= reply
+ 
+   reply :: forall a. (Binary a, Show a) => a -> IO ()
+   reply r = do
+-    when verbose $ putStrLn ("iserv: return: " ++ show r)
++    when verbose $ trace ("writing pipe: " ++ show r)
+     writePipe pipe (put r)
+     loop
+ 
+@@ -36,36 +44,43 @@ serv verbose hook pipe@Pipe{..} restore = loop
+   -- THMessage requests, and then finally send RunTHDone followed by a
+   -- QResult.  For an overview of how TH works with Remote GHCi, see
+   -- Note [Remote Template Haskell] in libraries/ghci/GHCi/TH.hs.
+-  wrapRunTH :: forall a. (Binary a, Show a) => IO a -> IO ()
+-  wrapRunTH io = do
+-    r <- try io
++  wrapRunTH :: forall a. (Binary a, Show a) => Bool -> IO a -> IO ()
++  wrapRunTH verbose io = do
++    when verbose $ trace "wrapRunTH..."
++    r <- Right <$> io -- try io
++    when verbose $ trace "wrapRunTH done."
++    when verbose $ trace "writing RunTHDone."
+     writePipe pipe (putTHMessage RunTHDone)
+     case r of
+       Left e
+-        | Just (GHCiQException _ err) <- fromException e  ->
++        | Just (GHCiQException _ err) <- fromException e  -> do
++           when verbose $ trace ("QFail " ++ show err)
+            reply (QFail err :: QResult a)
+         | otherwise -> do
+-           str <- showException e
++           str <- showException verbose e
++           when verbose $ trace ("QException " ++ str)
+            reply (QException str :: QResult a)
+       Right a -> do
+-        when verbose $ putStrLn "iserv: QDone"
++        when verbose $ trace "QDone"
+         reply (QDone a)
+ 
+   -- carefully when showing an exception, there might be other exceptions
+   -- lurking inside it.  If so, we return the inner exception instead.
+-  showException :: SomeException -> IO String
+-  showException e0 = do
++  showException :: Bool -> SomeException -> IO String
++  showException verbose e0 = do
++     when verbose $ trace "showException"
+      r <- try $ evaluate (force (show (e0::SomeException)))
+      case r of
+-       Left e -> showException e
++       Left e -> showException verbose e
+        Right str -> return str
+ 
+   -- throw away any pending ^C exceptions while we're not running
+   -- interpreted code.  GHC will also get the ^C, and either ignore it
+   -- (if this is GHCi), or tell us to quit with a Shutdown message.
+-  discardCtrlC = do
++  discardCtrlC verbose = do
++    when verbose $ trace "discardCtrlC"
+     r <- try $ restore $ return ()
+     case r of
+-      Left UserInterrupt -> return () >> discardCtrlC
++      Left UserInterrupt -> return () >> discardCtrlC verbose
+       Left e -> throwIO e
+       _ -> return ()
+diff --git a/libraries/libiserv/src/Remote/Slave.hs b/libraries/libiserv/src/Remote/Slave.hs
+index 701e7d24c9..a9b2fb7e41 100644
+--- a/libraries/libiserv/src/Remote/Slave.hs
++++ b/libraries/libiserv/src/Remote/Slave.hs
+@@ -25,6 +25,11 @@ import GHC.Fingerprint (getFileHash)
+ 
+ import qualified Data.ByteString as BS
+ 
++import Text.Printf
++import System.Environment (getProgName)
++
++trace :: String -> IO ()
++trace s = getProgName >>= \name -> printf "[%20s] %s\n" name s
+ 
+ dropLeadingPathSeparator :: FilePath -> FilePath
+ dropLeadingPathSeparator p | isAbsolute p = joinPath (drop 1 (splitPath p))
+@@ -43,9 +48,8 @@ foreign export ccall startSlave :: Bool -> Int -> CString -> IO ()
+ -- start the slave process, and runs iserv.
+ startSlave :: Bool -> Int -> CString -> IO ()
+ startSlave verbose port s = do
+-  putStr "DocRoot: "
+   base_path <- peekCString s
+-  putStrLn base_path
++  trace $ "DocRoot: " ++ base_path
+   _ <- forkIO $ startSlave' verbose base_path (toEnum port)
+   return ()
+ 
+@@ -54,16 +58,18 @@ startSlave verbose port s = do
+ -- slave process.
+ startSlave' :: Bool -> String -> PortNumber -> IO ()
+ startSlave' verbose base_path port = do
++  hSetBuffering stdin LineBuffering
++  hSetBuffering stdout LineBuffering
+ 
+   sock <- openSocket port
+ 
+   forever $ do
+-    when verbose $ putStrLn "Opening socket"
++    when verbose $ trace "Opening socket"
+     pipe <- acceptSocket sock >>= socketToPipe
+     putStrLn $ "Listening on port " ++ show port
+-    when verbose $ putStrLn "Starting serv"
++    when verbose $ trace "Starting serv"
+     uninterruptibleMask $ serv verbose (hook verbose base_path pipe) pipe
+-    when verbose $ putStrLn "serv ended"
++    when verbose $ trace "serv ended"
+     return ()
+ 
+ -- | The iserv library may need access to files, specifically
+@@ -118,7 +124,9 @@ hook verbose base_path pipe m = case m of
+   -- when loading DLLs (.so, .dylib, .dll, ...) and these are provided
+   -- as relative paths, the intention is to load a pre-existing system library,
+   -- therefore we hook the LoadDLL call only for absolute paths to ship the
+-  -- dll from the host to the target.
++  -- dll from the host to the target.  On windows we assume that we don't
++  -- want to copy libraries that are referenced in C:\ these are usually
++  -- system libraries.
+   Msg (LoadDLL path@('C':':':_)) -> do
+     when verbose $ putStrLn ("Need DLL: " ++ path)
+     return $ Msg (LoadDLL path)
+diff --git a/utils/iserv-proxy/Makefile b/utils/iserv-proxy/Makefile
+index f160978c19..dec92996f7 100644
+--- a/utils/iserv-proxy/Makefile
++++ b/utils/iserv-proxy/Makefile
+@@ -10,6 +10,6 @@
+ #
+ # -----------------------------------------------------------------------------
+ 
+-dir = iserv
+-TOP = ..
++dir = iserv-proxy
++TOP = ../..
+ include $(TOP)/mk/sub-makefile.mk
+diff --git a/utils/iserv-proxy/iserv-proxy.cabal b/utils/iserv-proxy/iserv-proxy.cabal
+deleted file mode 100644
+index 0ab0cfcff2..0000000000
+--- a/utils/iserv-proxy/iserv-proxy.cabal
++++ /dev/null
+@@ -1,78 +0,0 @@
+-Name: iserv-proxy
+-Version: 8.5
+-Copyright: XXX
+-License: BSD3
+--- XXX License-File: LICENSE
+-Author: XXX
+-Maintainer: XXX
+-Synopsis: iserv allows GHC to delegate Tempalte Haskell computations
+-Description:
+-  GHC can be provided with a path to the iserv binary with
+-  @-pgmi=/path/to/iserv-bin@, and will in combination with
+-  @-fexternal-interpreter@, compile Template Haskell though the
+-  @iserv-bin@ delegate. This is very similar to how ghcjs has been
+-  compiling Template Haskell, by spawning a separate delegate (so
+-  called runner on the javascript vm) and evaluating the splices
+-  there.
+-  .
+-  iserv can also be used in combination with cross compilation. For
+-  this, the @iserv-proxy@ needs to be built on the host, targeting the
+-  host (as it is running on the host). @cabal install -flibrary
+-  -fproxy@ will yield the proxy.
+-  .
+-  Using the cabal for the target @arch-platform-target-cabal install
+-  -flibrary@ will build the required library that contains the ffi
+-  @startSlave@ function, which needs to be invoked on the target
+-  (e.g. in an iOS application) to start the remote iserv slave.
+-  .
+-  calling the GHC cross compiler with @-fexternal-interpreter
+-  -pgmi=$HOME/.cabal/bin/iserv-proxy -opti\<ip address\> -opti\<port\>@
+-  will cause it to compile Template Haskell via the remote at \<ip address\>.
+-  .
+-  Thus to get cross compilation with Template Haskell follow the
+-  following receipt:
+-  .
+-  * compile the iserv library for your target
+-  .
+-      > iserv $ arch-platform-target-cabal install -flibrary
+-  .
+-  * setup an application for your target that calls the
+-  * startSlave function. This could be either haskell or your
+-  * targets ffi capable language, if needed.
+-  .
+-      >  void startSlave(false /* verbose */, 5000 /* port */,
+-      >                  "/path/to/storagelocation/on/target");
+-  .
+-  * build the iserv-proxy
+-  .
+-      > iserv $ cabal install -flibrary -fproxy
+-  * Start your iserv-slave app on your target running on say @10.0.0.1:5000@
+-  * compiler your sources with -fexternal-interpreter and the proxy
+-  .
+-      > project $ arch-platform-target-ghc ModuleContainingTH.hs \
+-      >             -fexternal-interpreter \
+-      >             -pgmi=$HOME/.cabal/bin/iserv-proxy \
+-      >             -opti10.0.0.1 -opti5000
+-  .
+-  Should something not work as expected, provide @-opti-v@ for verbose
+-  logging of the @iserv-proxy@.
+-
+-Category: Development
+-build-type: Simple
+-cabal-version: >=1.10
+-
+-Executable iserv-proxy
+-   Default-Language: Haskell2010
+-   Main-Is: Main.hs
+-   Hs-Source-Dirs: src
+-   Build-Depends: array      >= 0.5 && < 0.6,
+-                  base       >= 4   && < 5,
+-                  binary     >= 0.7 && < 0.9,
+-                  bytestring >= 0.10 && < 0.11,
+-                  containers >= 0.5 && < 0.6,
+-                  deepseq    >= 1.4 && < 1.5,
+-                  ghci       == 8.4.*,
+-                  directory  >= 1.3 && < 1.4,
+-                  network    >= 2.6,
+-                  filepath   >= 1.4 && < 1.5,
+-                  libiserv   == 8.4
+diff --git a/utils/iserv-proxy/iserv-proxy.cabal.in b/utils/iserv-proxy/iserv-proxy.cabal.in
+new file mode 100644
+index 0000000000..0819064601
+--- /dev/null
++++ b/utils/iserv-proxy/iserv-proxy.cabal.in
+@@ -0,0 +1,82 @@
++-- WARNING: iserv-proxy.cabal is automatically generated from iserv-proxy.cabal.in by
++-- ../../configure.  Make sure you are editing iserv-proxy.cabal.in, not
++-- iserv-proxy.cabal.
++
++Name: iserv-proxy
++Version: @ProjectVersion@
++Copyright: XXX
++License: BSD3
++-- XXX License-File: LICENSE
++Author: XXX
++Maintainer: XXX
++Synopsis: iserv allows GHC to delegate Tempalte Haskell computations
++Description:
++  GHC can be provided with a path to the iserv binary with
++  @-pgmi=/path/to/iserv-bin@, and will in combination with
++  @-fexternal-interpreter@, compile Template Haskell though the
++  @iserv-bin@ delegate. This is very similar to how ghcjs has been
++  compiling Template Haskell, by spawning a separate delegate (so
++  called runner on the javascript vm) and evaluating the splices
++  there.
++  .
++  iserv can also be used in combination with cross compilation. For
++  this, the @iserv-proxy@ needs to be built on the host, targeting the
++  host (as it is running on the host). @cabal install -flibrary
++  -fproxy@ will yield the proxy.
++  .
++  Using the cabal for the target @arch-platform-target-cabal install
++  -flibrary@ will build the required library that contains the ffi
++  @startSlave@ function, which needs to be invoked on the target
++  (e.g. in an iOS application) to start the remote iserv slave.
++  .
++  calling the GHC cross compiler with @-fexternal-interpreter
++  -pgmi=$HOME/.cabal/bin/iserv-proxy -opti\<ip address\> -opti\<port\>@
++  will cause it to compile Template Haskell via the remote at \<ip address\>.
++  .
++  Thus to get cross compilation with Template Haskell follow the
++  following receipt:
++  .
++  * compile the iserv library for your target
++  .
++      > iserv $ arch-platform-target-cabal install -flibrary
++  .
++  * setup an application for your target that calls the
++  * startSlave function. This could be either haskell or your
++  * targets ffi capable language, if needed.
++  .
++      >  void startSlave(false /* verbose */, 5000 /* port */,
++      >                  "/path/to/storagelocation/on/target");
++  .
++  * build the iserv-proxy
++  .
++      > iserv $ cabal install -flibrary -fproxy
++  * Start your iserv-slave app on your target running on say @10.0.0.1:5000@
++  * compiler your sources with -fexternal-interpreter and the proxy
++  .
++      > project $ arch-platform-target-ghc ModuleContainingTH.hs \
++      >             -fexternal-interpreter \
++      >             -pgmi=$HOME/.cabal/bin/iserv-proxy \
++      >             -opti10.0.0.1 -opti5000
++  .
++  Should something not work as expected, provide @-opti-v@ for verbose
++  logging of the @iserv-proxy@.
++
++Category: Development
++build-type: Simple
++cabal-version: >=1.10
++
++Executable iserv-proxy
++   Default-Language: Haskell2010
++   Main-Is: Main.hs
++   Hs-Source-Dirs: src
++   Build-Depends: array      >= 0.5 && < 0.6,
++                  base       >= 4   && < 5,
++                  binary     >= 0.7 && < 0.9,
++                  bytestring >= 0.10 && < 0.11,
++                  containers >= 0.5 && < 0.6,
++                  deepseq    >= 1.4 && < 1.5,
++                  directory  >= 1.3 && < 1.4,
++                  network    >= 2.6,
++                  filepath   >= 1.4 && < 1.5,
++                  ghci       == @ProjectVersionMunged@,
++                  libiserv   == @ProjectVersionMunged@
+diff --git a/utils/iserv-proxy/src/Main.hs b/utils/iserv-proxy/src/Main.hs
+index c91b2d08c6..3970ad5df1 100644
+--- a/utils/iserv-proxy/src/Main.hs
++++ b/utils/iserv-proxy/src/Main.hs
+@@ -1,4 +1,4 @@
+-{-# LANGUAGE CPP, GADTs, OverloadedStrings #-}
++{-# LANGUAGE CPP, GADTs, OverloadedStrings, LambdaCase #-}
+ 
+ {-
+ This is the proxy portion of iserv.
+@@ -65,6 +65,12 @@ import System.FilePath (isAbsolute)
+ import Data.Binary
+ import qualified Data.ByteString as BS
+ 
++import Control.Concurrent (threadDelay)
++import qualified Control.Exception as E
++
++trace :: String -> IO ()
++trace s = getProgName >>= \name -> printf "[%20s] %s\n" name s
++
+ dieWithUsage :: IO a
+ dieWithUsage = do
+     prog <- getProgName
+@@ -78,6 +84,9 @@ dieWithUsage = do
+ 
+ main :: IO ()
+ main = do
++  hSetBuffering stdin LineBuffering
++  hSetBuffering stdout LineBuffering
++
+   args <- getArgs
+   (wfd1, rfd2, host_ip, port, rest) <-
+       case args of
+@@ -104,10 +113,16 @@ main = do
+   let in_pipe = Pipe{pipeRead = inh, pipeWrite = outh, pipeLeftovers = lo_ref}
+ 
+   when verbose $
+-    putStrLn ("Trying to connect to " ++ host_ip ++ ":" ++ (show port))
+-  out_pipe <- connectTo host_ip port >>= socketToPipe
++    trace ("Trying to connect to " ++ host_ip ++ ":" ++ (show port))
+ 
+-  putStrLn "Starting proxy"
++  out_pipe <- do
++    let go n = E.try (connectTo host_ip port >>= socketToPipe) >>= \case
++          Left e | n == 0 -> E.throw (e :: E.SomeException)
++                 | n >  0 -> threadDelay 500000 >> go (n - 1)
++          Right a -> return a
++      in go 120 -- wait for up to 60seconds (polling every 0.5s).
++
++  trace "Starting proxy"
+   proxy verbose in_pipe out_pipe
+ 
+ -- | A hook, to transform outgoing (proxy -> slave)
+@@ -131,19 +146,24 @@ fwdTHMsg local msg = do
+ -- | Fowarard a @Message@ call and handle @THMessages@.
+ fwdTHCall :: (Binary a) => Bool -> Pipe -> Pipe -> Message a -> IO a
+ fwdTHCall verbose local remote msg = do
++  when verbose $ trace ("fwdTHCall: " ++ show msg)
+   writePipe remote (putMessage msg)
+   -- wait for control instructions
++  when verbose $ trace "waiting for control instructions..."
+   loopTH
++  when verbose $ trace "reading remote pipe result"
+   readPipe remote get
+     where
+       loopTH :: IO ()
+       loopTH = do
++        when verbose $
++          trace "fwdTHCall/loopTH: reading remote pipe..."
+         THMsg msg' <- readPipe remote getTHMessage
+         when verbose $
+-          putStrLn ("| TH Msg: ghc <- proxy -- slave: " ++ show msg')
++          trace ("| TH Msg: ghc <- proxy -- slave: " ++ show msg')
+         res <- fwdTHMsg local msg'
+         when verbose $
+-          putStrLn ("| Resp.:  ghc -- proxy -> slave: " ++ show res)
++          trace ("| Resp.:  ghc -- proxy -> slave: " ++ show res)
+         writePipe remote (put res)
+         case msg' of
+           RunTHDone -> return ()
+@@ -161,8 +181,10 @@ fwdTHCall verbose local remote msg = do
+ --
+ fwdLoadCall :: (Binary a, Show a) => Bool -> Pipe -> Pipe -> Message a -> IO a
+ fwdLoadCall verbose _ remote msg = do
++  when verbose $ trace "fwdLoadCall: writing remote pipe"
+   writePipe remote (putMessage msg)
+   loopLoad
++  when verbose $ trace "fwdLoadCall: reading local pipe"
+   readPipe remote get
+   where
+     truncateMsg :: Int -> String -> String
+@@ -171,17 +193,19 @@ fwdLoadCall verbose _ remote msg = do
+     reply :: (Binary a, Show a) => a -> IO ()
+     reply m = do
+       when verbose $
+-        putStrLn ("| Resp.:         proxy -> slave: "
++        trace ("| Resp.:         proxy -> slave: "
+                   ++ truncateMsg 80 (show m))
+       writePipe remote (put m)
+     loopLoad :: IO ()
+     loopLoad = do
++      when verbose $ trace "fwdLoadCall: reading remote pipe"
+       SlaveMsg msg' <- readPipe remote getSlaveMessage
+       when verbose $
+-        putStrLn ("| Sl Msg:        proxy <- slave: " ++ show msg')
++        trace ("| Sl Msg:        proxy <- slave: " ++ show msg')
+       case msg' of
+         Done -> return ()
+         Missing path -> do
++          trace $ "fwdLoadCall: missing path: " ++ path
+           reply =<< BS.readFile path
+           loopLoad
+         Have path remoteHash -> do
+@@ -198,21 +222,33 @@ proxy verbose local remote = loop
+   where
+     fwdCall :: (Binary a, Show a) => Message a -> IO a
+     fwdCall msg = do
++      when verbose $ trace "proxy/fwdCall: writing remote pipe"
+       writePipe remote (putMessage msg)
++      when verbose $ trace "proxy/fwdCall: reading remote pipe"
+       readPipe remote get
+ 
+     -- reply to ghc.
+     reply :: (Show a, Binary a) => a -> IO ()
+     reply msg = do
+       when verbose $
+-        putStrLn ("Resp.:    ghc <- proxy -- slave: " ++ show msg)
++        trace ("Resp.:    ghc <- proxy -- slave: " ++ show msg)
+       writePipe local (put msg)
+ 
+     loop = do
+       (Msg msg) <- readPipe local getMessage
+       when verbose $
+-        putStrLn ("Msg:      ghc -- proxy -> slave: " ++ show msg)
++        trace ("Msg:      ghc -- proxy -> slave: " ++ show msg)
+       (Msg msg') <- hook (Msg msg)
++      -- Note [proxy-communication]
++      --
++      -- The fwdTHCall/fwdLoadCall/fwdCall's have to match up
++      -- with their endpoints in libiserv:Remote.Slave otherwise
++      -- you will end up with hung connections.
++      --
++      -- We are intercepting some calls between ghc and iserv
++      -- and augment the protocol here.  Thus these two sides
++      -- need to line up and know what request/reply to expect.
++      --
+       case msg' of
+         -- TH might send some message back to ghc.
+         RunTH{} -> do
+@@ -233,6 +269,10 @@ proxy verbose local remote = loop
+           resp <- fwdLoadCall verbose local remote msg'
+           reply resp
+           loop
++        -- On windows we assume that we don't want to copy libraries
++        -- that are referenced in C:\ these are usually system libraries.
++        LoadDLL path@('C':':':_) -> do
++          fwdCall msg' >>= reply >> loop
+         LoadDLL path | isAbsolute path -> do
+           resp <- fwdLoadCall verbose local remote msg'
+           reply resp
+@@ -243,14 +283,19 @@ proxy verbose local remote = loop
+ 
+ connectTo :: String -> PortNumber -> IO Socket
+ connectTo host port = do
+-  let hints = defaultHints { addrFlags = [AI_NUMERICHOST, AI_NUMERICSERV]
+-                           , addrSocketType = Stream }
+-  addr:_ <- getAddrInfo (Just hints) (Just host) (Just (show port))
+-  sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
+-  putStrLn $ "Created socket for " ++ host ++ ":" ++ show port
+-  connect sock (addrAddress addr)
+-  putStrLn "connected"
+-  return sock
++  addr <- resolve host (show port)
++  open addr
++  where
++    resolve host port = do
++        let hints = defaultHints { addrSocketType = Stream }
++        addr:_ <- getAddrInfo (Just hints) (Just host) (Just port)
++        return addr
++    open addr = do
++        sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
++        trace $ "Created socket for " ++ host ++ ":" ++ show port
++        connect sock $ addrAddress addr
++        trace "connected"
++        return sock
+ 
+ -- | Turn a socket into an unbuffered pipe.
+ socketToPipe :: Socket -> IO Pipe
+diff --git a/utils/iserv/iserv.cabal.in b/utils/iserv/iserv.cabal.in
+new file mode 100644
+index 0000000000..356c8a444a
+--- /dev/null
++++ b/utils/iserv/iserv.cabal.in
+@@ -0,0 +1,48 @@
++-- WARNING: iserv.cabal is automatically generated from iserv.cabal.in by
++-- ../../configure.  Make sure you are editing iserv.cabal.in, not
++-- iserv.cabal.
++
++Name: iserv
++Version: @ProjectVersion@
++Copyright: XXX
++License: BSD3
++-- XXX License-File: LICENSE
++Author: XXX
++Maintainer: XXX
++Synopsis: iserv allows GHC to delegate Template Haskell computations
++Description:
++  GHC can be provided with a path to the iserv binary with
++  @-pgmi=/path/to/iserv-bin@, and will in combination with
++  @-fexternal-interpreter@, compile Template Haskell though the
++  @iserv-bin@ delegate. This is very similar to how ghcjs has been
++  compiling Template Haskell, by spawning a separate delegate (so
++  called runner on the javascript vm) and evaluating the splices
++  there.
++  .
++  To use iserv with cross compilers, please see @libraries/libiserv@
++  and @utils/iserv-proxy@.
++
++Category: Development
++build-type: Simple
++cabal-version: >=1.10
++
++Executable iserv
++    Default-Language: Haskell2010
++    ghc-options: -no-hs-main
++    Main-Is: Main.hs
++    C-Sources: cbits/iservmain.c
++    Hs-Source-Dirs: src
++    include-dirs: .
++    Build-Depends: array      >= 0.5 && < 0.6,
++                   base       >= 4   && < 5,
++                   binary     >= 0.7 && < 0.11,
++                   bytestring >= 0.10 && < 0.11,
++                   containers >= 0.5 && < 0.7,
++                   deepseq    >= 1.4 && < 1.5,
++                   ghci       == @ProjectVersionMunged@,
++                   libiserv   == @ProjectVersionMunged@
++
++    if os(windows)
++        Cpp-Options: -DWINDOWS
++    else
++        Build-Depends: unix   >= 2.7 && < 2.9
+diff --git a/utils/remote-iserv/Makefile b/utils/remote-iserv/Makefile
+new file mode 100644
+index 0000000000..c659a21a20
+--- /dev/null
++++ b/utils/remote-iserv/Makefile
+@@ -0,0 +1,15 @@
++# -----------------------------------------------------------------------------
++#
++# (c) 2009 The University of Glasgow
++#
++# This file is part of the GHC build system.
++#
++# To understand how the build system works and how to modify it, see
++#      http://ghc.haskell.org/trac/ghc/wiki/Building/Architecture
++#      http://ghc.haskell.org/trac/ghc/wiki/Building/Modifying
++#
++# -----------------------------------------------------------------------------
++
++dir = remote-iserv
++TOP = ../..
++include $(TOP)/mk/sub-makefile.mk
+diff --git a/utils/remote-iserv/Setup.hs b/utils/remote-iserv/Setup.hs
+new file mode 100644
+index 0000000000..44671092b2
+--- /dev/null
++++ b/utils/remote-iserv/Setup.hs
+@@ -0,0 +1,2 @@
++import           Distribution.Simple
++main = defaultMain
+diff --git a/utils/remote-iserv/ghc.mk b/utils/remote-iserv/ghc.mk
+new file mode 100644
+index 0000000000..db8f32fc22
+--- /dev/null
++++ b/utils/remote-iserv/ghc.mk
+@@ -0,0 +1,113 @@
++# -----------------------------------------------------------------------------
++#
++# (c) 2009-2012 The University of Glasgow
++#
++# This file is part of the GHC build system.
++#
++# To understand how the build system works and how to modify it, see
++#      http://ghc.haskell.org/trac/ghc/wiki/Building/Architecture
++#      http://ghc.haskell.org/trac/ghc/wiki/Building/Modifying
++#
++# -----------------------------------------------------------------------------
++
++utils/remote-iserv_USES_CABAL = YES
++utils/remote-iserv_PACKAGE = remote-iserv
++utils/remote-iserv_EXECUTABLE = remote-iserv
++
++ifeq "$(GhcDebugged)" "YES"
++utils/remote-iserv_stage2_MORE_HC_OPTS += -debug
++utils/remote-iserv_stage2_p_MORE_HC_OPTS += -debug
++utils/remote-iserv_stage2_dyn_MORE_HC_OPTS += -debug
++endif
++
++ifeq "$(GhcThreaded)" "YES"
++utils/remote-iserv_stage2_MORE_HC_OPTS += -threaded
++utils/remote-iserv_stage2_p_MORE_HC_OPTS += -threaded
++utils/remote-iserv_stage2_dyn_MORE_HC_OPTS += -threaded
++endif
++
++# Add -Wl,--export-dynamic enables GHCi to load dynamic objects that
++# refer to the RTS.  This is harmless if you don't use it (adds a bit
++# of overhead to startup and increases the binary sizes) but if you
++# need it there's no alternative.
++ifeq "$(TargetElf)" "YES"
++ifneq "$(TargetOS_CPP)" "solaris2"
++# The Solaris linker does not support --export-dynamic option. It also
++# does not need it since it exports all dynamic symbols by default
++utils/remote-iserv_stage2_MORE_HC_OPTS += -optl-Wl,--export-dynamic
++utils/remote-iserv_stage2_p_MORE_HC_OPTS += -optl-Wl,--export-dynamic
++utils/remote-iserv_stage2_dyn_MORE_HC_OPTS += -optl-Wl,--export-dynamic
++endif
++endif
++
++# Override the default way, because we want a specific version of this
++# program for each way.  Note that it's important to do this even for
++# the vanilla version, otherwise we get a dynamic executable when
++# DYNAMIC_GHC_PROGRAMS=YES.
++utils/remote-iserv_stage2_PROGRAM_WAY = v
++utils/remote-iserv_stage2_p_PROGRAM_WAY = p
++utils/remote-iserv_stage2_dyn_PROGRAM_WAY = dyn
++
++utils/remote-iserv_stage2_PROGNAME = ghc-iserv
++utils/remote-iserv_stage2_p_PROGNAME = ghc-iserv-prof
++utils/remote-iserv_stage2_dyn_PROGNAME = ghc-iserv-dyn
++
++utils/remote-iserv_stage2_MORE_HC_OPTS += -no-hs-main
++utils/remote-iserv_stage2_p_MORE_HC_OPTS += -no-hs-main
++utils/remote-iserv_stage2_dyn_MORE_HC_OPTS += -no-hs-main
++
++utils/remote-iserv_stage2_INSTALL = YES
++utils/remote-iserv_stage2_p_INSTALL = YES
++utils/remote-iserv_stage2_dyn_INSTALL = YES
++
++# Install in $(libexec), not in $(bindir)
++utils/remote-iserv_stage2_TOPDIR = YES
++utils/remote-iserv_stage2_p_TOPDIR = YES
++utils/remote-iserv_stage2_dyn_TOPDIR = YES
++
++utils/remote-iserv_stage2_INSTALL_INPLACE = YES
++utils/remote-iserv_stage2_p_INSTALL_INPLACE = YES
++utils/remote-iserv_stage2_dyn_INSTALL_INPLACE = YES
++
++ifeq "$(CLEANING)" "YES"
++
++NEED_iserv = YES
++NEED_iserv_p = YES
++NEED_iserv_dyn = YES
++
++else
++
++ifneq "$(findstring v, $(GhcLibWays))" ""
++NEED_iserv = YES
++else
++NEED_iserv = NO
++endif
++
++ifneq "$(findstring p, $(GhcLibWays))" ""
++NEED_iserv_p = YES
++else
++NEED_iserv_p = NO
++endif
++
++ifneq "$(findstring dyn, $(GhcLibWays))" ""
++NEED_iserv_dyn = YES
++else
++NEED_iserv_dyn = NO
++endif
++endif
++
++ifeq "$(NEED_iserv)" "YES"
++$(eval $(call build-prog,utils/remote-iserv,stage2,1))
++endif
++
++ifeq "$(NEED_iserv_p)" "YES"
++$(eval $(call build-prog,utils/remote-iserv,stage2_p,1))
++endif
++
++ifeq "$(NEED_iserv_dyn)" "YES"
++$(eval $(call build-prog,utils/remote-iserv,stage2_dyn,1))
++endif
++
++all_ghc_stage2 : $(remote-iserv-stage2_INPLACE)
++all_ghc_stage2 : $(remote-iserv-stage2_p_INPLACE)
++all_ghc_stage2 : $(remote-iserv-stage2_dyn_INPLACE)
+diff --git a/utils/remote-iserv/remote-iserv.cabal.in b/utils/remote-iserv/remote-iserv.cabal.in
+new file mode 100644
+index 0000000000..2e9123bf5e
+--- /dev/null
++++ b/utils/remote-iserv/remote-iserv.cabal.in
+@@ -0,0 +1,27 @@
++-- WARNING: iserv-proxy.cabal is automatically generated from iserv-proxy.cabal.in by
++-- ../../configure.  Make sure you are editing iserv-proxy.cabal.in, not
++-- iserv-proxy.cabal.
++
++Name: remote-iserv
++Version: @ProjectVersion@
++Copyright: XXX
++License: BSD3
++-- XXX License-File: LICENSE
++Author: Moritz Angermann <moritz.angermann@gmail.com>
++Maintainer: Moritz Angermann <moritz.angermann@gmail.com>
++Synopsis: iserv allows GHC to delegate Tempalte Haskell computations
++Description:
++  This is a very simple remote runner for iserv, to be used together
++  with iserv-proxy.  The foundamental idea is that this this wrapper
++  starts running libiserv on a given port to which iserv-proxy will
++  then connect.
++Category: Development
++build-type: Simple
++cabal-version: >=1.10
++
++Executable remote-iserv
++   Default-Language: Haskell2010
++   Main-Is: Cli.hs
++   Hs-Source-Dirs: src
++   Build-Depends: base       >= 4   && < 5,
++                  libiserv   == @ProjectVersionMunged@
+diff --git a/utils/remote-iserv/src/Cli.hs b/utils/remote-iserv/src/Cli.hs
+new file mode 100644
+index 0000000000..eb8f92c39c
+--- /dev/null
++++ b/utils/remote-iserv/src/Cli.hs
+@@ -0,0 +1,30 @@
++module Main where
++
++import           Remote.Slave (startSlave')
++import           System.Environment (getArgs, getProgName)
++import           System.Exit (die)
++
++main :: IO ()
++main = getArgs >>= startSlave
++
++dieWithUsage :: IO a
++dieWithUsage = do
++  prog <- getProgName
++  die $ msg prog
++ where
++  msg name = "usage: " ++ name ++ " /path/to/storage PORT [-v]"
++
++startSlave :: [String] -> IO ()
++startSlave args0
++  | "--help" `elem` args0 = dieWithUsage
++  | otherwise = do
++      (path, port, rest) <- case args0 of
++        arg0:arg1:rest -> return (arg0, read arg1, rest)
++        _              -> dieWithUsage
++
++      verbose <- case rest of
++        ["-v"] -> return True
++        []     -> return False
++        _      -> dieWithUsage
++
++      startSlave' verbose path port

--- a/overlays/patches/ghc/move-iserv-8.4.2.patch
+++ b/overlays/patches/ghc/move-iserv-8.4.2.patch
@@ -77,6 +77,43 @@ index 38c165d261..1a99aa3bb0 100644
  SRC_DIST_GHC_FILES += \
      configure.ac config.guess config.sub configure \
      aclocal.m4 README.md ANNOUNCE HACKING.md INSTALL.md LICENSE Makefile \
+diff --git a/libraries/libiserv/LICENSE b/libraries/libiserv/LICENSE
+new file mode 100644
+index 0000000000..6dc323b336
+--- /dev/null
++++ b/libraries/libiserv/LICENSE
+@@ -0,0 +1,31 @@
++The Glasgow Haskell Compiler License
++
++Copyright 2002, The University Court of the University of Glasgow.
++All rights reserved.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are met:
++
++- Redistributions of source code must retain the above copyright notice,
++this list of conditions and the following disclaimer.
++
++- Redistributions in binary form must reproduce the above copyright notice,
++this list of conditions and the following disclaimer in the documentation
++and/or other materials provided with the distribution.
++
++- Neither name of the University nor the names of its contributors may be
++used to endorse or promote products derived from this software without
++specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY COURT OF THE UNIVERSITY OF
++GLASGOW AND THE CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
++INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
++FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
++UNIVERSITY COURT OF THE UNIVERSITY OF GLASGOW OR THE CONTRIBUTORS BE LIABLE
++FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
++SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
++CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
++DAMAGE.
 diff --git a/iserv/Makefile b/libraries/libiserv/Makefile
 similarity index 100%
 rename from iserv/Makefile
@@ -218,16 +255,6 @@ index 0000000000..f160978c19
 +dir = iserv
 +TOP = ..
 +include $(TOP)/mk/sub-makefile.mk
-diff --git a/utils/iserv-proxy/cabal.project b/utils/iserv-proxy/cabal.project
-new file mode 100644
-index 0000000000..2e6cd12dc9
---- /dev/null
-+++ b/utils/iserv-proxy/cabal.project
-@@ -0,0 +1,4 @@
-+packages: . ../../libraries/libiserv
-+
-+package libiserv
-+  flags: +network
 diff --git a/utils/iserv-proxy/ghc.mk b/utils/iserv-proxy/ghc.mk
 new file mode 100644
 index 0000000000..b90a96a1fa
@@ -711,16 +738,6 @@ index 0000000000..c91b2d08c6
 +
 +  lo_ref <- newIORef Nothing
 +  pure Pipe{ pipeRead = hdl, pipeWrite = hdl, pipeLeftovers = lo_ref }
-diff --git a/utils/iserv-slave/cabal.project b/utils/iserv-slave/cabal.project
-new file mode 100644
-index 0000000000..2e6cd12dc9
---- /dev/null
-+++ b/utils/iserv-slave/cabal.project
-@@ -0,0 +1,4 @@
-+packages: . ../../libraries/libiserv
-+
-+package libiserv
-+  flags: +network
 diff --git a/utils/iserv-slave/iserv-slave.cabal b/utils/iserv-slave/iserv-slave.cabal
 new file mode 100644
 index 0000000000..7f82f3d125


### PR DESCRIPTION
Hopefully, fixes #425. See the commit message for details.

I don’t know what the patches actually fix, so I did not test whether they still serve their purpose after my changes, but, at least, things build now.