### PR TITLE
Improve collectComponents

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -139,9 +139,18 @@ with haskellLib;
   #     to: tests.mypackage.unit-tests
   #
   collectComponents = group: packageSel: haskellPackages:
-    (lib.mapAttrs (_: package: package.components.${group} // { recurseForDerivations = true; })
-     (lib.filterAttrs (name: package: (package.isHaskell or false) && packageSel package) haskellPackages))
-    // { recurseForDerivations = true; };
+    let packageToComponents = name: package:
+          # look for the components with this group if there are any
+          let components = package.components.${group} or {};
+          # set recurseForDerivations unless it's a derivation itself (e.g. the "library" component) or an empty set
+          in if lib.isDerivation components || components == {}
+             then components
+             else pkgs.recurseIntoAttrs components;
+        packageFilter = name: package: (package.isHaskell or false) && packageSel package;
+        filteredPkgs = lib.filterAttrs packageFilter haskellPackages;
+        # at this point we can filter out packages that don't have any of the given kind of component
+        packagesByComponent = lib.filterAttrs (_: components: components != {}) (lib.mapAttrs packageToComponents filteredPkgs);
+    in pkgs.recurseIntoAttrs packagesByComponent;
 
   # Equivalent to collectComponents with (_: true) as selection function.
   # Useful for pre-filtered package-set.


### PR DESCRIPTION
Fixes #457.

- Components that don't have a library component will no longer break
`collectComponents "library"`.
- Avoid having lots of empty attribute sets.
- Don't set `recurseForDerivations` excessively.