### PR TITLE
Add `sha256map` to `cabalProject` & `stackProject`

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -28,13 +28,16 @@ in
                      # If the tests and benchmarks are not needed and they
                      # causes the wrong plan to be choosen, then we can use
                      # `configureArgs = "--disable-tests --disable-benchmarks";`
-, lookupSha256  ? _: null
-                     # Use the as an alternative to adding `--sha256` comments into the
+, sha256map     ? null
+                     # An alternative to adding `--sha256` comments into the
                      # cabal.project file:
-                     #   lookupSha256 = repo:
+                     #   sha256map =
                      #     { "https://github.com/jgm/pandoc-citeproc"."0.17"
-                     #         = "0dxx8cp2xndpw3jwiawch2dkrkp15mil7pyx7dvd810pwc22pm2q"; }
-                     #       ."${repo.location}"."${repo.tag}";
+                     #         = "0dxx8cp2xndpw3jwiawch2dkrkp15mil7pyx7dvd810pwc22pm2q"; };
+, lookupSha256  ?
+  if sha256map != null
+    then { location, tag, ...}: sha256map."${location}"."${tag}"
+    else _: null
 , extra-hackage-tarballs ? []
 , ...
 }@args:

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -518,10 +518,7 @@ final: prev: {
         stackProject' =
             { ... }@args:
             let callProjectResults = callStackToNix ({ inherit cache; } // args);
-                generatedCache = genStackCache {
-                    inherit (args) src;
-                    stackYaml = args.stackYaml or "stack.yaml";
-                };
+                generatedCache = genStackCache args;
                 cache = args.cache or generatedCache;
             in let pkg-set = mkStackPkgSet
                 { stack-pkgs = importAndFilterProject callProjectResults;

--- a/test/default.nix
+++ b/test/default.nix
@@ -175,6 +175,8 @@ let
     stack-source-repo = callTest ./stack-source-repo {};
     extra-hackage = callTest ./extra-hackage {};
     compiler-nix-name = callTest ./compiler-nix-name {};
+    hls-cabal = callTest ./haskell-language-server/cabal.nix {};
+    hls-stack = callTest ./haskell-language-server/stack.nix {};
 
     unit = unitTests;
   } // lib.optionalAttrs (!stdenv.hostPlatform.isGhcjs && pkgs.haskell-nix.defaultCompilerNixName != "ghc8101" ) {

--- a/test/haskell-language-server/cabal.nix
+++ b/test/haskell-language-server/cabal.nix
@@ -7,8 +7,8 @@
     rev = "d2654185eef1b0d703cebc694e85438e20600e37";
     sha256 = "0s0k2i0imkcn9zykhrlqq0r4ssv25mwbpdyc675xkzgl1vj1l8kd";
   };
-  lookupSha256 = { location, tag, ... }: {
-      "https://github.com/wz1000/shake"."fb3859dca2e54d1bbb2c873e68ed225fa179fbef" = "0sa0jiwgyvjsmjwpfcpvzg2p7277aa0dgra1mm6afh2rfnjphz8z";
-      "https://github.com/peti/cabal-plan"."894b76c0b6bf8f7d2f881431df1f13959a8fce87" = "06iklj51d9kh9bhc42lrayypcpgkjrjvna59w920ln41rskhjr4y";
-    }."${location}"."${tag}";
+  sha256map = {
+    "https://github.com/wz1000/shake"."fb3859dca2e54d1bbb2c873e68ed225fa179fbef" = "0sa0jiwgyvjsmjwpfcpvzg2p7277aa0dgra1mm6afh2rfnjphz8z";
+    "https://github.com/peti/cabal-plan"."894b76c0b6bf8f7d2f881431df1f13959a8fce87" = "06iklj51d9kh9bhc42lrayypcpgkjrjvna59w920ln41rskhjr4y";
+  };
 }).haskell-language-server.components.exes.haskell-language-server

--- a/test/haskell-language-server/cabal.nix
+++ b/test/haskell-language-server/cabal.nix
@@ -1,0 +1,14 @@
+{ testSrc, evalPackages, buildPackages }:
+
+(buildPackages.haskell-nix.cabalProject {
+  src = evalPackages.fetchgit {
+    url = "https://github.com/haskell/haskell-language-server.git";
+    fetchSubmodules = true;
+    rev = "d2654185eef1b0d703cebc694e85438e20600e37";
+    sha256 = "0s0k2i0imkcn9zykhrlqq0r4ssv25mwbpdyc675xkzgl1vj1l8kd";
+  };
+  lookupSha256 = { location, tag, ... }: {
+      "https://github.com/wz1000/shake"."fb3859dca2e54d1bbb2c873e68ed225fa179fbef" = "0sa0jiwgyvjsmjwpfcpvzg2p7277aa0dgra1mm6afh2rfnjphz8z";
+      "https://github.com/peti/cabal-plan"."894b76c0b6bf8f7d2f881431df1f13959a8fce87" = "06iklj51d9kh9bhc42lrayypcpgkjrjvna59w920ln41rskhjr4y";
+    }."${location}"."${tag}";
+}).haskell-language-server.components.exes.haskell-language-server

--- a/test/haskell-language-server/stack.nix
+++ b/test/haskell-language-server/stack.nix
@@ -1,0 +1,15 @@
+{ testSrc, haskell-nix, evalPackages, buildPackages }:
+
+(buildPackages.haskell-nix.stackProject {
+  src = evalPackages.fetchgit {
+    url = "https://github.com/haskell/haskell-language-server.git";
+    fetchSubmodules = true;
+    rev = "d2654185eef1b0d703cebc694e85438e20600e37";
+    sha256 = "0s0k2i0imkcn9zykhrlqq0r4ssv25mwbpdyc675xkzgl1vj1l8kd";
+  };
+  stackYaml = "stack-${haskell-nix.ghc.version}.yaml";
+  lookupSha256 = { location, tag, ... }: {
+      "https://github.com/wz1000/shake.git"."fb3859dca2e54d1bbb2c873e68ed225fa179fbef" = "0sa0jiwgyvjsmjwpfcpvzg2p7277aa0dgra1mm6afh2rfnjphz8z";
+      "https://github.com/peti/cabal-plan.git"."894b76c0b6bf8f7d2f881431df1f13959a8fce87" = "06iklj51d9kh9bhc42lrayypcpgkjrjvna59w920ln41rskhjr4y";
+    }."${location}"."${tag}";
+}).haskell-language-server.components.exes.haskell-language-server

--- a/test/haskell-language-server/stack.nix
+++ b/test/haskell-language-server/stack.nix
@@ -8,8 +8,8 @@
     sha256 = "0s0k2i0imkcn9zykhrlqq0r4ssv25mwbpdyc675xkzgl1vj1l8kd";
   };
   stackYaml = "stack-${haskell-nix.ghc.version}.yaml";
-  lookupSha256 = { location, tag, ... }: {
-      "https://github.com/wz1000/shake.git"."fb3859dca2e54d1bbb2c873e68ed225fa179fbef" = "0sa0jiwgyvjsmjwpfcpvzg2p7277aa0dgra1mm6afh2rfnjphz8z";
-      "https://github.com/peti/cabal-plan.git"."894b76c0b6bf8f7d2f881431df1f13959a8fce87" = "06iklj51d9kh9bhc42lrayypcpgkjrjvna59w920ln41rskhjr4y";
-    }."${location}"."${tag}";
+  sha256map = {
+    "https://github.com/wz1000/shake.git"."fb3859dca2e54d1bbb2c873e68ed225fa179fbef" = "0sa0jiwgyvjsmjwpfcpvzg2p7277aa0dgra1mm6afh2rfnjphz8z";
+    "https://github.com/peti/cabal-plan.git"."894b76c0b6bf8f7d2f881431df1f13959a8fce87" = "06iklj51d9kh9bhc42lrayypcpgkjrjvna59w920ln41rskhjr4y";
+  };
 }).haskell-language-server.components.exes.haskell-language-server


### PR DESCRIPTION
This is a simple way to specify the sha256 values for references
to git repositories that do not have a `--sha256:` comment in the
`cabal.project` file or a `# nix-sha256:` comment in the `stack.yaml`
file.

The tests demonstrate how to use `sha256map` with both
`cabalProject` and `stackProject` to build the
haskell-language-server from github with the sha256 hashes
needed to work with `--option restrict-eval true`.