### PR TITLE
Add 'name' to cleanSource calls in tests

### DIFF
--- a/test/buildable/default.nix
+++ b/test/buildable/default.nix
@@ -5,7 +5,7 @@ with stdenv.lib;
 let
   project = cabalProject' {
     index-state = "2019-04-30T00:00:00Z";
-    src = haskellLib.cleanGit { src = ../..; subDir = "test/buildable"; };
+    src = haskellLib.cleanGit { src = ../..; name = "buildable"; subDir = "test/buildable"; };
     modules = [ { packages.buildable-test.flags.exclude-broken = true; } ];
   };
   packages = project.hsPkgs;

--- a/test/cabal-22/default.nix
+++ b/test/cabal-22/default.nix
@@ -4,7 +4,7 @@ with stdenv.lib;
 
 let
   project = cabalProject' {
-    src = haskellLib.cleanGit { src = ../..; subDir = "test/cabal-22"; };
+    src = haskellLib.cleanGit { src = ../..; name = "cabal22"; subDir = "test/cabal-22"; };
   };
 
   packages = project.hsPkgs;

--- a/test/cabal-simple-prof/default.nix
+++ b/test/cabal-simple-prof/default.nix
@@ -16,7 +16,7 @@ let
   ];
 
   project = cabalProject' {
-    src = haskellLib.cleanGit { src = ../..; subDir = "test/cabal-simple-prof"; };
+    src = haskellLib.cleanGit { src = ../..; name = "cabal-simple-prof"; subDir = "test/cabal-simple-prof"; };
     inherit modules;
   };
 

--- a/test/cabal-simple/default.nix
+++ b/test/cabal-simple/default.nix
@@ -13,7 +13,7 @@ let
   ];
 
   project = cabalProject' {
-    src = haskellLib.cleanGit { src = ../..; subDir = "test/cabal-simple"; };
+    src = haskellLib.cleanGit { src = ../..; name = "cabal-simple"; subDir = "test/cabal-simple"; };
     inherit modules;
   };
 

--- a/test/cabal-sublib/default.nix
+++ b/test/cabal-sublib/default.nix
@@ -14,7 +14,7 @@ let
 
   # The ./pkgs.nix works for linux & darwin, but not for windows
   project = cabalProject' {
-    src = haskellLib.cleanGit { src = ../..; subDir = "test/cabal-sublib"; };
+    src = haskellLib.cleanGit { src = ../..; name = "cabal-sublib"; subDir = "test/cabal-sublib"; };
     inherit modules;
   };
 

--- a/test/setup-deps/default.nix
+++ b/test/setup-deps/default.nix
@@ -5,7 +5,7 @@ with stdenv.lib;
 
 let
   project = haskell-nix.cabalProject' {
-    src = pkgs.haskell-nix.haskellLib.cleanGit { src = ../..; subDir = "test/setup-deps"; };
+    src = pkgs.haskell-nix.haskellLib.cleanGit { src = ../..; name = "setup-deps"; subDir = "test/setup-deps"; };
     modules = [{
       # Package has no exposed modules which causes
       #   haddock: No input file(s)


### PR DESCRIPTION
Otherwise we get unnecessary rebuilding of the tests in CI.