### PR TITLE
Use nix-tools built with the boot ghc by default

### DIFF
--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -29,7 +29,7 @@ let
   # Using boot-nix-tools avoids any chancde of need ing
   # to build or download ghc 8.6.5 (as the boot compiler installed
   # from a binary distro).
-  boot-nix-tools = final.haskell-nix.bootstrap.packages.nix-tools;
+  boot-nix-tools = final.buildPackages.haskell-nix.bootstrap.packages.nix-tools;
 
 in {
     haskell-nix = with final.haskell-nix; {


### PR DESCRIPTION
While it is possible to use `nix-tools` that version will be built
with the default ghc (currently 8.6.5).  This introduces a
dependency on that compiler in the a number of places.
This can be frustrating if you are using ghc 8.8.3.
Using boot-nix-tools avoids any chancde of need ing
to build or download ghc 8.6.5 (as the boot compiler installed
from a binary distro).