### PR TITLE
Fix flake overlay attr

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     # Using the eval-on-build version here as the plan is that
     # `builtins.currentSystem` will not be supported in flakes.
     # https://github.com/NixOS/rfcs/pull/49/files#diff-a5a138ca225433534de8d260f225fe31R429
-    overlay = self.overlays.combined-eval-on-build;
+    overlay = (self.overlays {}).combined-eval-on-build;
     overlays = import ./overlays;
     config = import ./config.nix;
     sources = import ./nixpkgs;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -53,4 +53,4 @@ let
     (ordered ++ [overlays.eval-on-current]);
   combined-eval-on-build = builtins.foldl' composeExtensions (_: _: { })
     (ordered ++ [overlays.eval-on-build]);
-in overlays // { inherit combined; }
+in overlays // { inherit combined combined-eval-on-build; }


### PR DESCRIPTION
Solves the following error:

while evaluating the attribute 'overlays.combined-eval-on-build' at /nix/store/0gg5rsi7nvwlk2ky1w595qyjgwpqj35g-source/flake.nix:11:5:
value is a function while a set was expected, at /nix/store/0gg5rsi7nvwlk2ky1w595qyjgwpqj35g-source/flake.nix:10:15