### PR TITLE
stackProject': Expose pkg-set

### DIFF
--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -420,7 +420,7 @@ self: super: {
                   modules = (args.modules or [])
                           ++ self.lib.optional (args ? ghc) { ghc.package = args.ghc; };
                 };
-            in { inherit (pkg-set.config) hsPkgs; plan-nix = plan.nix; };
+            in { inherit (pkg-set.config) hsPkgs; inherit pkg-set; plan-nix = plan.nix; };
 
         cabalProject = args: let p = cabalProject' args;
             in p.hsPkgs // {
@@ -445,7 +445,7 @@ self: super: {
                              ++ (args.modules or [])
                              ++ self.lib.optional (args ? ghc) { ghc.package = args.ghc; };
                 };
-            in { inherit (pkg-set.config) hsPkgs; stack-nix = stack.nix; };
+            in { inherit (pkg-set.config) hsPkgs; inherit pkg-set; stack-nix = stack.nix; };
 
         stackProject = args: let p = stackProject' args;
             in p.hsPkgs // {


### PR DESCRIPTION
This will allow the caller to use the haskell.nix options as a submodule.

It's the missing link that will let me make good use of #309 in projects structured with the module system (proof of concept ["project.nix"](https://github.com/hercules-ci/project.nix), needs docs). Without it, I can't make the `config` module parameter match the `config` definitions. Closes #309 
