### PR TITLE
Add pkgs to use nixpkgs-default easily

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,7 @@ let haskellNix = rec {
     overlays = [ allOverlays.combined ];
     allOverlays = import ./overlays;
     nixpkgsArgs = { inherit config overlays; };
+    pkgs = import sources.nixpkgs-default nixpkgsArgs;
   };
 
   haskellNixV1 = haskellNix.nixpkgsArgs;


### PR DESCRIPTION
Currently if we want to use nixpkgs-default and nixpkgsAgs it is a bit painful.  With this change:

```
nix-build -E 'let h = import ./. {}; in (import h.sources.nixpkgs-default h.nixpkgsArgs).haskell-nix.tool "hlint" "3.1"'
```

becomes

```
nix-build -E 'pkgs.haskell-nix.tool "hlint" "3.1"'
```