### PR TITLE
fix: consider relocatable data as writable

### DIFF
--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -102,6 +102,9 @@ let
     GhcRtsHcOpts += -fPIC
   '' + stdenv.lib.optionalString targetPlatform.useAndroidPrebuilt ''
     EXTRA_CC_OPTS += -std=gnu99
+  '' + stdenv.lib.optionalString useLLVM ''
+    GhcStage2HcOpts += -fast-llvm
+    GhcLibHcOpts += -fast-llvm
   '' + stdenv.lib.optionalString (!enableTerminfo) ''
     WITH_TERMINFO=NO
   ''

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -107,6 +107,7 @@ in {
                 ++ final.lib.optional (version == "8.6.4") ./patches/ghc/ghc-8.6.4-reinstallable-lib-ghc.patch
                 ++ final.lib.optional (version == "8.6.5") ./patches/ghc/ghc-8.6.5-reinstallable-lib-ghc.patch
                 ++ final.lib.optional (version == "8.6.5") ./patches/ghc/ghc-8.6.5-atomic-arm-arch.patch
+                ++ final.lib.optional (version == "8.6.5") ./patches/ghc/MR3214-writable-rel-ro-data.patch
                 ++ final.lib.optional (version == "8.8.1") ./patches/ghc/ghc-8.8.1-reinstallable-lib-ghc.patch
                 ++ fromUntil "8.8.2" "8.9"                ./patches/ghc/ghc-8.8.2-reinstallable-lib-ghc.patch
                 ++ final.lib.optional (version == "8.6.4") ./patches/ghc/ghc-8.6.4-better-plusSimplCountErrors.patch

--- a/overlays/patches/ghc/MR3214-writable-rel-ro-data.patch
+++ b/overlays/patches/ghc/MR3214-writable-rel-ro-data.patch
@@ -1,0 +1,13 @@
+diff --git a/compiler/cmm/Cmm.hs b/compiler/cmm/Cmm.hs
+index eb34618..f2cc32f 100644
+--- a/compiler/cmm/Cmm.hs
++++ b/compiler/cmm/Cmm.hs
+@@ -181,7 +181,7 @@ isSecConstant :: Section -> Bool
+ isSecConstant (Section t _) = case t of
+     Text                    -> True
+     ReadOnlyData            -> True
+-    RelocatableReadOnlyData -> True
++    RelocatableReadOnlyData -> False
+     ReadOnlyData16          -> True
+     CString                 -> True
+     Data                    -> False


### PR DESCRIPTION
@angerman (continuation of the ongoing discussion from PR #555) So I can confirm that considering the relocatable read-only data as _not_ constant does indeed work with the `-llvm-fast` flag and the gold linker. For completeness, another test should be performed without it though. But then, what is the status of that flag?

For reference, my scenario is:

- Cross-compilation from x86_64 to armv6l
- NixOS 19.09
- Tested on both the build platform through qemu and on real hardware (Raspberry Pi)

**Commit description**
When declared as constant, read-only relocatable data are written to an unwriteable `.rel.ro.data` section. Being unwriteable, the gold linker doesn't put them inside the `GNU_RELRO` segment, but in a always read-only segment. Starting the relocation phase of such a built program then ends in a segmentation fault.

By declaring read-only relocatable data as writeable, they will be put inside a writeable `.rel.ro.data` section. The gold linker will then assume that those can be put inside the `GNU_RELRO` segment, that will only be writeable during the relocation phase.

The as assembler and ld linker will always consider the .rel.ro.data as writeable before relocation, and put the associated data in the `GNU_RELRO`.