### PR TITLE
Add a cabal-check derivation for a package

### DIFF
--- a/builder/hspkg-builder.nix
+++ b/builder/hspkg-builder.nix
@@ -95,11 +95,21 @@ let
             ;
   };
 
-in rec {
-  components = haskellLib.applyComponents buildComp pkg;
-  checks = pkgs.recurseIntoAttrs (builtins.mapAttrs
+  cabal-check = haskellLib.cabal-check {
+    inherit name;
+    inherit (buildPackages) cabal-install runCommand;
+    src = pkg.src.outPath;
+  };
+
+  package-checks = components: pkgs.recurseIntoAttrs (builtins.mapAttrs
     (_: d: haskellLib.check d)
       (lib.filterAttrs (_: d: d.config.doCheck) components.tests));
+
+in rec {
+  components = haskellLib.applyComponents buildComp pkg;
+  checks = package-checks components // {
+    inherit cabal-check;
+  };
   inherit (package) identifier detailLevel isLocal;
   inherit setup cabalFile;
   isHaskell = true;

--- a/lib/cabal-check.nix
+++ b/lib/cabal-check.nix
@@ -1,0 +1,19 @@
+# { stdenv, lib, haskellLib, srcOnly, cabal-install }:
+{ cabal-install
+, runCommand
+, name
+, src
+}:
+
+runCommand ("${name}-cabal-check") {
+    nativeBuildInputs = [ cabal-install ];
+} ''
+  cp -r ${src}/* ./
+  touch "$out"
+
+  runHook preBuild
+
+  cabal check | tee "$out"
+
+  runHook postBuild
+''

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -213,6 +213,8 @@ in {
     inherit stdenv lib haskellLib srcOnly;
   };
 
+  cabal-check = import ./cabal-check.nix;
+
   # Use `isCrossHost` to identify when we are cross compiling and
   # the code we are producing will not run on the build system
   # without an emulator.


### PR DESCRIPTION
On top of the ghc8101 branch because that's the one I am interested in, but this is completely independent from 8.10 support. I can rebase if you prefer that.

This probably does things naively, might not handle cleaned or compressed sources, might break for multiple-package projects.