### PR TITLE
Add #! to dummy-ghc, --version and use bash case

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -305,11 +305,20 @@ let
     executable = true;
     destination = "/bin/${ghc.targetPrefix}ghc-pkg";
     text = ''
-      if [ "'$*'" == "'--version'" ]; then cat ${dummy-ghc-data}/ghc-pkg/version;
-      elif [ "'$*'" == "'dump --global -v0'" ]; then cat ${dummy-ghc-data}/ghc-pkg/dump-global;
-      else
-        false
-      fi
+      #!${pkgs.evalPackages.runtimeShell}
+      case "$*" in
+        --version)
+          cat ${dummy-ghc-data}/ghc-pkg/version
+          ;;
+        'dump --global -v0')
+          cat ${dummy-ghc-data}/ghc-pkg/dump-global
+          ;;
+        *)
+          echo "Unknown argment '$*'" >&2
+          exit 1
+          ;;
+        esac
+      exit 0
     '';
   };
 

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -239,6 +239,7 @@ let
   } ''
     mkdir -p $out/ghc
     mkdir -p $out/ghc-pkg
+    ${ghc.targetPrefix}ghc --version > $out/ghc/version
     ${ghc.targetPrefix}ghc --numeric-version > $out/ghc/numeric-version
     ${ghc.targetPrefix}ghc --info | grep -v /nix/store > $out/ghc/info
     ${ghc.targetPrefix}ghc --supported-languages > $out/ghc/supported-languages
@@ -269,14 +270,31 @@ let
     executable = true;
     destination = "/bin/${ghc.targetPrefix}ghc";
     text = ''
-      if [ "'$*'" == "'--numeric-version'" ]; then cat ${dummy-ghc-data}/ghc/numeric-version;
-      elif [ "'$*'" == "'--supported-languages'" ]; then cat ${dummy-ghc-data}/ghc/supported-languages;
-      elif [ "'$*'" == "'--print-global-package-db'" ]; then echo $out/dumby-db;
-      elif [ "'$*'" == "'--info'" ]; then cat ${dummy-ghc-data}/ghc/info;
-      elif [ "'$*'" == "'--print-libdir'" ]; then echo ${dummy-ghc-data}/ghc/libdir;
-      else
-        false
-      fi
+      #!${pkgs.evalPackages.runtimeShell}
+      case "$*" in
+        --version)
+          cat ${dummy-ghc-data}/ghc/version
+          ;;
+        --numeric-version)
+          cat ${dummy-ghc-data}/ghc/numeric-version
+          ;;
+        --supported-languages)
+          cat ${dummy-ghc-data}/ghc/supported-languages
+          ;;
+        --print-global-package-db)
+          echo "$out/dumby-db"
+          ;;
+        --info)
+          cat ${dummy-ghc-data}/ghc/info
+          ;;
+        --print-libdir)
+          echo ${dummy-ghc-data}/ghc/libdir
+          ;;
+        *)
+          echo "Unknown argment '$*'" >&2
+          ;;
+        esac
+      exit 0
     '';
   };
 

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -292,6 +292,7 @@ let
           ;;
         *)
           echo "Unknown argment '$*'" >&2
+          exit 1
           ;;
         esac
       exit 0

--- a/materialized/dummy-ghc/aarch64-unknown-linux-gnu-aarch64-unknown-linux-gnu-ghc-8.6.5-x86_64-linux/ghc/version
+++ b/materialized/dummy-ghc/aarch64-unknown-linux-gnu-aarch64-unknown-linux-gnu-ghc-8.6.5-x86_64-linux/ghc/version
@@ -1,0 +1,1 @@
+The Glorious Glasgow Haskell Compilation System, version 8.6.5

--- a/materialized/dummy-ghc/aarch64-unknown-linux-gnu-aarch64-unknown-linux-gnu-ghc-8.8.3-x86_64-linux/ghc/version
+++ b/materialized/dummy-ghc/aarch64-unknown-linux-gnu-aarch64-unknown-linux-gnu-ghc-8.8.3-x86_64-linux/ghc/version
@@ -1,0 +1,1 @@
+The Glorious Glasgow Haskell Compilation System, version 8.8.3

--- a/materialized/dummy-ghc/ghc-8.6.5-x86_64-darwin/ghc/version
+++ b/materialized/dummy-ghc/ghc-8.6.5-x86_64-darwin/ghc/version
@@ -1,0 +1,1 @@
+The Glorious Glasgow Haskell Compilation System, version 8.6.5

--- a/materialized/dummy-ghc/ghc-8.6.5-x86_64-linux/ghc/version
+++ b/materialized/dummy-ghc/ghc-8.6.5-x86_64-linux/ghc/version
@@ -1,0 +1,1 @@
+The Glorious Glasgow Haskell Compilation System, version 8.6.5

--- a/materialized/dummy-ghc/ghc-8.8.3-x86_64-darwin/ghc/version
+++ b/materialized/dummy-ghc/ghc-8.8.3-x86_64-darwin/ghc/version
@@ -1,0 +1,1 @@
+The Glorious Glasgow Haskell Compilation System, version 8.8.3

--- a/materialized/dummy-ghc/ghc-8.8.3-x86_64-linux/ghc/version
+++ b/materialized/dummy-ghc/ghc-8.8.3-x86_64-linux/ghc/version
@@ -1,0 +1,1 @@
+The Glorious Glasgow Haskell Compilation System, version 8.8.3

--- a/materialized/dummy-ghc/js-unknown-ghcjs-js-unknown-ghcjs-ghc-8.6.5-x86_64-darwin/ghc/version
+++ b/materialized/dummy-ghc/js-unknown-ghcjs-js-unknown-ghcjs-ghc-8.6.5-x86_64-darwin/ghc/version
@@ -1,0 +1,1 @@
+The Glorious Glasgow Haskell Compilation System, version 8.6.5

--- a/materialized/dummy-ghc/js-unknown-ghcjs-js-unknown-ghcjs-ghc-8.6.5-x86_64-linux/ghc/version
+++ b/materialized/dummy-ghc/js-unknown-ghcjs-js-unknown-ghcjs-ghc-8.6.5-x86_64-linux/ghc/version
@@ -1,0 +1,1 @@
+The Glorious Glasgow Haskell Compilation System, version 8.6.5

--- a/materialized/dummy-ghc/js-unknown-ghcjs-js-unknown-ghcjs-ghc-8.8.3-x86_64-darwin/ghc/version
+++ b/materialized/dummy-ghc/js-unknown-ghcjs-js-unknown-ghcjs-ghc-8.8.3-x86_64-darwin/ghc/version
@@ -1,0 +1,1 @@
+The Glorious Glasgow Haskell Compilation System, version 8.8.3

--- a/materialized/dummy-ghc/js-unknown-ghcjs-js-unknown-ghcjs-ghc-8.8.3-x86_64-linux/ghc/version
+++ b/materialized/dummy-ghc/js-unknown-ghcjs-js-unknown-ghcjs-ghc-8.8.3-x86_64-linux/ghc/version
@@ -1,0 +1,1 @@
+The Glorious Glasgow Haskell Compilation System, version 8.8.3

--- a/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-8.6.5-x86_64-linux/ghc/version
+++ b/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-8.6.5-x86_64-linux/ghc/version
@@ -1,0 +1,1 @@
+The Glorious Glasgow Haskell Compilation System, version 8.6.5

--- a/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-8.8.3-x86_64-linux/ghc/version
+++ b/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-8.8.3-x86_64-linux/ghc/version
@@ -1,0 +1,1 @@
+The Glorious Glasgow Haskell Compilation System, version 8.8.3

--- a/materialized/dummy-ghc/x86_64-w64-mingw32-x86_64-w64-mingw32-ghc-8.6.5-x86_64-linux/ghc/version
+++ b/materialized/dummy-ghc/x86_64-w64-mingw32-x86_64-w64-mingw32-ghc-8.6.5-x86_64-linux/ghc/version
@@ -1,0 +1,1 @@
+The Glorious Glasgow Haskell Compilation System, version 8.6.5

--- a/materialized/dummy-ghc/x86_64-w64-mingw32-x86_64-w64-mingw32-ghc-8.8.3-x86_64-linux/ghc/version
+++ b/materialized/dummy-ghc/x86_64-w64-mingw32-x86_64-w64-mingw32-ghc-8.8.3-x86_64-linux/ghc/version
@@ -1,0 +1,1 @@
+The Glorious Glasgow Haskell Compilation System, version 8.8.3


### PR DESCRIPTION
This change improves the dummy ghc scripts by adding a bang pattern,
supporting `--version` and using bash case instead of lots of `elif`