### PR TITLE
Allow to override components

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -1,5 +1,6 @@
 { stdenv, buildPackages, ghc, lib, gobject-introspection ? null, haskellLib, makeConfigFiles, ghcForComponent, hsPkgs, runCommand, libffi, gmp, nodejs }:
 
+lib.makeOverridable (
 { componentId
 , component
 , package
@@ -359,4 +360,4 @@ stdenv.mkDerivation ({
     preInstall postInstall preHaddock postHaddock;
 }
 // lib.optionalAttrs (stdenv.buildPlatform.libc == "glibc"){ LOCALE_ARCHIVE = "${buildPackages.glibcLocales}/lib/locale/locale-archive"; }
-))
+)))


### PR DESCRIPTION
Not being able to override components values once they have been setup
and exclusively relying on the module system to do its thing, can be
quite constraining. This change allows us to override components.