### PR TITLE
Fix quirks with overlays/hackage-default-args.nix

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -7,6 +7,7 @@
     #(import ./ghcjs-asterius-triple.nix)
     #(import ./python.nix)
     (import ./haskell.nix)
+    (import ./hackage-default-args.nix)
     (import ./bootstrap.nix)
     (import ./ghc.nix)
     (import ./ghc-packages.nix)

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -7,7 +7,7 @@
     #(import ./ghcjs-asterius-triple.nix)
     #(import ./python.nix)
     (import ./haskell.nix)
-    (import ./hackage-default-args.nix)
+    (import ./hackage-quirks.nix)
     (import ./bootstrap.nix)
     (import ./ghc.nix)
     (import ./ghc-packages.nix)

--- a/overlays/hackage-default-args.nix
+++ b/overlays/hackage-default-args.nix
@@ -1,0 +1,58 @@
+# This overlay adds hackageDefaultArgs to provide suitable default
+# arguments for `haskell-nix.hackage-project` and the functions
+# that use it (like `hackage-package`)
+#
+self: super:
+let
+  inherit (self) lib;
+
+in { haskell-nix = super.haskell-nix // {
+
+  hackageDefaultArgs = { name, version }: {
+    # FIXME: this is required to build cabal-install 3.2 with ghc 8.6,
+    # but also for
+    # https://github.com/input-output-hk/haskell.nix/issues/422
+    cabal-install = {
+      modules = [ { reinstallableLibGhc = true; } ];
+    };
+
+    hlint = {
+      modules = [ { reinstallableLibGhc = true; } ];
+      pkg-def-extras = [
+        (hackage: {
+          packages = {
+            "alex" = (((hackage.alex)."3.2.5").revisions).default;
+          };
+        })
+      ];
+    };
+
+    pandoc = {
+      # Function that returns a sha256 string by looking up the location
+      # and tag in a nested attrset
+      lookupSha256 = { location, tag, ... }:
+        { "https://github.com/jgm/pandoc-citeproc"."0.17"
+            = "0dxx8cp2xndpw3jwiawch2dkrkp15mil7pyx7dvd810pwc22pm2q"; }
+          ."${location}"."${tag}";
+      modules = [
+        # Windows characters confuse cross compilation
+        # See https://github.com/snoyberg/file-embed/pull/33
+        (lib.optionalAttrs (version == "2.9.2.1") {
+          packages.file-embed.src = self.fetchgit {
+            url = "https://github.com/hamishmack/file-embed.git";
+            rev = "12b33b8b710517308954c1facff3dc679c2dc5e3";
+            sha256 = "0jcpja4s4cylmg9rddyakb1p1fb4l41ffwmy0njpb1dxc5z3v618";
+          };
+        })
+        # Musl needs static zlib
+        (lib.optionalAttrs self.stdenv.hostPlatform.isMusl {
+          packages.pandoc.components.exes.pandoc.configureFlags = [
+            "--ghc-option=-optl=-L${self.zlib.static}/lib"
+          ];
+        })
+      ];
+    };
+
+  }."${name}" or {};
+
+}; }

--- a/overlays/hackage-quirks.nix
+++ b/overlays/hackage-quirks.nix
@@ -1,4 +1,4 @@
-# This overlay adds hackageDefaultArgs to provide suitable default
+# This overlay adds hackageQuirks to provide suitable default
 # arguments for `haskell-nix.hackage-project` and the functions
 # that use it (like `hackage-package`)
 #
@@ -8,7 +8,7 @@ let
 
 in { haskell-nix = super.haskell-nix // {
 
-  hackageDefaultArgs = { name, version }: {
+  hackageQuirks = { name, version }: {
     # FIXME: this is required to build cabal-install 3.2 with ghc 8.6,
     # but also for
     # https://github.com/input-output-hk/haskell.nix/issues/422

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -415,7 +415,7 @@ self: super: {
                 mv "${name}-${version}" $out
                 '';
           in cabalProject' (
-            (self.haskell-nix.hackageDefaultArgs { inherit name version; }) // 
+            (self.haskell-nix.hackageQuirks { inherit name version; }) // 
               builtins.removeAttrs args [ "version" ] // { inherit src; });
 
         # This function is like `cabalProject` but it makes the plan-nix available

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -414,7 +414,9 @@ self: super: {
                 tar xzf ${tarball}
                 mv "${name}-${version}" $out
                 '';
-            in cabalProject' (builtins.removeAttrs args [ "version" ] // { inherit src; });
+          in cabalProject' (
+            (self.haskell-nix.hackageDefaultArgs { inherit name version; }) // 
+              builtins.removeAttrs args [ "version" ] // { inherit src; });
 
         # This function is like `cabalProject` but it makes the plan-nix available
         # separately from the hsPkgs.  The advantage is that the you can get the

--- a/test/lookup-sha256/default.nix
+++ b/test/lookup-sha256/default.nix
@@ -1,7 +1,5 @@
 { pkgs, lib, stdenv, haskell-nix, testSrc, zlib } :
-let
-  pandoc = haskell-nix.hackage-package {
-    name         = "pandoc";
+  haskell-nix.tool "pandoc" {
     version      = "2.9.2.1";
     index-state  = "2020-04-15T00:00:00Z"; 
     # Function that returns a sha256 string by looking up the location
@@ -10,24 +8,4 @@ let
       { "https://github.com/jgm/pandoc-citeproc"."0.17"
           = "0dxx8cp2xndpw3jwiawch2dkrkp15mil7pyx7dvd810pwc22pm2q"; }
         ."${location}"."${tag}";
-    modules = [
-      # Windows characters confuse cross compilation
-      # See https://github.com/snoyberg/file-embed/pull/33
-      {
-        packages.file-embed.src = pkgs.fetchgit {
-          url = "https://github.com/hamishmack/file-embed.git";
-          rev = "12b33b8b710517308954c1facff3dc679c2dc5e3";
-          sha256 = "0jcpja4s4cylmg9rddyakb1p1fb4l41ffwmy0njpb1dxc5z3v618";
-        };
-      }
-      # Musl needs static zlib
-      (lib.optionalAttrs stdenv.hostPlatform.isMusl {
-        packages.pandoc.components.exes.pandoc.configureFlags = [
-          "--ghc-option=-optl=-L${zlib.static}/lib"
-        ];
-      })
-    ];
-  };
-in
-  pandoc.components.exes.pandoc
-
+  }

--- a/test/lookup-sha256/default.nix
+++ b/test/lookup-sha256/default.nix
@@ -1,5 +1,6 @@
 { pkgs, lib, stdenv, haskell-nix, testSrc, zlib } :
-  haskell-nix.tool "pandoc" {
+  (haskell-nix.hackage-package {
+    name         = "pandoc";
     version      = "2.9.2.1";
     index-state  = "2020-04-15T00:00:00Z"; 
     # Function that returns a sha256 string by looking up the location
@@ -8,4 +9,4 @@
       { "https://github.com/jgm/pandoc-citeproc"."0.17"
           = "0dxx8cp2xndpw3jwiawch2dkrkp15mil7pyx7dvd810pwc22pm2q"; }
         ."${location}"."${tag}";
-  }
+  }).components.exes.pandoc


### PR DESCRIPTION
Adds a place for fixes to common problems that arise when using
`hackage-project` and `hackage-package`.