### PR TITLE
fix: don't use fast-llvm for aarch32

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -75,9 +75,8 @@ let
       [ "--with-gcc=${stdenv.cc.targetPrefix}cc"
       ] ++
       # BINTOOLS
-      (if stdenv.hostPlatform.isLinux && !stdenv.targetPlatform.isAarch32
+      (if stdenv.hostPlatform.isLinux
         # use gold as the linker on linux to improve link times
-        # Causes segfaults on Aarch32 though.
         then [
           "--with-ld=${stdenv.cc.bintools.targetPrefix}ld.gold"
           "--ghc-option=-optl-fuse-ld=gold"

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -98,11 +98,6 @@ let
     GhcRtsHcOpts += -fPIC
   '' + stdenv.lib.optionalString targetPlatform.useAndroidPrebuilt ''
     EXTRA_CC_OPTS += -std=gnu99
-  ''
-  # At least for Aarch32, using -fast-llvm with the gold linker ends up in program segfaulting at startup.
-  + stdenv.lib.optionalString (useLLVM && !stdenv.targetPlatform.isAarch32) ''
-    GhcStage2HcOpts += -fast-llvm
-    GhcLibHcOpts += -fast-llvm
   '' + stdenv.lib.optionalString (!enableTerminfo) ''
     WITH_TERMINFO=NO
   ''


### PR DESCRIPTION
In a cross-compiling scenario (from x86_64 to armv6l, GHC 8.6.5), using the gold linker with the fast-llvm flag ends up in built Haskell program segfaulting at startup. Removing the fast-llvm flag solves the issue.

The following is what I've found on a more technical side. I couldn't find any info on this on the GHC Gitlab. Note that this pertains to Aarch32 + LLVM + GLIBC + GHC 8.6.5 (my very specific use case!), but I couldn't test other configurations.

The segfault is happening because the produced Haskell programs have some relocatable data (.data.rel.ro section) in a read-only segment, when they should actually be in a read-write segment segment, that will be write-protected after relocation (GNU_RELRO segment) by GLIBC. Updating the relocatable data then ends up in segfault.

Compiling Haskell code may produce relocatable data (in the .data.rel.ro section) that needs relocation. However, when using the LLVM backend with the fast-llvm flag, the LLVM mangler and GNU assembler are bypassed. And it turns out the LLVM backend alone considers the relocatable data as constant, marking the associated section as read-only. The gold linker seeing that section read-only then act accordingly, ending up in segfault at startup. The ld linker seems to be recognizing the section as special, and marks it writable anyway. After removing the fast-llvm flag, the GNU assembler is the one producing the object code. However, when seeing the .data.rel.ro section, it recognizes it as special (like the ld linker) and automatically marks it as writeable. The gold linker then recognizes it as containing relocatable data, and thus use a GNU_RELRO segment, ending up in a functional compiled program.

Is using the fast-llvm flag a prerequisite for a specific scenario?