### PR TITLE
Revert "Update Hackage and Stackage"

### DIFF
--- a/hackage-src.json
+++ b/hackage-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/hackage.nix",
-  "rev": "9416457638da51a476f26cb8ae478782e1ac096c",
-  "date": "2020-05-12T01:21:37+00:00",
-  "sha256": "1vaxrkbnhl2da1zw538h3hjljpw03acxv9l4f4gg5vv1a8jmdci8",
+  "rev": "becd747fdbc1a5df1abfbfb461b727b7da82f47e",
+  "date": "2020-05-03T01:16:00+00:00",
+  "sha256": "03kb8ml0lhrfz7d20wichaasdaav9c5lvncpl7k73fc7gpvm8x66",
   "fetchSubmodules": false
 }

--- a/stackage-src.json
+++ b/stackage-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/stackage.nix",
-  "rev": "2c3f7150c32a18fdf2241a51ae6a2a8ab193a0b9",
-  "date": "2020-05-12T01:03:22+00:00",
-  "sha256": "012qmnl2dmyv9jw80v4h223rij1csdg20frj5rfcagb8bgrs0hsq",
+  "rev": "7126a87c5636deb2f8820c609818a65d7b9b20f8",
+  "date": "2020-05-11T01:01:49+00:00",
+  "sha256": "10y9k9zhfd0jg36sd8hdhrwarg6wam5l8vzm68v8xdj52xpjarl6",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
This reverts commit c9f056ed49f24d23040e17d53782d6c75b08553f.

We need to roll these back so the update job can build and run the fixed nix-tools.