### PR TITLE
Profiled iserv for profiled builds

### DIFF
--- a/overlays/windows.nix
+++ b/overlays/windows.nix
@@ -34,6 +34,7 @@ self: super:
           wine = pkgs.buildPackages.winePackages.minimal;
           inherit (pkgs.windows) mingw_w64_pthreads;
           inherit (pkgs) gmp;
+          inherit (pkgs.buildPackages) symlinkJoin;
           # iserv-proxy needs to come from the buildPackages, as it needs to run on the
           # build host.
           inherit (self.buildPackages.ghc-extra-packages."${config.compiler.nix-name}".iserv-proxy.components.exes) iserv-proxy;


### PR DESCRIPTION
When trying to build profiled builds, we might end up in a situation
where the library we load requires symbols from the profiled rts. In
those cases we rely on the profiled RTS linked against iserv.

Also ghc has the slightly annoying preference of adding the `-prof`
suffix to the provided iserv program, thus we need two iservs now.

Depends on #571, #572