### PR TITLE
Materialization: add scripts for fixing materialized files and shas, expose via passthru and errors

### DIFF
--- a/lib/materialize.nix
+++ b/lib/materialize.nix
@@ -60,7 +60,7 @@ let
       ''
     + (pkgs.lib.optionalString (sha256 != null) ''
         NEW_HASH=$(${calculateMaterializedSha})
-        if [ "${sha256}" != "$NEW_HASH" ]; then
+        if [[ ${sha256} != $NEW_HASH ]]; then
           echo Changes to ${name} not reflected in ${sha256Arg}
           diff -ru ${calculateUseHash} ${calculateNoHash} || true
           echo "Calculated hash for ${name} was not ${sha256}. New hash is :" >> $ERR
@@ -87,7 +87,7 @@ let
             fi
           '')
         + ''
-            if [ -e $ERR ]; then
+            if [[ -e $ERR ]]; then
               cat $ERR
               false
             else

--- a/lib/materialize.nix
+++ b/lib/materialize.nix
@@ -53,9 +53,7 @@ let
         builtins.trace sha256message (builtins.trace materializeMessage calculateNoHash);
 
   # Build fully and check the hash and materialized versions
-  checked = runCommand name {
-    buildInputs = [ nix ];
-  } (''
+  checked = runCommand name {} (''
         ERR=$(mktemp -d)/errors.txt
       ''
     + (pkgs.lib.optionalString (sha256 != null) ''
@@ -121,9 +119,7 @@ let
       chmod -R +w $out
     '';
   calculateMaterializedSha =
-    writeShellScript "calculateSha" ''
-      nix-hash --base32 --type sha256 ${calculateNoHash}
-  '';
+    writeShellScript "calculateSha" ''${nix}/nix-hash --base32 --type sha256 ${calculateNoHash}'';
 
   updateMaterialized =
     assert materialized != null;

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -248,7 +248,7 @@ final: prev: {
           inherit (final.evalPackages) nix;
           inherit (final.haskell-nix) checkMaterialization;
           pkgs = final.evalPackages.pkgs;
-          inherit (final.evalPackages.pkgs) runCommand;
+          inherit (final.evalPackages.pkgs) runCommand writeShellScript;
         };
 
         update-index-state-hashes = import ../scripts/update-index-state-hashes.nix {


### PR DESCRIPTION
At the moment we help people fix their shas and materialized files by printing something out to stderr. This is helpful, but:

- Users have to copy something slightly fiddly from the log output:
    - In the case of the sha256 it's part of a line between backticks
    - In the case of the materialized files it's several (indented!) lines
- To do an update, users have to run a build, wait for it to fail, copy and run the command, then try again.

This improves the situation by making scripts for these actions, so:
- We can print them in the log output still, but they're easier to copy (a path is one "word" so e.g. in my terminal I can highlight it with a double-click).
- We can expose them via passthru, so in the common case where users know they need to do an update, they can run the command directly, which cuts out a step.

It would be nice to have an actual updater for the sha, but this would require some `unsafeGetAttrPos` cleverness that's beyond me atm.

I also added a little logic change to `unchecked`: I think it's clearer to have the positive cases first, and since you can now have materialized files without the sha, it prints out both options in the case where you have neither.