### PR TITLE
Fix compiler-nix-name test for mingwW64

### DIFF
--- a/test/compiler-nix-name/Main.hs
+++ b/test/compiler-nix-name/Main.hs
@@ -2,4 +2,4 @@
 module Main where
 
 main :: IO ()
-main = print __GLASGOW_HASKELL__
+main = putStr $ show __GLASGOW_HASKELL__


### PR DESCRIPTION
The `'\r'` added by windows caused the test to fail