### PR TITLE
Add sodium -> libsodium mapping

### DIFF
--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -76,6 +76,7 @@ pkgs:
      icui18n = pkgs.icu;
      icudata = pkgs.icu;
      vulkan = pkgs.vulkan-loader;
+     sodium = pkgs.libsodium;
    }
 # -- windows
 // { advapi32 = null; gdi32 = null; imm32 = null; msimg32 = null;


### PR DESCRIPTION
This is required by `saltine`, which in turn is pulled by newer `hnix`
and this is needed for `nix-tools`.