### PR TITLE
Allow cabal.project* files to be symlinks

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -2,7 +2,7 @@
 let readIfExists = src: fileName:
       let origSrcDir = src.origSrcSubDir or src;
       in
-        if ((__readDir origSrcDir)."${fileName}" or "") == "regular"
+        if builtins.elem ((__readDir origSrcDir)."${fileName}" or "") ["regular" "symlink"]
           then __readFile (origSrcDir + "/${fileName}")
           else null;
 in


### PR DESCRIPTION
Hi.

I use `symlinkJoin` to customize my sources before putting them into `cabalProject`, and in this mode `haskell.nix` fails to read `cabal.project` in order to extract source-repository-packages.

This PR fixes it by allowing these files to be symlinks.