### PR TITLE
Add NIX_GHC_LIBDIR to shellFor (like nixpkgs does)

### DIFF
--- a/builder/shell-for.nix
+++ b/builder/shell-for.nix
@@ -89,6 +89,9 @@ in
     installPhase = "echo $nativeBuildInputs $buildInputs > $out";
     LANG = "en_US.UTF-8";
     LOCALE_ARCHIVE = lib.optionalString (stdenv.hostPlatform.libc == "glibc") "${glibcLocales}/lib/locale/locale-archive";
+
+    # This helps tools like `ghcide` (that use the ghc api) to find
+    # the correct global package DB.
     NIX_GHC_LIBDIR = ghcEnv + "/" + configFiles.libDir;
 
     passthru = (mkDrvArgs.passthru or {}) // {

--- a/builder/shell-for.nix
+++ b/builder/shell-for.nix
@@ -89,6 +89,7 @@ in
     installPhase = "echo $nativeBuildInputs $buildInputs > $out";
     LANG = "en_US.UTF-8";
     LOCALE_ARCHIVE = lib.optionalString (stdenv.hostPlatform.libc == "glibc") "${glibcLocales}/lib/locale/locale-archive";
+    NIX_GHC_LIBDIR = ghcEnv + "/" + configFiles.libDir;
 
     passthru = (mkDrvArgs.passthru or {}) // {
       ghc = ghcEnv;


### PR DESCRIPTION
Tools like ghcide use this to find the correct global package db.