### PR TITLE
Linux Cross Work-Around for GHC #15275

### DIFF
--- a/overlays/linux-cross.nix
+++ b/overlays/linux-cross.nix
@@ -47,7 +47,9 @@ let
     [ "-fexternal-interpreter"
       "-pgmi" "${qemuIservWrapper}/bin/iserv-wrapper"
       "-L${gmp}/lib"
-    ]) ++ lib.optionals hostPlatform.isAarch32 (map (opt: "--gcc-option=" + opt) [ "-fno-pic" "-fno-plt" ]);
+    ]) ++ lib.optionals hostPlatform.isAarch32 (map (opt: "--gcc-option=" + opt) [ "-fno-pic" "-fno-plt" ])
+       # Required to work-around https://gitlab.haskell.org/ghc/ghc/issues/15275
+       ++ lib.optionals hostPlatform.isAarch64 [ "-fPIC" "--gcc-option=-fPIC" ];
   qemuTestWrapper = writeScriptBin "test-wrapper" ''
     #!${stdenv.shell}
     set -euo pipefail


### PR DESCRIPTION
This is a partial work-around for GHC issue https://gitlab.haskell.org/ghc/ghc/issues/15275. Although Ben mentions in the issue comments that building with `-fPIC` is not sufficient to prevent the problematic relocations from being emitted, in practice this has been true with the handful of packages I've tested. There may be packages for which the `-fPIC` bandaid is insufficient, but it fixes some set of them for a pretty minimal cost.

I've put up a [small test package](https://github.com/TravisWhitaker/template-haskell-hello) for demonstrating that this works. Simply clone that package, run `nix build '(import ./default.nix {}).template-haskell-hello.components.all'`, and then grab a coffee/beer while your machine builds a cross-GHC.