### PR TITLE
Add project and package attrs to components

### DIFF
--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -477,12 +477,9 @@ final: prev: {
         # a `.package` attribute on the components.
         addProjectAndPackageAttrs = rawProject:
           final.lib.fix (project: rawProject // {
-            hsPkgs = final.lib.mapAttrs (n: package:
+            hsPkgs = (final.lib.mapAttrs (n: package:
               if package == null
-                  || n == "shellFor"
-                  || n == "ghcWithHoogle"
-                  || n == "ghcWithPackages"
-                then package # shellFor is not really a package
+                then null
                 else
                   package // {
                     components = final.lib.mapAttrs (n: v:
@@ -490,7 +487,11 @@ final: prev: {
                         then v // { inherit project package; }
                         else final.lib.mapAttrs (_: c: c // { inherit project package; }) v
                 ) package.components;
-              }) rawProject.hsPkgs;
+              }) rawProject.hsPkgs
+              // {
+                # These are functions not packages
+                inherit (rawProject.hsPkgs) shellFor ghcWithHoogle ghcWithPackages;
+              });
           });
 
         cabalProject = args: let p = cabalProject' args;

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -470,7 +470,25 @@ final: prev: {
                               { compiler.nix-name = args.compiler-nix-name; };
                   extra-hackages = args.extra-hackages or [];
                 };
-            in { inherit (pkg-set.config) hsPkgs; inherit pkg-set; plan-nix = plan.nix; };
+            in addProjectAndPackageAttrs { inherit (pkg-set.config) hsPkgs; inherit pkg-set; plan-nix = plan.nix; };
+
+        # Take `hsPkgs` from the `rawProject` and update all the packages and
+        # components so they have a `.project` attribute and as well as
+        # a `.package` attribute on the components.
+        addProjectAndPackageAttrs = rawProject:
+          final.lib.fix (project: rawProject // {
+            hsPkgs = final.lib.mapAttrs (n: package:
+              if n == "shellFor"
+                then package # shellFor is not really a package
+                else
+                  package // {
+                    components = final.lib.mapAttrs (n: v:
+                      if n == "library"
+                        then v // { inherit project package; }
+                        else final.lib.mapAttrs (_: c: c // { inherit project package; }) v
+                ) package.components;
+              }) rawProject.hsPkgs;
+          });
 
         cabalProject = args: let p = cabalProject' args;
             in p.hsPkgs // {
@@ -495,7 +513,7 @@ final: prev: {
                              ++ (args.modules or [])
                              ++ final.lib.optional (args ? ghc) { ghc.package = args.ghc; };
                 };
-            in { inherit (pkg-set.config) hsPkgs; inherit pkg-set; stack-nix = stack.nix; };
+            in addProjectAndPackageAttrs { inherit (pkg-set.config) hsPkgs; inherit pkg-set; stack-nix = stack.nix; };
 
         stackProject = args: let p = stackProject' args;
             in p.hsPkgs // {

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -483,7 +483,7 @@ final: prev: {
                 else
                   package // {
                     components = final.lib.mapAttrs (n: v:
-                      if n == "library"
+                      if n == "library" || n == "all"
                         then v // { inherit project package; }
                         else final.lib.mapAttrs (_: c: c // { inherit project package; }) v
                 ) package.components;

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -478,7 +478,10 @@ final: prev: {
         addProjectAndPackageAttrs = rawProject:
           final.lib.fix (project: rawProject // {
             hsPkgs = final.lib.mapAttrs (n: package:
-              if n == "shellFor"
+              if package == null
+                  || n == "shellFor"
+                  || n == "ghcWithHoogle"
+                  || n == "ghcWithPackages"
                 then package # shellFor is not really a package
                 else
                   package // {

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -486,8 +486,10 @@ final: prev: {
                       if n == "library" || n == "all"
                         then v // { inherit project package; }
                         else final.lib.mapAttrs (_: c: c // { inherit project package; }) v
-                ) package.components;
-              }) rawProject.hsPkgs
+                    ) package.components;
+                    inherit project;
+                  }
+              ) rawProject.hsPkgs
               // {
                 # These are functions not packages
                 inherit (rawProject.hsPkgs) shellFor ghcWithHoogle ghcWithPackages;


### PR DESCRIPTION
This is handy if you want to access `project.hsPkgs.shellFor` or
`project.plan-nix` (will help with #653).

For example with this change you can get the plan used to
build alex with:

```
nix-build -A 'pkgs.haskell-nix.alex.project.plan-nix'
```