### PR TITLE
cleanCabalComponent: Do not fail on licenses in a subdir

### DIFF
--- a/lib/clean-cabal-component.nix
+++ b/lib/clean-cabal-component.nix
@@ -70,6 +70,7 @@ in
             traceReason "directory is needed" (
               lib.any (d: lib.strings.hasPrefix (rPath + "/") d) (
                    dirsNeeded
+                ++ package.licenseFiles
                 ++ package.extraSrcFiles
                 ++ component.extraSrcFiles
                 ++ package.extraDocFiles


### PR DESCRIPTION
When the `license-file` is not at the top-level, e.g. in the LICENSES
subdirectory, it didn’t have any chance of being included, as the
subdirectory was filtered out right away.

Include `licenseFiles` in the list of subdirs used for determining
“needed” subdirectories (the ones that will be kept).