### PR TITLE
fix: not use ld.gold on aarch32

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -75,8 +75,9 @@ let
       [ "--with-gcc=${stdenv.cc.targetPrefix}cc"
       ] ++
       # BINTOOLS
-      (if stdenv.hostPlatform.isLinux
+      (if stdenv.hostPlatform.isLinux && !stdenv.targetPlatform.isAarch32
         # use gold as the linker on linux to improve link times
+        # Causes segfaults on Aarch32 though.
         then [
           "--with-ld=${stdenv.cc.bintools.targetPrefix}ld.gold"
           "--ghc-option=-optl-fuse-ld=gold"

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -42,13 +42,7 @@
   # specific flavour and falls back to ghc default values.
   ghcFlavour ? stdenv.lib.optionalString haskell-nix.haskellLib.isCrossTarget (
     if useLLVM
-      then (
-        # TODO check if the issues with qemu and Aarch32 persist. See
-        # https://github.com/input-output-hk/haskell.nix/pull/411/commits/1986264683067198e7fdc1d665351622b664712e
-        if stdenv.targetPlatform.isAarch32
-          then "quick-cross"
-          else "perf-cross"
-      )
+      then "perf-cross"
       else "perf-cross-ncg"
     )
 
@@ -218,13 +212,15 @@ in let configured-src = stdenv.mkDerivation (rec {
             "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
         ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
             "--enable-bootstrap-with-devel-snapshot"
-        ] ++ stdenv.lib.optionals (targetPlatform.isAarch32) [
-            "CFLAGS=-fuse-ld=gold"
-            "CONF_GCC_LINKER_OPTS_STAGE1=-fuse-ld=gold"
-            "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"
         ] ++ stdenv.lib.optionals (disableLargeAddressSpace) [
             "--disable-large-address-space"
         ];
+        # FIXME Currently causes segfaults on armv6l cross-compilation.
+        # ++ stdenv.lib.optionals (targetPlatform.isAarch32) [
+        #     "CFLAGS=-fuse-ld=gold"
+        #     "CONF_GCC_LINKER_OPTS_STAGE1=-fuse-ld=gold"
+        #     "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"
+        # ] ;
 
         outputs = [ "out" ];
         phases = [ "unpackPhase" "patchPhase" ]


### PR DESCRIPTION
It seems that ld.gold is responsible for cross-compiled programs (from x86_64 to armv6l with Linux at the very least) to segfault before having a chance to actually start when using the `perf-cross` flavour. That includes the instance of `remote-iserv` used during cross-compilation.

Returning to ld seems to fix that issue, and compiled programs run just fine with `perf-cross`. However, I can't find the reference to the reason why in some cases ld.gold is actually required anymore. So maybe this PR is not suited for every cases? However it runs fine on a cross-compilation scenario to armv6l with ffi interactions. So at the very least, if the PR can help...

A reference to an issue that may be linked, though I'm not quite sure (I'm not using musl, and my segfault event doesn't look like the one referenced in the issue):
https://github.com/NixOS/nixpkgs/issues/49071

On another note, without this PR, I've managed to get some cross-compiled programs to partially work (they do start, but segfault on some other parts) by modifying the compilation flags. But after experimenting, I've stumbled upon some issues in the GHC issue tracker that kind of look like what was happening, so perhaps this issue is already investigated?

Have a nice day!