### PR TITLE
Link to iohk.cachix.org instead of nix-tools.cachix.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -77,7 +77,7 @@ cabal new-repl your-package-name:library:your-package-name
 CI pushes to [[https://cachix.org][cachix]] so you can benefit from the cache
 if you pin a combination of =haskell.nix= and =nixpkgs= built by CI.
 
-You'll need to configure the [[https://nix-tools.cachix.org][nix-tools cachix]]
+You'll need to configure the [[https://iohk.cachix.org][iohk cachix]]
 as a =substituter= for =nix= and add the public key found at the url to
 =trusted-public-keys=.
 


### PR DESCRIPTION
... like in the big fat warning at the top of the file.