### PR TITLE
Properly build profling executables

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -41,6 +41,9 @@ lib.makeOverridable (
 
 # Data
 , enableSeparateDataOutput ? component.enableSeparateDataOutput
+
+# Debug
+, enableDebugRTS ? false
 }:
 
 let
@@ -56,6 +59,7 @@ let
   configFiles = makeConfigFiles {
     inherit (package) identifier;
     inherit component fullName flags;
+    needsProfiling = enableExecutableProfiling || enableLibraryProfiling;
   };
 
   enableFeature = enable: feature:
@@ -114,6 +118,7 @@ let
         ++ lib.optional (package.buildType == "Configure") "--configure-option=--host=${stdenv.hostPlatform.config}" )
       ++ component.configureFlags
       ++ (ghc.extraConfigureFlags or [])
+      ++ lib.optional enableDebugRTS "--ghc-option=-debug"
     );
 
   setupGhcOptions = lib.optional (package.ghcOptions != null) '' --ghc-options="${package.ghcOptions}"'';

--- a/builder/make-config-files.nix
+++ b/builder/make-config-files.nix
@@ -63,12 +63,13 @@ let
   libDir         = "lib/${ghcCommand}-${ghc.version}";
   packageCfgDir  = "${libDir}/package.conf.d";
 
-in { identifier, component, fullName, flags ? {} }:
+in { identifier, component, fullName, flags ? {}, needsProfiling ? false }:
   # Filters out only library packages that for this GHC target
   # TODO investigate why this is needed
   # TODO find out why p ? configFiles helps (for instance for `R1909.aarch64-unknown-linux-gnu.tests.cabal-22.run.x86_64-linux`)
-  let libDeps = lib.filter (p: (p ? configFiles) && p.configFiles.targetPrefix == ghc.targetPrefix)
-        (map getLibComponent component.depends);
+  let libDeps = (if needsProfiling then (x: map (p: p.override { enableLibraryProfiling = true; }) x) else x: x)
+        (lib.filter (p: (p ? configFiles) && p.configFiles.targetPrefix == ghc.targetPrefix)
+         (map getLibComponent component.depends));
       cfgFiles =
         let xs = map
           (p: "${p.configFiles}")


### PR DESCRIPTION
When building profiling executables we want the libraries also with
profiling. This change also adds a flag to link against the debug RTS.
This does not require everything to be built against the debug RTS and
only requires the final linking step, hence no threading is necessary.