### PR TITLE
Update nixpkgs pins

### DIFF
--- a/nixpkgs/github.json
+++ b/nixpkgs/github.json
@@ -1,7 +1,7 @@
 {
-  "url": "https://github.com/input-output-hk/nixpkgs",
-  "rev": "af4c8e76eb9d853b86f3360f23913d0712bbedfa",
-  "date": "2020-03-07T12:26:17+13:00",
-  "sha256": "0rpjvpxykpx7w9r0k9wyfapnvppp79nlsksqyh86jq7y7rzlfz9g",
+  "url": "https://github.com/NixOS/nixpkgs",
+  "rev": "a81842b6994ce710ebad13303fde29438f610e8c",
+  "date": "2020-03-07T09:04:39+01:00",
+  "sha256": "0ch8mnx4iicsh8j6a2a6sgdshbgn6wxhzgf35pnq72avc9pdf2xi",
   "fetchSubmodules": false
 }

--- a/nixpkgs/github.json
+++ b/nixpkgs/github.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/nixpkgs",
-  "rev": "8215f2ee01c56a764416f703c66767404a321d92",
-  "date": "2020-01-25T20:38:55+13:00",
-  "sha256": "0cdmpwpi19354hqvph7mnxrdbphina1vg61fk487i9559bsv545m",
+  "rev": "af4c8e76eb9d853b86f3360f23913d0712bbedfa",
+  "date": "2020-03-07T12:26:17+13:00",
+  "sha256": "0rpjvpxykpx7w9r0k9wyfapnvppp79nlsksqyh86jq7y7rzlfz9g",
   "fetchSubmodules": false
 }

--- a/nixpkgs/release-19.03.json
+++ b/nixpkgs/release-19.03.json
@@ -1,7 +1,7 @@
 {
-  "url": "https://github.com/NixOS/nixpkgs",
-  "rev": "34c7eb7545d155cc5b6f499b23a7cb1c96ab4d59",
-  "date": "2020-02-10T19:09:03-05:00",
-  "sha256": "11z6ajj108fy2q5g8y4higlcaqncrbjm3dnv17pvif6avagw4mcb",
+  "url": "https://github.com/input-output-hk/nixpkgs",
+  "rev": "6ba07b5124ded6a5ceaba18d3374b759075f7817",
+  "date": "2020-03-07T12:28:35+13:00",
+  "sha256": "045y9gyqwayl8llhy4h5xszfga7k2m7gsmpsl50r1k40x9sfxibl",
   "fetchSubmodules": false
 }

--- a/nixpkgs/release-19.03.json
+++ b/nixpkgs/release-19.03.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/nixpkgs",
-  "rev": "a8f81dc037a5977414a356dd068f2621b3c89b60",
-  "date": "2019-10-17T21:54:56+08:00",
-  "sha256": "01z13axll5g5yl00lz9adr2jw2bs12g9skhbb1vxy8p7fjjbhhhm",
+  "rev": "6ba07b5124ded6a5ceaba18d3374b759075f7817",
+  "date": "2020-03-07T12:28:35+13:00",
+  "sha256": "045y9gyqwayl8llhy4h5xszfga7k2m7gsmpsl50r1k40x9sfxibl",
   "fetchSubmodules": false
 }

--- a/nixpkgs/release-19.03.json
+++ b/nixpkgs/release-19.03.json
@@ -1,7 +1,7 @@
 {
-  "url": "https://github.com/input-output-hk/nixpkgs",
-  "rev": "6ba07b5124ded6a5ceaba18d3374b759075f7817",
-  "date": "2020-03-07T12:28:35+13:00",
-  "sha256": "045y9gyqwayl8llhy4h5xszfga7k2m7gsmpsl50r1k40x9sfxibl",
+  "url": "https://github.com/NixOS/nixpkgs",
+  "rev": "34c7eb7545d155cc5b6f499b23a7cb1c96ab4d59",
+  "date": "2020-02-10T19:09:03-05:00",
+  "sha256": "11z6ajj108fy2q5g8y4higlcaqncrbjm3dnv17pvif6avagw4mcb",
   "fetchSubmodules": false
 }

--- a/nixpkgs/release-19.09.json
+++ b/nixpkgs/release-19.09.json
@@ -1,7 +1,7 @@
 {
-  "url": "https://github.com/input-output-hk/nixpkgs",
-  "rev": "af4c8e76eb9d853b86f3360f23913d0712bbedfa",
-  "date": "2020-03-07T12:26:17+13:00",
-  "sha256": "0rpjvpxykpx7w9r0k9wyfapnvppp79nlsksqyh86jq7y7rzlfz9g",
+  "url": "https://github.com/NixOS/nixpkgs",
+  "rev": "a81842b6994ce710ebad13303fde29438f610e8c",
+  "date": "2020-03-07T09:04:39+01:00",
+  "sha256": "0ch8mnx4iicsh8j6a2a6sgdshbgn6wxhzgf35pnq72avc9pdf2xi",
   "fetchSubmodules": false
 }

--- a/nixpkgs/release-19.09.json
+++ b/nixpkgs/release-19.09.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/nixpkgs",
-  "rev": "8215f2ee01c56a764416f703c66767404a321d92",
-  "date": "2020-01-25T20:38:55+13:00",
-  "sha256": "0cdmpwpi19354hqvph7mnxrdbphina1vg61fk487i9559bsv545m",
+  "rev": "af4c8e76eb9d853b86f3360f23913d0712bbedfa",
+  "date": "2020-03-07T12:26:17+13:00",
+  "sha256": "0rpjvpxykpx7w9r0k9wyfapnvppp79nlsksqyh86jq7y7rzlfz9g",
   "fetchSubmodules": false
 }

--- a/overlays/release-19.03.nix
+++ b/overlays/release-19.03.nix
@@ -12,4 +12,30 @@ self: super: super.lib.optionalAttrs (super.lib.versions.majorMinor super.lib.ve
              export TMPDIR=/tmp
            '';
     });
+    openssl = if self.stdenv.hostPlatform.isWindows
+      then let static = false;  # TODO check that it is ok to assume this (or find a way to detect without instanciating perl)
+        in super.openssl.overrideAttrs (attrs: {
+          postInstall = self.stdenv.lib.optionalString (!static) ''
+            # If we're building dynamic libraries, then don't install static
+            # libraries.
+            if [ -n "$(echo $out/lib/*.so $out/lib/*.dylib $out/lib/*.dll)" ]; then
+                rm "$out/lib/"*.a
+            fi
+
+          '' +
+          ''
+            mkdir -p $bin
+            mv $out/bin $bin/
+
+            mkdir $dev
+            mv $out/include $dev/
+
+            # remove dependency on Perl at runtime
+            rm -r $out/etc/ssl/misc
+
+            rmdir $out/etc/ssl/{certs,private}
+          '';
+        postFixup = "";
+      })
+      else super.openssl;
 }

--- a/release.nix
+++ b/release.nix
@@ -2,7 +2,7 @@
 , scrubJobs ? true
 , haskell-nix ? { outPath = ./.; rev = "abcdef"; }
 , nixpkgsArgs ? {}
-, ifdLevel ? 3
+, ifdLevel ? 0
 }:
 
 let defaultNixpkgs = import ./nixpkgs {}; in

--- a/release.nix
+++ b/release.nix
@@ -2,7 +2,7 @@
 , scrubJobs ? true
 , haskell-nix ? { outPath = ./.; rev = "abcdef"; }
 , nixpkgsArgs ? {}
-, ifdLevel ? 2
+, ifdLevel ? 3
 }:
 
 let defaultNixpkgs = import ./nixpkgs {}; in

--- a/release.nix
+++ b/release.nix
@@ -2,7 +2,7 @@
 , scrubJobs ? true
 , haskell-nix ? { outPath = ./.; rev = "abcdef"; }
 , nixpkgsArgs ? {}
-, ifdLevel ? 0
+, ifdLevel ? 1
 }:
 
 let defaultNixpkgs = import ./nixpkgs {}; in

--- a/release.nix
+++ b/release.nix
@@ -2,7 +2,7 @@
 , scrubJobs ? true
 , haskell-nix ? { outPath = ./.; rev = "abcdef"; }
 , nixpkgsArgs ? {}
-, ifdLevel ? 1
+, ifdLevel ? 2
 }:
 
 let defaultNixpkgs = import ./nixpkgs {}; in


### PR DESCRIPTION
This change updates the pins for nixpkgs to the latest upstream `nixpkgs-19.*-darwin` branches.  It also moves the remaining fixes from the `haskell-nix/channels/nixpkgs-19.*-darwin` branches into overlays in haskell.nix.
