### PR TITLE
Delete noisy trace message

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -173,7 +173,7 @@ let
         else null;
   } // pkgs.lib.optionalAttrs (checkMaterialization != null) {
     inherit checkMaterialization;
-  }) (builtins.trace "[${if name == null then "plan-to-nix-pkgs" else name + "-plan-to-nix-pkgs"}] cabal new-configure --with-ghc=${ghc.targetPrefix}ghc --with-ghc-pkg=${ghc.targetPrefix}ghc-pkg" (runCommand (if name == null then "plan-to-nix-pkgs" else name + "-plan-to-nix-pkgs") {
+  }) (runCommand (if name == null then "plan-to-nix-pkgs" else name + "-plan-to-nix-pkgs") {
     nativeBuildInputs = [ nix-tools ghc hpack cabal-install pkgs.rsync pkgs.git ];
     # Needed or stack-to-nix will die on unicode inputs
     LOCALE_ARCHIVE = pkgs.lib.optionalString (pkgs.stdenv.hostPlatform.libc == "glibc") "${pkgs.glibcLocales}/lib/locale/locale-archive";
@@ -247,5 +247,5 @@ let
 
     # move pkgs.nix to default.nix ensure we can just nix `import` the result.
     mv $out/pkgs.nix $out/default.nix
-  ''));
+  '');
 in { projectNix = plan-nix; inherit src; inherit (fixedProject) sourceRepos; }


### PR DESCRIPTION
This fires at least 3 times for every haskell.nix project (bootstrap
happy, alex, and hscolor), and then again for every `cabalProject` and
`hackage-package`. Moreover, it isn't actually informative: it just says
`ghc` and `ghc-pkg` for the executables being used.