### PR TITLE
Fix evaluation of haskellLib.collectComponents

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, haskellLib, runCommand, git, srcOnly }:
+{ stdenv, lib, haskellLib, runCommand, git, recurseIntoAttrs, srcOnly }:
 
 with haskellLib;
 
@@ -145,12 +145,12 @@ with haskellLib;
           # set recurseForDerivations unless it's a derivation itself (e.g. the "library" component) or an empty set
           in if lib.isDerivation components || components == {}
              then components
-             else pkgs.recurseIntoAttrs components;
+             else recurseIntoAttrs components;
         packageFilter = name: package: (package.isHaskell or false) && packageSel package;
         filteredPkgs = lib.filterAttrs packageFilter haskellPackages;
         # at this point we can filter out packages that don't have any of the given kind of component
         packagesByComponent = lib.filterAttrs (_: components: components != {}) (lib.mapAttrs packageToComponents filteredPkgs);
-    in pkgs.recurseIntoAttrs packagesByComponent;
+    in recurseIntoAttrs packagesByComponent;
 
   # Equivalent to collectComponents with (_: true) as selection function.
   # Useful for pre-filtered package-set.

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -59,7 +59,7 @@ self: super: {
 
         # Utility functions for working with the component builder.
         haskellLib = let hl = import ../lib {
-            inherit (self) stdenv lib runCommand srcOnly;
+            inherit (self) stdenv lib runCommand recurseIntoAttrs srcOnly;
             inherit (self.buildPackages) git;
             haskellLib = hl;
         }; in hl;

--- a/package-set.nix
+++ b/package-set.nix
@@ -7,7 +7,7 @@ in pkgs.lib.evalModules {
       _module.args = {
         # this is *not* the hasekllLib from nixpkgs; it is rather our own
         # library from haskell.nix
-        haskellLib = let hl = import ./lib { inherit lib; inherit (pkgs) stdenv runCommand git srcOnly; haskellLib = hl; }; in hl;
+        haskellLib = let hl = import ./lib { inherit lib; inherit (pkgs) stdenv runCommand recurseIntoAttrs git srcOnly; haskellLib = hl; }; in hl;
 
         # The package descriptions depend on pkgs, which are used to resolve system package dependencies
         # as well as pkgconfPkgs, which are used to resolve pkgconfig name to nixpkgs names.  We simply

--- a/test/cabal-22/default.nix
+++ b/test/cabal-22/default.nix
@@ -63,7 +63,7 @@ in recurseIntoAttrs {
 
     meta.platforms = platforms.all;
     passthru = {
-      inherit (packages) project;
+      inherit project;
     };
   };
 }


### PR DESCRIPTION
I was getting evaluation errors from Hydra:

    error: undefined variable 'pkgs' at /nix/store/931zzi6jdgfzn7m9376a1813awvngds0-source/lib/default.nix

Testing manually :slightly_frowning_face: 

```
$ nix repl test/default.nix
Welcome to Nix version 2.4pre7250_94c93437. Type :? for help.

Loading 'test/default.nix'...
Added 26 variables.

nix-repl> pkgs = import ./nixpkgs/default.nix (import ./.)                                            

nix-repl> pkgs.haskell-nix.haskellLib.collectComponents "tests" (p: p.identifier.name == "project") cabal-22.run.project.hsPkgs

nix-repl> tests = pkgs.haskell-nix.haskellLib.collectComponents "tests" (p: true) cabal-22.run.project.hsPkgs

nix-repl> tests.project.unit
«derivation /nix/store/jsid4k4219ags4dqji9d31fyd73z4xqc-project-0.1.0.0-test-unit.drv»
```
