### PR TITLE
Remove failing iserv build

### DIFF
--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -523,7 +523,7 @@ self: super: {
         };
 
         haskellNixRoots' = ifdLevel:
-            let filterSupportedGhc = self.lib.filterAttrs (n: _: n == "ghc865" || n == "ghc882" || n == "ghc883");
+            let filterSupportedGhc = self.lib.filterAttrs (n: _: n == "ghc865" || n == "ghc883");
           in self.recurseIntoAttrs ({
             # Things that require no IFD to build
             inherit (self.buildPackages.haskell-nix) nix-tools source-pins;


### PR DESCRIPTION
Removes ghc 8.8.2 from haskellNixRoots as #573 broke the compilation
of iserv for windows cross compilation (but 8.8.3 is ok).