### PR TITLE
Added gfortran -> gfortran.cc.lib system package mapping

### DIFF
--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -77,6 +77,7 @@ pkgs:
      icudata = pkgs.icu;
      vulkan = pkgs.vulkan-loader;
      sodium = pkgs.libsodium;
+     gfortran = pkgs.gfortran.cc.lib;
    }
 # -- windows
 // { advapi32 = null; gdi32 = null; imm32 = null; msimg32 = null;


### PR DESCRIPTION
This mapping allows packages to use `extra-libraries: gfortran`
Came across this while depending on `hmatrix`

Fairly sure it should be here, and not in [the pkgconfig mapping](https://github.com/input-output-hk/haskell.nix/blob/master/lib/pkgconf-nixpkgs-map.nix)?