### PR TITLE
Fix for #647 (cross builds broken on haddock)

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -21,7 +21,7 @@ let
   # Wraps GHC to provide dependencies in a way that works for both the
   # component builder and for nix-shells.
   ghcForComponent = import ./ghc-for-component-wrapper.nix {
-    inherit lib ghc;
+    inherit lib ghc haskellLib;
     inherit (buildPackages) stdenv runCommand makeWrapper;
     inherit (buildPackages.xorg) lndir;
   };

--- a/builder/ghc-for-component-wrapper.nix
+++ b/builder/ghc-for-component-wrapper.nix
@@ -6,7 +6,7 @@
 # GHC automatically configured with the dependencies in the package
 # database.
 
-{ lib, stdenv, ghc, runCommand, lndir, makeWrapper
+{ lib, stdenv, ghc, runCommand, lndir, makeWrapper, haskellLib
 }:
 
 { componentName  # Full derivation name of the component
@@ -19,7 +19,7 @@ let
   libDir         = "$out/${configFiles.libDir}";
   docDir         = "$out/share/doc/ghc/html";
   # For musl we can use haddock from the buildGHC
-  haddock        = if stdenv.hostPlatform.isLinux && stdenv.targetPlatform.isMusl && !(stdenv.buildPlatform == stdenv.hostPlatform)
+  haddock        = if stdenv.hostPlatform.isLinux && stdenv.targetPlatform.isMusl && !haskellLib.isNativeMusl
     then ghc.buildGHC
     else ghc;
 


### PR DESCRIPTION
In de3f82a419976c5a5f95a149553673b72fbe94ea a isNativeMusl function was
added, but we did not use it in `builder/ghc-for-component-wrapper.nix`
for selecting a ghc with a suitable `haddock` executable (it was only
used in builder/default.nix).