### PR TITLE
Add missing pins and test ghc865 and ghc883

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -3,13 +3,19 @@
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
 , ifdLevel ? 3
 # Whether or not we are evaluating in restricted mode. This is true in Hydra, but not in Hercules.
-, restrictEval ? false }:
-let
+, restrictEval ? false
+, checkMaterialization ? false }:
+ let
   inherit (import ./ci-lib.nix) dimension platformFilterGeneric filterAttrsOnlyRecursive;
   inherit (import ./default.nix { checkMaterialization = false; }) sources nixpkgsArgs;
   nixpkgsVersions = {
     "R1909" = "nixpkgs-1909";
     "R2003" = "nixpkgs-2003";
+  };
+  compilerNixNames = builtins.mapAttrs (defaultCompilerNixName: _:
+    (import ./default.nix { inherit checkMaterialization defaultCompilerNixName; }).nixpkgsArgs) {
+    ghc865 = {};
+    ghc883 = {};
   };
   systems = nixpkgs: nixpkgs.lib.filterAttrs (_: v: builtins.elem v supportedSystems) {
     # I wanted to take these from 'lib.systems.examples', but apparently there isn't one for linux!
@@ -33,54 +39,56 @@ dimension "Nixpkgs version" nixpkgsVersions (nixpkgsName: nixpkgs-pin:
   let pinnedNixpkgsSrc = sources.${nixpkgs-pin};
       # We need this for generic nixpkgs stuff at the right version
       genericPkgs = import pinnedNixpkgsSrc {};
-  in dimension "System" (systems genericPkgs) (systemName: system:
-    let pkgs = import pinnedNixpkgsSrc (nixpkgsArgs // { inherit system; });
-        build = import ./build.nix { inherit pkgs ifdLevel; };
-        platformFilter = platformFilterGeneric pkgs system;
-        compilers = {
-          inherit (pkgs.haskell-nix.compiler) ghc865 ghc883;
-        };
-    in filterAttrsOnlyRecursive (_: v: platformFilter v) {
-      # Native builds
-      # TODO: can we merge this into the general case by picking an appropriate "cross system" to mean native?
-      native = pkgs.recurseIntoAttrs ({
-        inherit (build) tests tools maintainer-scripts maintainer-script-cache;
-        ghc = pkgs.recurseIntoAttrs compilers;
-      } // pkgs.lib.optionalAttrs (ifdLevel >= 1) {
-        iserv-proxy = pkgs.recurseIntoAttrs (
-          pkgs.lib.mapAttrs (ghcName: _:
-            pkgs.ghc-extra-packages."${ghcName}".iserv-proxy.components.exes.iserv-proxy
-          ) compilers);
-      } // pkgs.lib.optionalAttrs (ifdLevel >= 2) {
-        hello = (pkgs.haskell-nix.hackage-package { name = "hello"; version = "1.0.0.2"; }).components.exes.hello;
-      });
-    }
-    //
-    dimension "Cross system" (crossSystems nixpkgsName genericPkgs system) (crossSystemName: crossSystem:
-      # Cross builds
-      let pkgs = import pinnedNixpkgsSrc (nixpkgsArgs // { inherit system crossSystem; });
+  in dimension "GHC version" compilerNixNames (compilerNixName: nixpkgsArgs:
+    dimension "System" (systems genericPkgs) (systemName: system:
+      let pkgs = import pinnedNixpkgsSrc (nixpkgsArgs // { inherit system; });
           build = import ./build.nix { inherit pkgs ifdLevel; };
-      in pkgs.recurseIntoAttrs (pkgs.lib.optionalAttrs (ifdLevel >= 1) {
-        ghc = pkgs.recurseIntoAttrs compilers;
-        # TODO: look into making tools work when cross compiling
-        # inherit (build) tools;
-      } // pkgs.lib.optionalAttrs (ifdLevel >= 2) {
-        remote-iserv = pkgs.recurseIntoAttrs (
-          pkgs.lib.mapAttrs (ghcName: _:
-            pkgs.ghc-extra-packages."${ghcName}".remote-iserv.components.exes.remote-iserv
-          ) compilers);
-        iserv-proxy = pkgs.recurseIntoAttrs (
-          pkgs.lib.mapAttrs (ghcName: _:
-            pkgs.ghc-extra-packages."${ghcName}".iserv-proxy.components.exes.iserv-proxy
-          ) compilers);
-      } // pkgs.lib.optionalAttrs (ifdLevel >= 3) {
-        hello = (pkgs.haskell-nix.hackage-package { name = "hello"; version = "1.0.0.2"; }).components.exes.hello;
+          platformFilter = platformFilterGeneric pkgs system;
+          compilers = {
+            inherit (pkgs.haskell-nix.compiler) ghc865 ghc883;
+          };
+      in filterAttrsOnlyRecursive (_: v: platformFilter v) {
+        # Native builds
+        # TODO: can we merge this into the general case by picking an appropriate "cross system" to mean native?
+        native = pkgs.recurseIntoAttrs ({
+          inherit (build) tests tools maintainer-scripts maintainer-script-cache;
+          ghc = pkgs.recurseIntoAttrs compilers;
+        } // pkgs.lib.optionalAttrs (ifdLevel >= 1) {
+          iserv-proxy = pkgs.recurseIntoAttrs (
+            pkgs.lib.mapAttrs (ghcName: _:
+              pkgs.ghc-extra-packages."${ghcName}".iserv-proxy.components.exes.iserv-proxy
+            ) compilers);
+        } // pkgs.lib.optionalAttrs (ifdLevel >= 2) {
+          hello = (pkgs.haskell-nix.hackage-package { name = "hello"; version = "1.0.0.2"; }).components.exes.hello;
+        });
       }
       //
-      # Tests are broken on aarch64 cross https://github.com/input-output-hk/haskell.nix/issues/513
-      pkgs.lib.optionalAttrs (crossSystemName != "aarch64-multiplatform") {
-        inherit (build) tests;
-      })
+      dimension "Cross system" (crossSystems nixpkgsName genericPkgs system) (crossSystemName: crossSystem:
+        # Cross builds
+        let pkgs = import pinnedNixpkgsSrc (nixpkgsArgs // { inherit system crossSystem; });
+            build = import ./build.nix { inherit pkgs ifdLevel; };
+        in pkgs.recurseIntoAttrs (pkgs.lib.optionalAttrs (ifdLevel >= 1) {
+          ghc = pkgs.recurseIntoAttrs compilers;
+          # TODO: look into making tools work when cross compiling
+          # inherit (build) tools;
+        } // pkgs.lib.optionalAttrs (ifdLevel >= 2) {
+          remote-iserv = pkgs.recurseIntoAttrs (
+            pkgs.lib.mapAttrs (ghcName: _:
+              pkgs.ghc-extra-packages."${ghcName}".remote-iserv.components.exes.remote-iserv
+            ) compilers);
+          iserv-proxy = pkgs.recurseIntoAttrs (
+            pkgs.lib.mapAttrs (ghcName: _:
+              pkgs.ghc-extra-packages."${ghcName}".iserv-proxy.components.exes.iserv-proxy
+            ) compilers);
+        } // pkgs.lib.optionalAttrs (ifdLevel >= 3) {
+          hello = (pkgs.haskell-nix.hackage-package { name = "hello"; version = "1.0.0.2"; }).components.exes.hello;
+        }
+        //
+        # Tests are broken on aarch64 cross https://github.com/input-output-hk/haskell.nix/issues/513
+        pkgs.lib.optionalAttrs (crossSystemName != "aarch64-multiplatform") {
+          inherit (build) tests;
+        })
+      )
     )
   )
 )

--- a/ci.nix
+++ b/ci.nix
@@ -62,7 +62,8 @@ dimension "Nixpkgs version" nixpkgsVersions (nixpkgsName: nixpkgs-pin:
         let pkgs = import pinnedNixpkgsSrc (nixpkgsArgs // { inherit system crossSystem; });
             build = import ./build.nix { inherit pkgs ifdLevel; };
         in pkgs.recurseIntoAttrs (pkgs.lib.optionalAttrs (ifdLevel >= 1) {
-          ghc = pkgs.haskell-nix.compiler."${compilerNixName}";
+          # TODO: look into cross compiling ghc itself
+          # ghc = pkgs.haskell-nix.compiler."${compilerNixName}";
           # TODO: look into making tools work when cross compiling
           # inherit (build) tools;
         } // pkgs.lib.optionalAttrs (ifdLevel >= 2) {

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -527,12 +527,12 @@ final: prev: {
             let filterSupportedGhc = final.lib.filterAttrs (n: _: n == "ghc865" || n == "ghc883");
           in final.recurseIntoAttrs ({
             # Things that require no IFD to build
-            inherit (final.buildPackages.haskell-nix) nix-tools source-pins;
+            inherit (final.buildPackages.haskell-nix) source-pins;
           } // final.lib.optionalAttrs (ifdLevel > 0) {
             # Things that require one IFD to build (the inputs should be in level 0)
-            alex = final.buildPackages.haskell-nix.bootstrap.packages.alex;
-            happy = final.buildPackages.haskell-nix.bootstrap.packages.happy;
-            hscolour = final.buildPackages.haskell-nix.bootstrap.packages.hscolour;
+            boot-alex = final.buildPackages.haskell-nix.bootstrap.packages.alex;
+            boot-happy = final.buildPackages.haskell-nix.bootstrap.packages.happy;
+            boot-hscolour = final.buildPackages.haskell-nix.bootstrap.packages.hscolour;
             ghc865 = final.buildPackages.haskell-nix.compiler.ghc865;
             ghc883 = final.buildPackages.haskell-nix.compiler.ghc883;
             ghc-boot-packages-nix = final.recurseIntoAttrs
@@ -542,7 +542,8 @@ final: prev: {
               (filterSupportedGhc final.ghc-extra-projects));
           } // final.lib.optionalAttrs (ifdLevel > 1) {
             # Things that require two levels of IFD to build (inputs should be in level 1)
-            inherit (final.haskell-nix) nix-tools;
+            inherit (final.buildPackages.haskell-nix.haskellPackages.hpack.components.exes) hpack;
+            inherit (final.buildPackages.haskell-nix) cabal-install dotCabal nix-tools alex happy hscolour;
             # These seem to be the only things we use from `ghc-extra-packages`
             # in haskell.nix itfinal.
             iserv-proxy = final.recurseIntoAttrs

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -543,7 +543,7 @@ final: prev: {
           } // final.lib.optionalAttrs (ifdLevel > 1) {
             # Things that require two levels of IFD to build (inputs should be in level 1)
             inherit (final.buildPackages.haskell-nix.haskellPackages.hpack.components.exes) hpack;
-            inherit (final.buildPackages.haskell-nix) cabal-install dotCabal nix-tools alex happy hscolour;
+            inherit (final.buildPackages.haskell-nix) cabal-install dotCabal nix-tools alex happy;
             # These seem to be the only things we use from `ghc-extra-packages`
             # in haskell.nix itfinal.
             iserv-proxy = final.recurseIntoAttrs

--- a/release.nix
+++ b/release.nix
@@ -17,7 +17,7 @@ in allJobs // {
       meta.description = "All jobs required to pass CI";
       # Hercules will require all of these, we just require the 20.03 jobs
       # to avoid stressing Hydra too much
-      constituents = lib.collect lib.isDerivation allJobs.R2003.linux.native;
+      constituents = lib.collect lib.isDerivation allJobs.R2003.ghc865.linux.native;
     };
   }
 

--- a/test/buildable/default.nix
+++ b/test/buildable/default.nix
@@ -4,7 +4,7 @@ with stdenv.lib;
 
 let
   project = cabalProject' {
-    index-state = "2019-04-30T00:00:00Z";
+    index-state = "2020-05-25T00:00:00Z";
     src = testSrc "buildable";
     modules = [ { packages.buildable-test.flags.exclude-broken = true; } ];
   };

--- a/test/cabal-source-repo/default.nix
+++ b/test/cabal-source-repo/default.nix
@@ -4,7 +4,7 @@ with stdenv.lib;
 
 let
   project = cabalProject' {
-    index-state = "2019-04-30T00:00:00Z";
+    index-state = "2020-05-25T00:00:00Z";
     src = testSrc "cabal-source-repo";
   };
   packages = project.hsPkgs;

--- a/test/call-cabal-project-to-nix/default.nix
+++ b/test/call-cabal-project-to-nix/default.nix
@@ -6,7 +6,7 @@ let
   # This test could use cabalProject', but it does so that it
   # tests using callCabalProjectToNix and importAndFilterProject
   plan = (importAndFilterProject (callCabalProjectToNix {
-    index-state = "2019-04-30T00:00:00Z";
+    index-state = "2020-05-25T00:00:00Z";
     # reuse the cabal-simple test project
     src = testSrc "cabal-simple";
   }));

--- a/test/ghc-options/cabal.nix
+++ b/test/ghc-options/cabal.nix
@@ -4,7 +4,7 @@ with stdenv.lib;
 
 let
   project = cabalProject' {
-    index-state = "2019-04-30T00:00:00Z";
+    index-state = "2020-05-25T00:00:00Z";
     src = testSrc "ghc-options";
     # TODO find a way to get the ghc-options into plan.json so we can use it in plan-to-nix
     modules = [ { packages.test-ghc-options.package.ghcOptions = "-DTEST_GHC_OPTION"; } ];

--- a/test/lookup-sha256/default.nix
+++ b/test/lookup-sha256/default.nix
@@ -2,7 +2,7 @@
   (haskell-nix.hackage-package {
     name         = "pandoc";
     version      = "2.9.2.1";
-    index-state  = "2020-04-15T00:00:00Z"; 
+    index-state  = "2020-05-25T00:00:00Z"; 
     # Function that returns a sha256 string by looking up the location
     # and tag in a nested attrset
     lookupSha256 = { location, tag, ... }:

--- a/test/project-flags/cabal.nix
+++ b/test/project-flags/cabal.nix
@@ -4,7 +4,7 @@ with stdenv.lib;
 
 let
   project = cabalProject' {
-    index-state = "2019-04-30T00:00:00Z";
+    index-state = "2020-05-25T00:00:00Z";
     src = testSrc "project-flags";
   };
   packages = project.hsPkgs;

--- a/test/setup-deps/cabal.project
+++ b/test/setup-deps/cabal.project
@@ -1,3 +1,3 @@
-index-state: 2019-10-01T00:00:00Z
+index-state: 2020-05-25T00:00:00Z
 
 packages: pkg

--- a/test/shell-for-setup-deps/cabal.project
+++ b/test/shell-for-setup-deps/cabal.project
@@ -1,3 +1,3 @@
-index-state: 2019-10-01T00:00:00Z
+index-state: 2020-05-25T00:00:00Z
 
 packages: pkg


### PR DESCRIPTION
Now that the defaultCompilerNixName is used to choose which GHC to use
for tools we need to update haskellNixRoots to make sure the common
tools wind up in the cache.

To do this we add the compilerNixName as a dimension in ci.nix.
This has the added bonus of ensuring the tests a run with the
supported versions of ghc (not just the default one).

haskellNixRoots is also updated to include the tools built with the
defaultCompilerNixName (in particular cabal-install was not pinned
and this was the likely cause of significant builds due to cache
misses).