### PR TITLE
Use `subDir` not `src` to construct default names

### DIFF
--- a/lib/clean-git.nix
+++ b/lib/clean-git.nix
@@ -59,7 +59,8 @@ then
 
     # Identify the .git directory and filter just the files that we need.
     gitDir = cleanSourceWith ({
-        inherit name;
+        caller = "cleanGit";
+        name = (if name == null then "" else name + "-") + "gitFiles";
         filter = path: type:
           type == "directory" ||
           lib.any (i: (lib.hasSuffix i path)) [
@@ -103,7 +104,9 @@ then
     gitModules = builtins.path { name = "gitmodules"; path = gitModulesStr; };
 
     gitSubmoduleFiles = cleanSourceWith {
-      inherit name src;
+      caller = "cleanGit";
+      name = (if name == null then "" else name + "-") + "gitSubmoduleFiles";
+      inherit src;
       filter = path: type:
           type == "directory" # TODO get sudmodule directories from `.gitmodules`
                               # and use that to filter directory tree here
@@ -144,12 +147,14 @@ then
     filter = filter_from_list src whitelist;
   in
     cleanSourceWith {
+      caller = "cleanGit";
       inherit name src subDir filter;
     }
 
 else
   trace "gitSource.nix: ${toString src} does not seem to be a git repository,\nassuming it is a clean checkout." (
     cleanSourceWith {
+      caller = "cleanGit";
       inherit name src subDir;
     }
   )

--- a/lib/clean-git.nix
+++ b/lib/clean-git.nix
@@ -59,6 +59,7 @@ then
 
     # Identify the .git directory and filter just the files that we need.
     gitDir = cleanSourceWith ({
+        inherit name;
         filter = path: type:
           type == "directory" ||
           lib.any (i: (lib.hasSuffix i path)) [
@@ -102,7 +103,7 @@ then
     gitModules = builtins.path { name = "gitmodules"; path = gitModulesStr; };
 
     gitSubmoduleFiles = cleanSourceWith {
-      inherit src;
+      inherit name src;
       filter = path: type:
           type == "directory" # TODO get sudmodule directories from `.gitmodules`
                               # and use that to filter directory tree here

--- a/lib/clean-source-with.nix
+++ b/lib/clean-source-with.nix
@@ -74,7 +74,7 @@
           if subDirName != ""
             then if src ? name
               then src.name + "-" + subDirName 
-              else "cleaned-" + subDirName
+              else "unnamed-" + subDirName
             else if src ? name
               then src.name
               else

--- a/lib/clean-source-with.nix
+++ b/lib/clean-source-with.nix
@@ -32,16 +32,23 @@
   #             https://nixos.org/nix/manual/#builtin-filterSource
   #
   #   subDir:   Descend into a subdirectory in a way that will compose.
-  #             It will be ase if `src = src + "/${subDir}` and filters
+  #             It will be as if `src = src + "/${subDir}` and filters
   #             already applied to `src` will be respected.
   #
   #   name:     Optional name to use as part of the store path.
-  #             This defaults `src.name` or otherwise `baseNameOf src`.
-  #             We recommend setting `name` whenever `src` is syntactically `./.`.
-  #             Otherwise, you depend on `./.`'s name in the parent directory,
-  #             which can cause inconsistent names, defeating caching.
+  #             If you do not provide a `name` it wil be derived
+  #             from the `subDir`. You should provide `name` or
+  #             `subDir`.  If you do not a warning will be displayed
+  #             and the name used will be `unnamed-${caller}`.
   #
-  cleanSourceWith = { filter ? _path: _type: true, src, subDir ? "", name ? null }:
+  #   caller:   Name of the function used in warning message and
+  #             in the default `unnamed-${caller}` name.  Functions
+  #             that are implemented using `cleanSourceWith`, and
+  #             forward a `name` argument, can use this to make
+  #             the message to the use more meaningful.
+  #
+  cleanSourceWith = { filter ? _path: _type: true, src, subDir ? "", name ? null
+      , caller ? "cleanSourceWith" }:
     let
       subDir' = if subDir == "" then "" else "/" + subDir;
       subDirName = __replaceStrings ["/"] ["-"] subDir;
@@ -87,8 +94,8 @@
                 #   * A warning message.
                 #   * A default name that gives a hint as to why there is no name.
                 __trace (
-                    "WARNING: `cleanSourceWith` called on ${toString src} without a `name`. "
-                    + "Consider adding `name = \"${baseNameOf src};\"`") "unnamed-cleanSourceWith";
+                    "WARNING: `${caller}` called on ${toString src} without a `name`. "
+                    + "Consider adding `name = \"${baseNameOf src};\"`") "unnamed-${caller}";
     in {
       inherit origSrc origSubDir origSrcSubDir;
       filter = filter';

--- a/lib/clean-source-with.nix
+++ b/lib/clean-source-with.nix
@@ -39,12 +39,11 @@
   #             If you do not provide a `name` it wil be derived
   #             from the `subDir`. You should provide `name` or
   #             `subDir`.  If you do not a warning will be displayed
-  #             and the name used will be `source-${caller}`.
+  #             and the name used will be `source`.
   #
-  #   caller:   Name of the function used in warning message and
-  #             in the default `source-${caller}` name.  Functions
-  #             that are implemented using `cleanSourceWith` (and
-  #             forward a `name` argument) can use this to make
+  #   caller:   Name of the function used in warning message.
+  #             Functions that are implemented using `cleanSourceWith`
+  #             (and forward a `name` argument) can use this to make
   #             the message to the use more meaningful.
   #
   cleanSourceWith = { filter ? _path: _type: true, src, subDir ? "", name ? null
@@ -74,7 +73,7 @@
           if subDirName != ""
             then if src ? name
               then src.name + "-" + subDirName 
-              else "source-${caller}-" + subDirName
+              else "source-" + subDirName
             else if src ? name
               then src.name
               else
@@ -95,7 +94,7 @@
                 #   * A default name that gives a hint as to why there is no name.
                 __trace (
                     "WARNING: `${caller}` called on ${toString src} without a `name`. "
-                    + "Consider adding `name = \"${baseNameOf src};\"`") "source-${caller}";
+                    + "Consider adding `name = \"${baseNameOf src};\"`") "source";
     in {
       inherit origSrc origSubDir origSrcSubDir;
       filter = filter';

--- a/lib/clean-source-with.nix
+++ b/lib/clean-source-with.nix
@@ -39,12 +39,12 @@
   #             If you do not provide a `name` it wil be derived
   #             from the `subDir`. You should provide `name` or
   #             `subDir`.  If you do not a warning will be displayed
-  #             and the name used will be `unnamed-${caller}`.
+  #             and the name used will be `source-${caller}`.
   #
   #   caller:   Name of the function used in warning message and
-  #             in the default `unnamed-${caller}` name.  Functions
-  #             that are implemented using `cleanSourceWith`, and
-  #             forward a `name` argument, can use this to make
+  #             in the default `source-${caller}` name.  Functions
+  #             that are implemented using `cleanSourceWith` (and
+  #             forward a `name` argument) can use this to make
   #             the message to the use more meaningful.
   #
   cleanSourceWith = { filter ? _path: _type: true, src, subDir ? "", name ? null
@@ -74,7 +74,7 @@
           if subDirName != ""
             then if src ? name
               then src.name + "-" + subDirName 
-              else "unnamed-${caller}-" + subDirName
+              else "source-${caller}-" + subDirName
             else if src ? name
               then src.name
               else
@@ -95,7 +95,7 @@
                 #   * A default name that gives a hint as to why there is no name.
                 __trace (
                     "WARNING: `${caller}` called on ${toString src} without a `name`. "
-                    + "Consider adding `name = \"${baseNameOf src};\"`") "unnamed-${caller}";
+                    + "Consider adding `name = \"${baseNameOf src};\"`") "source-${caller}";
     in {
       inherit origSrc origSubDir origSrcSubDir;
       filter = filter';

--- a/lib/clean-source-with.nix
+++ b/lib/clean-source-with.nix
@@ -74,7 +74,7 @@
           if subDirName != ""
             then if src ? name
               then src.name + "-" + subDirName 
-              else "unnamed-" + subDirName
+              else "unnamed-${caller}-" + subDirName
             else if src ? name
               then src.name
               else


### PR DESCRIPTION
When no name is provided to `cleanSourceWith` or `cleanGit` we
currently use `baseNameOf src` as a default.

This was cute, but it lead to cache misses.  For instance if
`x = cleanSourceWith { src = ./.; }` then `baseName src`
will be different when `src` resolves to "/nix/store/X"
than when it is in a local directory.  If people use
git worktrees they also may wind up with different
values for `name`. Anything that depends on `x.name` will
propagate the issue.

This change uses `subDir` if present or if it is not it encourages
adding a suitable `name` with:

  * A warning message.
  * A default name that gives a hint as to why there is no name.