### PR TITLE
Use package version as component version

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -4,7 +4,7 @@ lib.makeOverridable (
 { componentId
 , component
 , package
-, name
+, name # This is the package name
 , setup
 , src
 , flags
@@ -61,9 +61,11 @@ let
     then builtins.trace ("Cleaning component source not supported for hpack package: " + name) src
     else haskellLib.cleanCabalComponent package component src;
 
-  fullName = if haskellLib.isAll componentId
-    then "${name}-all"
-    else "${name}-${componentId.ctype}-${componentId.cname}";
+  nameOnly = if haskellLib.isAll componentId
+    then "${package.identifier.name}-all"
+    else "${package.identifier.name}-${componentId.ctype}-${componentId.cname}";
+
+  fullName = "${nameOnly}-${package.identifier.version}";
 
   configFiles = makeConfigFiles {
     inherit (package) identifier;
@@ -167,7 +169,8 @@ let
 in stdenv.lib.fix (drv:
 
 stdenv.mkDerivation ({
-  name = "${ghc.targetPrefix}${fullName}";
+  name = nameOnly;
+  inherit (package.identifier) version;
 
   src = cleanSrc;
 

--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -169,7 +169,7 @@ let
 in stdenv.lib.fix (drv:
 
 stdenv.mkDerivation ({
-  name = nameOnly;
+  pname = nameOnly;
   inherit (package.identifier) version;
 
   src = cleanSrc;

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluting
 # on a machine with e.g. no way to build the Darwin IFDs you need! 
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 3 }:
+, ifdLevel ? 0 }:
 
 let
   inherit (import ./ci-lib.nix) stripAttrsForHydra filterDerivations;

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluting
 # on a machine with e.g. no way to build the Darwin IFDs you need! 
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 2 }:
+, ifdLevel ? 3 }:
 
 let
   inherit (import ./ci-lib.nix) stripAttrsForHydra filterDerivations;

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluting
 # on a machine with e.g. no way to build the Darwin IFDs you need! 
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 0 }:
+, ifdLevel ? 1 }:
 
 let
   inherit (import ./ci-lib.nix) stripAttrsForHydra filterDerivations;

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluting
 # on a machine with e.g. no way to build the Darwin IFDs you need! 
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 2 }:
+, ifdLevel ? 0 }:
 
 let
   inherit (import ./ci-lib.nix) stripAttrsForHydra filterDerivations;

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluting
 # on a machine with e.g. no way to build the Darwin IFDs you need! 
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 1 }:
+, ifdLevel ? 2 }:
 
 let
   inherit (import ./ci-lib.nix) stripAttrsForHydra filterDerivations;


### PR DESCRIPTION
Currently we do not give components a version and this is inconvenient
as it means nix code that checks for a version does not work
with haskell.nix components.