### PR TITLE
Include terminfo in nonReinstallablePkgs for reinstallableLibGhc

### DIFF
--- a/modules/component-driver.nix
+++ b/modules/component-driver.nix
@@ -65,8 +65,8 @@ in
       # "ghci" "haskeline"
       "hpc"
       "mtl" "parsec" "process" "text" "time" "transformers"
-      "unix" "xhtml"
-      # "stm" "terminfo"
+      "unix" "xhtml" "terminfo"
+      # "stm"
     ];
 
   options.bootPkgs = lib.mkOption {


### PR DESCRIPTION
This allows building at least haddock-api, which depends on the ghc library, with just `reinstallableLibGhc = true`.

Ping @angerman as we had a discussion regarding this on IRC recently

Relevant is also https://github.com/input-output-hk/haskell.nix/issues/313 and I think this can f​ix https://github.com/input-output-hk/haskell.nix/issues/442