### PR TITLE
Get the hackage index tarball at runtime, not eval time

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -36,11 +36,7 @@ dimension "Nixpkgs version" nixpkgsVersions (nixpkgsName: nixpkgs-pin:
     let pkgs = import ./nixpkgs (haskellNixArgs // { inherit nixpkgs-pin system; });
         build = import ./build.nix { inherit pkgs ifdLevel; };
         platformFilter = platformFilterGeneric pkgs system;
-        blacklisted = n:
-              # update-hackage accesses the hackage index at eval time (!), which doesn't work in restricted mode
-              # https://github.com/input-output-hk/haskell.nix/issues/507
-              (restrictEval && (n == "update-hackage")) ;
-    in filterAttrsOnlyRecursive (n: v: !(blacklisted n) && platformFilter v) {
+    in filterAttrsOnlyRecursive (_: v: platformFilter v) {
       # Native builds
       # TODO: can we merge this into the general case by picking an appropriate "cross system" to mean native?
       native = pkgs.recurseIntoAttrs {

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -210,7 +210,7 @@ self: super: {
 
         update-index-state-hashes = import ../scripts/update-index-state-hashes.nix {
             inherit (self.haskell-nix) indexStateHashesPath nix-tools;
-            inherit (self) coreutils nix writeShellScriptBin stdenv;
+            inherit (self) coreutils nix writeShellScriptBin stdenv curl;
         };
 
         # Function to call stackToNix

--- a/scripts/update-index-state-hashes.nix
+++ b/scripts/update-index-state-hashes.nix
@@ -1,10 +1,8 @@
-{ indexStateHashesPath, nix-tools, coreutils, nix, writeShellScriptBin, stdenv }:
+{ indexStateHashesPath, nix-tools, coreutils, nix, writeShellScriptBin, stdenv, curl }:
 with builtins;
 with stdenv.lib;
 writeShellScriptBin "update-index-state-hashes" ''
-   # get all the tools we need. I wonder if there is a better way? But I couldn't find
-   # any buildInputs for writeShellScriptBin :-/
-   export PATH="${getBin coreutils}/bin:${getBin nix-tools}/bin:${getBin nix}/bin:$PATH"
+   export PATH="${makeBinPath [ coreutils nix-tools nix]}"
    
    # We'll take the last element from the indexStatesHashes file via nix and get the name.
    # This is the last timestamp recorded in the file (implicit assumption: the file is
@@ -31,7 +29,8 @@ writeShellScriptBin "update-index-state-hashes" ''
 
       # ensure we don't generate the $start date twice (skip the first invocation).
       if [[ "''${dt}T00:00:00Z" != "$start" ]]; then
-        truncate-index -o ''${dt}-01-index.tar.gz -i ${fetchurl "https://hackage.haskell.org/01-index.tar.gz"} -s "''${dt}T00:00:00Z"
+        curl "https://hackage.haskell.org/01-index.tar.gz" --output index.tar.gz --fail-early
+        truncate-index -o ''${dt}-01-index.tar.gz -i index.tar.gz -s "''${dt}T00:00:00Z"
         sha256=$(nix-hash --flat --type sha256 ''${dt}-01-index.tar.gz)
         echo "  \"''${dt}T00:00:00Z\" = \"''${sha256}\";"
       fi


### PR DESCRIPTION
Fixes #507.

Will let me delete a special case in https://github.com/input-output-hk/haskell.nix/pull/504, but that's going to be a while yet.