### PR TITLE
Fix enableShared logic

### DIFF
--- a/overlays/ghc.nix
+++ b/overlays/ghc.nix
@@ -2,7 +2,10 @@ self: super: with super;
   # sadly we need to patch GHC a bit.
    let
     ghcPkgOverrides = {
-        enableShared = super.stdenv.targetPlatform == super.stdenv.hostPlatform;
+        # Required for cross-compilation, otherwise it throws
+        # Failed to load interface for ‘GHC.Integer.Type’
+        # Perhaps you haven't installed the "dyn" libraries for package ‘integer-gmp-1.0.2.0’?
+        enableShared = super.stdenv.buildPlatform == super.stdenv.hostPlatform;
         enableIntegerSimple = false;
       } // lib.optionalAttrs self.stdenv.hostPlatform.isAarch32 {
         enableRelocatableStaticLibs = false;


### PR DESCRIPTION
This PR fixes cross-compilation by correcting `enableShared` logic. See https://github.com/input-output-hk/haskell.nix/issues/378, it describes both the problem and the solution.