### PR TITLE
pkgconf-nixpkgs-map.nix: add libsecp256k1

### DIFF
--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -83,6 +83,7 @@ pkgs:
     "libqrencode"                        = [ pkgs."qrencode" ];
     "libR"                               = [ pkgs."R" ];
     "librsvg-2.0"                        = [ pkgs."librsvg" ];
+    "libsecp256k1"                       = [ pkgs."secp256k1" ];
     "libsoup-2.4"                        = [ pkgs."libsoup" ];
     "libsoup-gnome-2.4"                  = [ pkgs."libsoup" ];
     "libsystemd"                         = [ pkgs."systemd" ];


### PR DESCRIPTION
Used by `secp256k1-haskell` package