### PR TITLE
Add compiler-nix-name to cabalProject

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -94,11 +94,11 @@ If your project has a `cabal.project` you can add a `default.nix` like this:
 
 ```nix
 { pkgs ? import <nixpkgs> (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz) {}).nixpkgsArgs
-, haskellCompiler ? "ghc865"
+, compiler-nix-name ? "ghc865"
 }:
   pkgs.haskell-nix.cabalProject {
     src = pkgs.haskell-nix.haskellLib.cleanGit { src = ./.; };
-    ghc = pkgs.buildPackages.pkgs.haskell-nix.compiler.${haskellCompiler};
+    inherit compiler-nix-name;
     # pkg-def-extras = [
     #   # Additional packages ontop of all those listed in `cabal.project`
     # ];

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -43,6 +43,8 @@ let
         if ghc != null
           then __trace ("WARNING: A `ghc` argument was passed" + forName
             + " this has been deprecated in favour of `compiler-nix-name`. "
+            + "Using `ghc` will break cross compilation setups, as haskell.nix can not"
+            + "pick the correct `ghc` package from the respective buildPackages. "
             + "For example use `compiler-nix-name = \"ghc865\";` for ghc 8.6.5") ghc
           else
             if compiler-nix-name != null

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -384,7 +384,7 @@ in {
             # to build ghcs from source.
             alex-project = hackage-project {
                 # Only a boot compiler is suitable here
-                ghc = ghc // { isHaskellNixCompiler = ghc.isHaskellNixBootCompiler; };
+                ghcOverride = ghc // { isHaskellNixCompiler = ghc.isHaskellNixBootCompiler; };
                 inherit (bootstrap.packages) cabal-install nix-tools hpack;
                 name = "alex"; version = "3.2.4";
                 index-state = final.haskell-nix.internalHackageIndexState;
@@ -393,7 +393,7 @@ in {
             alex = bootstrap.packages.alex-project.hsPkgs.alex.components.exes.alex;
             happy-project = hackage-project {
                 # Only a boot compiler is suitable here
-                ghc = ghc // { isHaskellNixCompiler = ghc.isHaskellNixBootCompiler; };
+                ghcOverride = ghc // { isHaskellNixCompiler = ghc.isHaskellNixBootCompiler; };
                 inherit (bootstrap.packages) cabal-install nix-tools hpack;
                 name = "happy"; version = "1.19.11";
                 index-state = final.haskell-nix.internalHackageIndexState;
@@ -402,7 +402,7 @@ in {
             happy = bootstrap.packages.happy-project.hsPkgs.happy.components.exes.happy;
             hscolour-project = hackage-project {
                 # Only a boot compiler is suitable here
-                ghc = ghc // { isHaskellNixCompiler = ghc.isHaskellNixBootCompiler; };
+                ghcOverride = ghc // { isHaskellNixCompiler = ghc.isHaskellNixBootCompiler; };
                 inherit (bootstrap.packages) cabal-install nix-tools hpack;
                 name = "hscolour"; version = "1.24.4";
                 index-state = final.haskell-nix.internalHackageIndexState;

--- a/overlays/ghc-packages.nix
+++ b/overlays/ghc-packages.nix
@@ -172,7 +172,7 @@ in rec {
         if __pathExists materializedPath
           then materializedPath
           else null;
-      ghc = final.buildPackages.haskell-nix.compiler.${ghcName};
+      ghcOverride = final.buildPackages.haskell-nix.compiler.${ghcName};
       configureArgs = "--disable-tests"; # avoid failures satisfying bytestring package tests dependencies
     })
     ghc-extra-pkgs-cabal-projects;

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -463,7 +463,10 @@ final: prev: {
                 { plan-pkgs = plan.pkgs;
                   pkg-def-extras = args.pkg-def-extras or [];
                   modules = (args.modules or [])
-                          ++ final.lib.optional (args ? ghc) { ghc.package = args.ghc; };
+                          ++ final.lib.optional (args ? ghcOverride || args ? ghc)
+                              { ghc.package = args.ghcOverride or args.ghc; }
+                          ++ final.lib.optional (args ? compiler-nix-name)
+                              { compiler.nix-name = args.compiler-nix-name; };
                   extra-hackages = args.extra-hackages or [];
                 };
             in { inherit (pkg-set.config) hsPkgs; inherit pkg-set; plan-nix = plan.nix; };

--- a/test/compiler-nix-name/Main.hs
+++ b/test/compiler-nix-name/Main.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE CPP #-}
+module Main where
+
+main :: IO ()
+main = print __GLASGOW_HASKELL__

--- a/test/compiler-nix-name/compiler-nix-name.cabal
+++ b/test/compiler-nix-name/compiler-nix-name.cabal
@@ -1,0 +1,11 @@
+cabal-version:       >=1.10
+name:                compiler-nix-name
+version:             0.1.0.0
+license:             PublicDomain
+author:              Hamish Mackenzie
+build-type:          Simple
+
+executable compiler-nix-name
+  main-is:             Main.hs
+  build-depends:       base >=4.13 && <4.14
+  default-language:    Haskell2010

--- a/test/compiler-nix-name/default.nix
+++ b/test/compiler-nix-name/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, haskell-nix, recurseIntoAttrs, testSrc }:
+
+with stdenv.lib;
+
+let
+  project = haskell-nix.cabalProject' {
+    src = testSrc "compiler-nix-name";
+    compiler-nix-name = "ghc883";
+  };
+
+  packages = project.hsPkgs;
+  compiler-nix-name =
+    packages.compiler-nix-name.components.exes.compiler-nix-name;
+
+in recurseIntoAttrs {
+  ifdInputs = {
+    inherit (project) plan-nix;
+  };
+
+  run = stdenv.mkDerivation {
+    name = "compiler-nix-name-test";
+
+    buildCommand = ''
+      exe="${compiler-nix-name}/bin/compiler-nix-name${stdenv.hostPlatform.extensions.executable}"
+      if [[ "$(${toString compiler-nix-name.config.testWrapper} $exe)" != "808" ]]; then
+        echo "Unexpected GHC version" >& 2
+        false
+      else
+        touch $out
+      fi
+    '';
+
+    meta.platforms = platforms.all;
+
+    passthru = {
+      # Used for debugging with nix repl
+      inherit project packages;
+    };
+  };
+}

--- a/test/default.nix
+++ b/test/default.nix
@@ -176,6 +176,7 @@ let
     stack-source-repo = callTest ./stack-source-repo {};
     lookup-sha256 = callTest ./lookup-sha256 {};
     extra-hackage = callTest ./extra-hackage {};
+    compiler-nix-name = callTest ./compiler-nix-name {};
 
     unit = unitTests;
   };


### PR DESCRIPTION
Setting the compiler explicitly does not make it easy for cross
compilation to also choose the correct compiler when compiling
build tools for the build platform.  Also it is easy to pass the
wrong compiler type.  Specifying just the nix-name of the compiler
makes that less likely.