### PR TITLE
Fix foreign-library component prefix

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -56,9 +56,8 @@ in {
     lib.optional c.buildable c ++ acc) [];
 
   componentPrefix = {
-    # Are all of these right?
     sublibs = "lib";
-    foreignlibs = "foreignlib";
+    foreignlibs = "flib";
     exes = "exe";
     tests = "test";
     benchmarks = "bench";


### PR DESCRIPTION
"foreignlib" is not a valid build target prefix
These seem to correspond to [cabal's componetKinds](https://github.com/ezyang/cabal/blob/master/Cabal/Distribution/Simple/BuildTarget.hs#L540).
Using `flib` here successfully builds a foreign library with `haskell.nix`.