### PR TITLE
Allow .so dynamic libraries on Darwin

### DIFF
--- a/builder/make-config-files.nix
+++ b/builder/make-config-files.nix
@@ -170,7 +170,7 @@ in { identifier, component, fullName, flags ? {} }:
       done | sed 's|''${pkgroot}/../../../|/nix/store/|' | sort -u
     )
     for d in $dirsToLink; do
-      ln -f -s "$d/"*.dylib $dynamicLinksDir
+      ln -f -s "$d/"*.{dylib,so} $dynamicLinksDir
     done
     # Edit the local package DB to reference the links directory.
     for f in "$out/${packageCfgDir}/"*.conf; do

--- a/builder/make-config-files.nix
+++ b/builder/make-config-files.nix
@@ -170,7 +170,7 @@ in { identifier, component, fullName, flags ? {} }:
       done | sed 's|''${pkgroot}/../../../|/nix/store/|' | sort -u
     )
     for d in $dirsToLink; do
-      ln -f -s "$d/"*.{dylib,so} $dynamicLinksDir
+      ln -f -s "$d/"*.{a,dylib,so} $dynamicLinksDir
     done
     # Edit the local package DB to reference the links directory.
     for f in "$out/${packageCfgDir}/"*.conf; do


### PR DESCRIPTION
See commit.

Not tested, because it causes a massive rebuild, and my computer is incompatible with building GHC.