### PR TITLE
Update old-ghc-nix

### DIFF
--- a/compiler/old-ghc-nix/old-ghc-nix.json
+++ b/compiler/old-ghc-nix/old-ghc-nix.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/angerman/old-ghc-nix",
-  "rev": "ee5e7181f681522f075e01a1875228188b03cc8c",
-  "date": "2019-12-08T20:24:29+08:00",
-  "sha256": "0ywvyjvyw9vm0qbf0a7k6zpsrzcz5wa7y16rfcs3wfv36plj3qd5",
+  "rev": "bf640c1a3f55203bb7492a366c6492ff3c211332",
+  "date": "2020-02-27T19:53:36+08:00",
+  "sha256": "050g06911rpmvn66y5lmnszswz17flw3b979imdchc2apji6a1sm",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
To pull in https://github.com/angerman/old-ghc-nix/pull/6.