### PR TITLE
README: Update usage example

### DIFF
--- a/README.org
+++ b/README.org
@@ -37,8 +37,8 @@ in
 # 'cabalProject' generates a package set based on a cabal.project (and the corresponding .cabal files)
 pkgs.haskell-nix.cabalProject {
   # 'cleanGit' cleans a source directory based on the files known by git
-  src = pkgs.haskell-nix.haskellLib.cleanGit { src = ./.; };
-  ghc = pkgs.buildPackages.pkgs.haskell-nix.compiler.${haskellCompiler};
+  src = pkgs.haskell-nix.haskellLib.cleanGit { name = "haskell-nix-project"; src = ./.; };
+  compiler-nix-name = haskellCompiler;
 }
 #+end_src
 


### PR DESCRIPTION
Previously the example would blurt

trace: WARNING: `cleanGit` called on /home/ben/code/trec-car/mediawiki-annotate without a `name`. Consider adding `name = "mediawiki-annotate";`
trace: WARNING: A `ghc` argument was passed for source this has been deprecated in favour of `compiler-nix-name`. Using `ghc` will break cross compilation setups, as haskell.nix can notpick the correct `ghc` package from the respective buildPackages. For example use `compiler-nix-name = "ghc865";` for ghc 8.6.5