### PR TITLE
Use "default" as default profilingDetail

### DIFF
--- a/modules/plan.nix
+++ b/modules/plan.nix
@@ -150,7 +150,7 @@ let
 
     profilingDetail = mkOption {
       type = nullOr uniqueStr;
-      default = (def.profilingDetail or "exported-functions");
+      default = (def.profilingDetail or "default");
     };
 
     keepSource = mkOption {


### PR DESCRIPTION
 so that toplevel-functions is used for executables by default.
cf. https://www.haskell.org/cabal/users-guide/installing-packages.html?highlight=exported%20functions#cmdoption-setup-configure-profiling-detail