### PR TITLE
Fix path to nix-hash

### DIFF
--- a/lib/materialize.nix
+++ b/lib/materialize.nix
@@ -119,7 +119,7 @@ let
       chmod -R +w $out
     '';
   calculateMaterializedSha =
-    writeShellScript "calculateSha" ''${nix}/nix-hash --base32 --type sha256 ${calculateNoHash}'';
+    writeShellScript "calculateSha" ''${nix}/bin/nix-hash --base32 --type sha256 ${calculateNoHash}'';
 
   # Generate the materialized files in a particular path.
   generateMaterialized =


### PR DESCRIPTION
:facepalm: 

This would only get tested if we had a test with a `plan-sha256` and `checkMaterialization=true`, which apparently we don't.