### PR TITLE
Check that materialize does not limit concurrency

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,3 +28,8 @@ steps:
       - ./update-docs.sh
     agents:
       system: x86_64-linux
+
+  - label: 'Make sure materialize function does not limit concurrency'
+    command:
+      - nix-build build.nix -A maintainer-scripts.check-materialization-concurrency -o check-materialization-concurrency.sh
+      - ./check-materialization-concurrency.sh

--- a/build.nix
+++ b/build.nix
@@ -54,6 +54,7 @@ in rec {
         { name = "hpack";         path = haskell.haskellPackages.hpack.components.exes.hpack; }
       ];
     };
+    check-materialization-concurrency = pkgs.buildPackages.callPackage ./scripts/check-materialization-concurrency/check.nix {};
   };
 
   # These are pure parts of maintainer-script so they can be built by hydra

--- a/scripts/check-materialization-concurrency/check.nix
+++ b/scripts/check-materialization-concurrency/check.nix
@@ -16,7 +16,7 @@ writeScript "check-materialization-concurrency.sh" ''
   echo EVENT end hello >> $WORK/expected.txt
   echo EVENT end world >> $WORK/expected.txt
 
-  nix-build scripts/check-materialization-concurrency --arg n "\"$(date)\"" 2>&1 | grep '^EVENT' > $WORK/actual.txt
+  nix-build -j2 scripts/check-materialization-concurrency --arg n "\"$(date)\"" 2>&1 | grep '^EVENT' > $WORK/actual.txt
 
   diff -u $WORK/expected.txt $WORK/actual.txt
 ''

--- a/scripts/check-materialization-concurrency/check.nix
+++ b/scripts/check-materialization-concurrency/check.nix
@@ -1,0 +1,23 @@
+{ stdenv, writeScript }:
+
+with stdenv.lib;
+
+writeScript "check-materialization-concurrency.sh" ''
+  #!${stdenv.shell}
+
+  set -euo pipefail
+
+  WORK=$(mktemp -d)
+
+  # We expect to see both the hello and world derivations to start building
+  # before either of them finish.
+  echo EVENT start hello > $WORK/expected.txt
+  echo EVENT start world >> $WORK/expected.txt
+  echo EVENT end hello >> $WORK/expected.txt
+  echo EVENT end world >> $WORK/expected.txt
+
+  nix-build scripts/check-materialization-concurrency --arg n "\"$(date)\"" 2>&1 | grep '^EVENT' > $WORK/actual.txt
+
+  diff -u $WORK/expected.txt $WORK/actual.txt
+''
+

--- a/scripts/check-materialization-concurrency/default.nix
+++ b/scripts/check-materialization-concurrency/default.nix
@@ -1,0 +1,28 @@
+{ n }:
+# This test makes sure that adding materialize function call with no materialized files
+# does not impact performance by reducing the ability of nix to perform concurrent
+# builds.
+let
+  inherit (import ../../. {}) pkgs;
+  hello = pkgs.haskell-nix.materialize { materialized = null; } (pkgs.runCommand "hello" {} ''
+      echo ${n}
+      echo EVENT start hello
+      sleep 2
+      echo EVENT end hello
+      echo hello > $out
+    '');
+  world = pkgs.haskell-nix.materialize { materialized = null; } (pkgs.runCommand "world" {} ''
+      echo ${n}
+      echo EVENT start world
+      sleep 3
+      echo EVENT end world
+      echo world > $out
+    '');
+  hello-world = pkgs.runCommand "hello-world" {} ''
+      cat ${hello} > $out
+      echo ' '
+      cat ${world} > $out
+    '';
+in hello-world
+
+


### PR DESCRIPTION
Adding materialize call to a derivation should not prevent nix form
building it concurrently with other derivations.

This test makes sure that is the case.