### PR TITLE
Make text-icu build by mapping the dependencies

### DIFF
--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -72,6 +72,9 @@ pkgs:
      boost_wserialization = pkgs.boost;
      tensorflow = pkgs.libtensorflow;
      opencv = pkgs.opencv3;
+     icuuc = pkgs.icu;
+     icui18n = pkgs.icu;
+     icudata = pkgs.icu;
    }
 # -- windows
 // { advapi32 = null; gdi32 = null; imm32 = null; msimg32 = null;


### PR DESCRIPTION
Adds three package mapping so that `text-icu` actually builds.

All three new pkgs map to `icu` just in case.

@maksbotan