### PR TITLE
Add native musl support

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, ghc, lib, gobject-introspection ? null, haskellLib, makeConfigFiles, ghcForComponent, hsPkgs, runCommand, libffi, gmp, nodejs }:
+{ stdenv, buildPackages, ghc, lib, gobject-introspection ? null, haskellLib, makeConfigFiles, ghcForComponent, hsPkgs, runCommand, libffi, gmp, zlib, ncurses, nodejs }:
 
 lib.makeOverridable (
 { componentId
@@ -118,6 +118,8 @@ let
       "--ghc-option=-optl=-pthread"
       "--ghc-option=-optl=-static"
       "--ghc-option=-optl=-L${gmp.override { withStatic = true; }}/lib"
+      "--ghc-option=-optl=-L${zlib.static}/lib"
+      "--ghc-option=-optl=-L${ncurses.override { enableStatic = true; }}/lib"
     ] ++ lib.optional enableSeparateDataOutput "--datadir=$data/share/${ghc.name}"
       ++ lib.optional doHaddock' "--docdir=${docdir "$doc"}"
       ++ lib.optional (enableLibraryProfiling || enableExecutableProfiling) "--profiling-detail=${profilingDetail}"

--- a/builder/default.nix
+++ b/builder/default.nix
@@ -43,7 +43,7 @@ let
   in { packages ? [], hoogle ? pkgs.buildPackages.haskell-nix.haskellPackages.hoogle.components.exes.hoogle }:
     haskellLib.weakCallPackage pkgs nixpkgsHoogle { 
       # For musl we can use haddock from the buildGHC
-      ghc = if stdenv.hostPlatform.isLinux && stdenv.targetPlatform.isMusl
+      ghc = if stdenv.hostPlatform.isLinux && stdenv.targetPlatform.isMusl && !haskellLib.isNativeMusl
         then ghc.buildGHC
         else ghc;
       inherit packages hoogle;

--- a/builder/ghc-for-component-wrapper.nix
+++ b/builder/ghc-for-component-wrapper.nix
@@ -20,7 +20,7 @@ let
   docDir         = "$out/share/doc/ghc/html";
   # For musl we can use haddock from the buildGHC
   haddock        = if stdenv.hostPlatform.isLinux && stdenv.targetPlatform.isMusl
-    then ghc.buildGHC
+    then (if stdenv.buildPlatform == stdenv.hostPlatform then ghc else ghc.buildGHC)
     else ghc;
 
 in runCommand "${componentName}-${ghc.name}-env" {

--- a/builder/ghc-for-component-wrapper.nix
+++ b/builder/ghc-for-component-wrapper.nix
@@ -19,8 +19,8 @@ let
   libDir         = "$out/${configFiles.libDir}";
   docDir         = "$out/share/doc/ghc/html";
   # For musl we can use haddock from the buildGHC
-  haddock        = if stdenv.hostPlatform.isLinux && stdenv.targetPlatform.isMusl
-    then (if stdenv.buildPlatform == stdenv.hostPlatform then ghc else ghc.buildGHC)
+  haddock        = if stdenv.hostPlatform.isLinux && stdenv.targetPlatform.isMusl && !(stdenv.buildPlatform == stdenv.hostPlatform)
+    then ghc.buildGHC
     else ghc;
 
 in runCommand "${componentName}-${ghc.name}-env" {

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -325,12 +325,6 @@ in let configured-src = stdenv.mkDerivation (rec {
         -e 's/ghcprog="ghc-/ghcprog="${targetPrefix}ghc-/' \
         $i
     done
-
-    # Use absolute path to ar when cross-compiling
-    for file in $(find "$out" -name settings); do
-      substituteInPlace $file --replace '"${targetCC.bintools.targetPrefix}ar"' \
-        '"${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"'
-    done
   '' + installDeps targetPrefix;
 
   passthru = {

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -67,12 +67,14 @@ let
   inherit (bootPkgs) ghc;
 
   # TODO check if this posible fix for segfaults works or not.
-  targetLibffi = let targetLibffi = targetPackages.libffi or libffi; # empty targetPackages in pkgsCross
-    in if stdenv.targetPlatform.isMusl
+  targetLibffi =
+    # on native platforms targetPlatform.{libffi, gmp} do not exist; thus fall back
+    # to the non-targetPlatform version in those cases.
+    let targetLibffi = targetPackages.libffi or libffi; in
+    # we need to set `dontDisableStatic` for musl for libffi to work.
+    if stdenv.targetPlatform.isMusl
     then targetLibffi.overrideAttrs (old: { dontDisableStatic = true; })
-    else if targetPlatform != hostPlatform
-    then targetLibffi
-    else libffi;
+    else targetLibffi;
 
   targetGmp = targetPackages.gmp or gmp;
 

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -67,14 +67,14 @@ let
   inherit (bootPkgs) ghc;
 
   # TODO check if this posible fix for segfaults works or not.
-  targetLibffi =
-    if stdenv.targetPlatform.isMusl && (targetPackages.libffi or null) != null
-    then targetPackages.libffi.overrideAttrs (old: { dontDisableStatic = true; })
+  targetLibffi = let targetLibffi = targetPackages.libffi or libffi; # empty targetPackages in pkgsCross
+    in if stdenv.targetPlatform.isMusl
+    then targetLibffi.overrideAttrs (old: { dontDisableStatic = true; })
     else if targetPlatform != hostPlatform
-    then (targetPackages.libffi or libffi)
+    then targetLibffi
     else libffi;
 
-  targetGmp = (targetPackages.gmp or gmp);
+  targetGmp = targetPackages.gmp or gmp;
 
   # TODO(@Ericson2314) Make unconditional
   targetPrefix = stdenv.lib.optionalString
@@ -324,7 +324,7 @@ in let configured-src = stdenv.mkDerivation (rec {
         $i
     done
 
-    # Use absolute path to ar when cross-compile
+    # Use absolute path to ar when cross-compiling
     for file in $(find "$out" -name settings); do
       substituteInPlace $file --replace '"${targetCC.bintools.targetPrefix}ar"' \
         '"${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"'

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -199,6 +199,10 @@ with haskellLib;
   # This is the same as isCrossHost but for use when building ghc itself
   isCrossTarget = stdenv.targetPlatform != stdenv.hostPlatform
     && !(stdenv.hostPlatform.isLinux && stdenv.targetPlatform.isMusl && stdenv.hostPlatform.isx86 && stdenv.targetPlatform.isx86);
+  # Native musl build-host-target combo
+  isNativeMusl = stdenv.hostPlatform.isMusl
+    && stdenv.buildPlatform == stdenv.hostPlatform
+    && stdenv.hostPlatform == stdenv.targetPlatform;
 
   # Takes a version number or attr set of arguments (for cabalProject)
   # and conversios it to an attr set of argments.  This allows

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -100,6 +100,7 @@ in {
                 ++ fromUntil "8.6.4" "8.8"   ./patches/ghc/ghc-8.6.4-prim-no-arm-atomics.patch
                 ++ fromUntil "8.6.4" "8.8"   ./patches/ghc/global-offset-table.patch
                 ++ fromUntil "8.6.4" "8.8"   ./patches/ghc/global-offset-table-2.patch
+                ++ always                    ./patches/ghc/respect-ar-path.patch
 
                 ++ self.lib.optional (version == "8.6.3") ./patches/ghc/T16057--ghci-doa-on-windows.patch
                 ++ self.lib.optional (version == "8.6.3") ./patches/ghc/ghc-8.6.3-reinstallable-lib-ghc.patch

--- a/overlays/musl.nix
+++ b/overlays/musl.nix
@@ -1,4 +1,4 @@
-final: prev: prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl {
+final: prev: prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl ({
   # On nixpkgs 19.09 openssl is configured as `linux-generic64` instead
   # of `linux-x86_64` and as a result the `asm` parts of of openssl
   # are not built.  Because the `no_asm` configure flag is also not passed
@@ -8,12 +8,12 @@ final: prev: prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl {
       configureScript = "./Configure linux-x86_64";
     });
 
-  # Fix infinite recursion between openssh and fetchcvs
-  openssh = prev.openssh.override { withFIDO = false; };
-
   # Prevent pkgsMusl.pkgsStatic chain
   busybox-sandbox-shell = prev.busybox-sandbox-shell.override { inherit (final) busybox; };
 
   # Fails on cross compile
   nix = prev.nix.overrideAttrs (_: { doInstallCheck = false; });
-}
+} // prev.lib.optionalAttrs (prev.lib.versionAtLeast prev.lib.version "20.03") {
+  # Fix infinite recursion between openssh and fetchcvs
+  openssh = prev.openssh.override { withFIDO = false; };
+})

--- a/overlays/musl.nix
+++ b/overlays/musl.nix
@@ -7,4 +7,13 @@ self: super: super.lib.optionalAttrs super.stdenv.hostPlatform.isMusl {
     super.lib.optionalAttrs super.stdenv.hostPlatform.isx86_64 {
       configureScript = "./Configure linux-x86_64";
     });
+
+  # Fix infinite recursion between openssh and fetchcvs
+  openssh = super.openssh.override { withFIDO = false; };
+
+  # Prevent pkgsMusl.pkgsStatic chain
+  busybox-sandbox-shell = super.busybox-sandbox-shell.override { inherit (self) busybox; };
+
+  # Fails on cross compile
+  nix = super.nix.overrideAttrs (_: { doInstallCheck = false; });
 }

--- a/overlays/musl.nix
+++ b/overlays/musl.nix
@@ -1,19 +1,19 @@
-self: super: super.lib.optionalAttrs super.stdenv.hostPlatform.isMusl {
+final: prev: prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl {
   # On nixpkgs 19.09 openssl is configured as `linux-generic64` instead
   # of `linux-x86_64` and as a result the `asm` parts of of openssl
   # are not built.  Because the `no_asm` configure flag is also not passed
   # the c versions of the functions are also not included.
-  openssl = super.openssl.overrideAttrs (attrs:
-    super.lib.optionalAttrs super.stdenv.hostPlatform.isx86_64 {
+  openssl = prev.openssl.overrideAttrs (attrs:
+    prev.lib.optionalAttrs super.stdenv.hostPlatform.isx86_64 {
       configureScript = "./Configure linux-x86_64";
     });
 
   # Fix infinite recursion between openssh and fetchcvs
-  openssh = super.openssh.override { withFIDO = false; };
+  openssh = prev.openssh.override { withFIDO = false; };
 
   # Prevent pkgsMusl.pkgsStatic chain
-  busybox-sandbox-shell = super.busybox-sandbox-shell.override { inherit (self) busybox; };
+  busybox-sandbox-shell = prev.busybox-sandbox-shell.override { inherit (final) busybox; };
 
   # Fails on cross compile
-  nix = super.nix.overrideAttrs (_: { doInstallCheck = false; });
+  nix = prev.nix.overrideAttrs (_: { doInstallCheck = false; });
 }

--- a/overlays/patches/ghc/respect-ar-path.patch
+++ b/overlays/patches/ghc/respect-ar-path.patch
@@ -1,0 +1,12 @@
+--- a/aclocal.m4	2020-05-06 12:01:51.205674085 +0500
++++ b/aclocal.m4	2020-05-06 12:02:36.619673673 +0500
+@@ -1079,7 +1079,8 @@
+ # thinks that target == host so it never checks the unqualified
+ # tools for Windows. See #14274.
+ AC_DEFUN([FP_PROG_AR],
+-[if test -z "$fp_prog_ar"; then
++[AC_SUBST(fp_prog_ar,$AR)
++if test -z "$fp_prog_ar"; then
+   if test "$HostOS" = "mingw32"
+   then
+     AC_PATH_PROG([fp_prog_ar], [ar])

--- a/overlays/tools.nix
+++ b/overlays/tools.nix
@@ -80,7 +80,7 @@ in { haskell-nix = prev.haskell-nix // {
             sha256 = "0d158xifwvz0y69ah98ckxakzqpz229mq7rpf2bpbmwhnpw3jmm6";
           };
           modules = [({config, ...}: {
-            packages.ghcide.configureFlags = lib.optional (!self.stdenv.targetPlatform.isMusl)
+            packages.ghcide.configureFlags = lib.optional (!final.stdenv.targetPlatform.isMusl)
                                               "--enable-executable-dynamic";
             nonReinstallablePkgs = [ "Cabal" "array" "base" "binary" "bytestring" "containers" "deepseq"
                                      "directory" "filepath" "ghc" "ghc-boot" "ghc-boot-th" "ghc-compact"

--- a/overlays/tools.nix
+++ b/overlays/tools.nix
@@ -80,7 +80,8 @@ in { haskell-nix = super.haskell-nix // {
             sha256 = "0d158xifwvz0y69ah98ckxakzqpz229mq7rpf2bpbmwhnpw3jmm6";
           };
           modules = [({config, ...}: {
-            packages.ghcide.configureFlags = [ "--enable-executable-dynamic" ];
+            packages.ghcide.configureFlags = lib.optional (!self.stdenv.targetPlatform.isMusl)
+                                              "--enable-executable-dynamic";
             nonReinstallablePkgs = [ "Cabal" "array" "base" "binary" "bytestring" "containers" "deepseq"
                                      "directory" "filepath" "ghc" "ghc-boot" "ghc-boot-th" "ghc-compact"
                                      "ghc-heap" "ghc-prim" "ghci" "haskeline" "hpc" "integer-gmp"


### PR DESCRIPTION
Set build-host-target combo to musl-musl-musl.

Build recipe and test with:

```
let

  # Haskell.nix with native musl support
  haskell-nix-src = builtins.fetchTarball {
    name = "haskell-nix-src";
    url = "https://github.com/tuxmaniac/haskell.nix/archive/b7ee53d89936a66f9fee8c6c2f082aed8cf689ff.tar.gz";
    sha256 = "1qbs7gypmnbf1m02wq5jppy01ilhf4yhd051mwjbpkwkshn2773z";
  };

  # Release 20.03
  pinned-pkgs-src = builtins.fetchTarball {
    name = "nixpkgs";
    url = "https://github.com/NixOS/nixpkgs/archive/5272327b81ed355bbed5659b8d303cf2979b6953.tar.gz";
    sha256 = "0182ys095dfx02vl2a20j1hz92dx3mfgz2a6fhn31bqlp1wa8hlq";
  };

  pkgs-build = import pinned-pkgs-src {
    config = import "${haskell-nix-src}/config.nix";
    overlays = import "${haskell-nix-src}/overlays";
  };

  pkgs-cross = import pinned-pkgs-src {
    config = import "${haskell-nix-src}/config.nix";
    overlays = (import "${haskell-nix-src}/overlays")  ++ [(self: super: {
      haskell-nix = super.haskell-nix // {
        bootstrap = super.haskell-nix.bootstrap // {
          # Compiler from previos step will be bootstrap here
          compiler = pkgs-build.haskell-nix.compiler;
          # Reuse tools from previos step (they just exes)
          packages = pkgs-build.haskell-nix.bootstrap.packages;
        };
      };
    })];
    crossSystem = pkgs-build.lib.systems.examples.musl64;
  };

  pkgs = import pinned-pkgs-src {
    config = import "${haskell-nix-src}/config.nix";
    overlays = [(_: super: super.pkgsMusl)] ++ (import "${haskell-nix-src}/overlays") ++ [(self: super: {
      haskell-nix = super.haskell-nix // {
        bootstrap = super.haskell-nix.bootstrap // {
          # Same here for compiler and tools, use cross-compiler from previos step
          compiler = pkgs-cross.haskell-nix.compiler;
          # and tools from first step
          packages = pkgs-build.haskell-nix.bootstrap.packages;
        };
      };
    })];
  };

in pkgs.haskell-nix.haskellNixRoots.Level1
```

Pros:
- we are not cross-compiling like in pkgsCross.musl64
- native musl environment with nix-shell

Cons:
- bootstrap process too long?