### PR TITLE
Ignore extra ghc-options in dummy ghc. Fixes #656

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -286,22 +286,22 @@ let
     text = ''
       #!${pkgs.evalPackages.runtimeShell}
       case "$*" in
-        --version)
+        --version*)
           cat ${dummy-ghc-data}/ghc/version
           ;;
-        --numeric-version)
+        --numeric-version*)
           cat ${dummy-ghc-data}/ghc/numeric-version
           ;;
-        --supported-languages)
+        --supported-languages*)
           cat ${dummy-ghc-data}/ghc/supported-languages
           ;;
-        --print-global-package-db)
+        --print-global-package-db*)
           echo "$out/dumby-db"
           ;;
-        --info)
+        --info*)
           cat ${dummy-ghc-data}/ghc/info
           ;;
-        --print-libdir)
+        --print-libdir*)
           echo ${dummy-ghc-data}/ghc/libdir
           ;;
         *)

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -305,7 +305,7 @@ let
           echo ${dummy-ghc-data}/ghc/libdir
           ;;
         *)
-          echo "Unknown argment '$*'" >&2
+          echo "Unknown argument '$*'" >&2
           exit 1
           ;;
         esac
@@ -328,7 +328,9 @@ let
           cat ${dummy-ghc-data}/ghc-pkg/dump-global
           ;;
         *)
-          echo "Unknown argment '$*'" >&2
+          echo "Unknown argument '$*'. " >&2
+          echo "Additional ghc-pkg-options are not currently supported." >&2
+          echo "See https://github.com/input-output-hk/haskell.nix/pull/658" >&2
           exit 1
           ;;
         esac


### PR DESCRIPTION
Since the dummy ghc is only used for getting information about ghc,
it should be safe to ignore these.