### PR TITLE
Fix nixpkgs version check

### DIFF
--- a/overlays/musl.nix
+++ b/overlays/musl.nix
@@ -13,7 +13,7 @@ final: prev: prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl ({
 
   # Fails on cross compile
   nix = prev.nix.overrideAttrs (_: { doInstallCheck = false; });
-} // prev.lib.optionalAttrs (prev.lib.versionAtLeast prev.lib.version "20.03") {
+} // prev.lib.optionalAttrs (prev.lib.versionAtLeast prev.lib.trivial.release "20.03") {
   # Fix infinite recursion between openssh and fetchcvs
   openssh = prev.openssh.override { withFIDO = false; };
 })


### PR DESCRIPTION
How version defined in lib/trivial.nix:

```
version = release + versionSuffix;

release = lib.strings.fileContents ../.version;

versionSuffix =
  let suffixFile = ../.version-suffix;
  in if pathExists suffixFile
  then lib.strings.fileContents suffixFile
  else "pre-git";
```

but in nixpkgs git tree there is no .version-suffix file and lib.version will always be like "20.03pre-git" which is less then "20.03". For release-specific checks we should use lib.trivial.release instead of lib.version.