### PR TITLE
comp-builder: fix for ghcjs

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -70,7 +70,7 @@ let
       "--with-ghc=${ghc.targetPrefix}ghc"
       "--with-ghc-pkg=${ghc.targetPrefix}ghc-pkg"
       "--with-hsc2hs=${ghc.targetPrefix}hsc2hs"
-    ] ++ lib.optionals (stdenv.cc != null)
+    ] ++ lib.optionals (stdenv.hasCC or (stdenv.cc != null))
     ( # CC
       [ "--with-gcc=${stdenv.cc.targetPrefix}cc"
       ] ++


### PR DESCRIPTION
Otherwise, eval fails with error about C compiler.