### PR TITLE
Pass name argument through cleanGit

### DIFF
--- a/lib/clean-git.nix
+++ b/lib/clean-git.nix
@@ -1,6 +1,6 @@
 # From https://github.com/NixOS/nix/issues/2944
 { lib, runCommand, git, cleanSourceWith }:
-{ src, subDir ? "" }:
+{ name ? null, src, subDir ? "" }:
 
 # The function call
 #
@@ -143,12 +143,12 @@ then
     filter = filter_from_list src whitelist;
   in
     cleanSourceWith {
-      inherit src subDir filter;
+      inherit name src subDir filter;
     }
 
 else
   trace "gitSource.nix: ${toString src} does not seem to be a git repository,\nassuming it is a clean checkout." (
     cleanSourceWith {
-      inherit src subDir;
+      inherit name src subDir;
     }
   )


### PR DESCRIPTION
`cleanSourceWith` now accepts a `name` argument, but `cleanGit` doesn't. This PR adds that functionality (it can be used to reduce cache misses).