### PR TITLE
Split configured-src out of ghc/default.nix

### DIFF
--- a/compiler/ghc/configured-src.nix
+++ b/compiler/ghc/configured-src.nix
@@ -1,0 +1,113 @@
+{ stdenv, fetchurl,
+, ghc-version, ghc-patches, src-spec
+, targetPrefix,
+, targetPlatform, hostPlatform
+, targetPackages
+, perl, autoconf, automake, m4, python3, sphinx, ghc, bootPkgs
+, autoreconfHook, toolsForTarget, bash
+, libDeps
+, useLLVM, llvmPackages
+, targetCC
+, enableIntegerSimple, targetGmp
+, ncurses, targetLibffi, libiconv
+, disableLargeAddressSpace
+}:
+stdenv.mkDerivation (rec {
+
+    version = ghc-version;
+    patches = ghc-patches;
+    name = "${targetPrefix}ghc-${ghc-version}-configured-src";
+
+    # Make sure we never relax`$PATH` and hooks support for compatability.
+    strictDeps = true;
+
+    nativeBuildInputs = [
+        perl autoconf automake m4 python3 sphinx
+        ghc bootPkgs.alex bootPkgs.happy bootPkgs.hscolour
+    ] ++ stdenv.lib.optional (patches != []) autoreconfHook;
+
+    # For building runtime libs
+    depsBuildTarget = toolsForTarget;
+
+    buildInputs = [ perl bash ] ++ (libDeps hostPlatform);
+
+    propagatedBuildInputs = [ targetPackages.stdenv.cc ]
+        ++ stdenv.lib.optional useLLVM llvmPackages.llvm;
+
+    depsTargetTarget = map stdenv.lib.getDev (libDeps targetPlatform);
+    depsTargetTargetPropagated = map (stdenv.lib.getOutput "out") (libDeps targetPlatform);
+
+    postPatch = "patchShebangs .";
+
+    src = fetchurl { inherit (src-spec) url sha256; };
+
+    # GHC is a bit confused on its cross terminology.
+    preConfigure = ''
+        for env in $(env | grep '^TARGET_' | sed -E 's|\+?=.*||'); do
+        export "''${env#TARGET_}=''${!env}"
+        done
+        # GHC is a bit confused on its cross terminology, as these would normally be
+        # the *host* tools.
+        export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
+        export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
+        # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
+        export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
+        export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
+        export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
+        export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
+        export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
+        export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
+        export STRIP="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}strip"
+
+        echo -n "${buildMK}" > mk/build.mk
+        sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
+    '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
+        export NIX_LDFLAGS+=" -rpath $out/lib/${targetPrefix}ghc-${version}"
+    '' + stdenv.lib.optionalString stdenv.isDarwin ''
+        export NIX_LDFLAGS+=" -no_dtrace_dof"
+    '' + stdenv.lib.optionalString targetPlatform.useAndroidPrebuilt ''
+        sed -i -e '5i ,("armv7a-unknown-linux-androideabi", ("e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64", "cortex-a8", ""))' llvm-targets
+    '' + stdenv.lib.optionalString targetPlatform.isMusl ''
+        echo "patching llvm-targets for musl targets..."
+        echo "Cloning these existing '*-linux-gnu*' targets:"
+        grep linux-gnu llvm-targets | sed 's/^/  /'
+        echo "(go go gadget sed)"
+        sed -i 's,\(^.*linux-\)gnu\(.*\)$,\0\n\1musl\2,' llvm-targets
+        echo "llvm-targets now contains these '*-linux-musl*' targets:"
+        grep linux-musl llvm-targets | sed 's/^/  /'
+
+        echo "And now patching to preserve '-musleabi' as done with '-gnueabi'"
+        # (aclocal.m4 is actual source, but patch configure as well since we don't re-gen)
+        for x in configure aclocal.m4; do
+            substituteInPlace $x \
+            --replace '*-android*|*-gnueabi*)' \
+                        '*-android*|*-gnueabi*|*-musleabi*)'
+        done
+    '';
+
+    configurePlatforms = [ "build" "host" "target" ];
+    # `--with` flags for libraries needed for RTS linker
+    configureFlags = [
+        "--datadir=$doc/share/doc/ghc"
+        "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
+    ] ++ stdenv.lib.optionals (targetLibffi != null) ["--with-system-libffi" "--with-ffi-includes=${targetLibffi.dev}/include" "--with-ffi-libraries=${targetLibffi.out}/lib"
+    ] ++ stdenv.lib.optional (!enableIntegerSimple) [
+        "--with-gmp-includes=${targetGmp.dev}/include" "--with-gmp-libraries=${targetGmp.out}/lib"
+    ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.libc != "glibc" && !targetPlatform.isWindows) [
+        "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
+    ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
+        "--enable-bootstrap-with-devel-snapshot"
+    ] ++ stdenv.lib.optionals (disableLargeAddressSpace) [
+        "--disable-large-address-space"
+    ] ++ stdenv.lib.optionals (targetPlatform.isAarch32) [
+        "CFLAGS=-fuse-ld=gold"
+        "CONF_GCC_LINKER_OPTS_STAGE1=-fuse-ld=gold"
+        "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"
+    ] ;
+
+    outputs = [ "out" ];
+    phases = [ "unpackPhase" "patchPhase" ]
+            ++ stdenv.lib.optional (ghc-patches != []) "autoreconfPhase"
+            ++ [ "configurePhase" "installPhase" ];
+    installPhase = "cp -r . $out";
+});

--- a/compiler/ghc/configured-src.nix
+++ b/compiler/ghc/configured-src.nix
@@ -11,6 +11,7 @@
 , enableIntegerSimple, targetGmp
 , ncurses, targetLibffi, libiconv
 , disableLargeAddressSpace
+, buildMK
 }:
 stdenv.mkDerivation (rec {
 

--- a/compiler/ghc/configured-src.nix
+++ b/compiler/ghc/configured-src.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl,
+{ stdenv, fetchurl
 , ghc-version, ghc-patches, src-spec
-, targetPrefix,
+, targetPrefix
 , targetPlatform, hostPlatform
 , targetPackages
 , perl, autoconf, automake, m4, python3, sphinx, ghc, bootPkgs

--- a/compiler/ghc/configured-src.nix
+++ b/compiler/ghc/configured-src.nix
@@ -110,4 +110,4 @@ stdenv.mkDerivation (rec {
             ++ stdenv.lib.optional (ghc-patches != []) "autoreconfPhase"
             ++ [ "configurePhase" "installPhase" ];
     installPhase = "cp -r . $out";
-});
+})

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -319,4 +319,4 @@ stdenv.mkDerivation (rec {
   dontStrip = true;
   dontPatchELF = true;
   noAuditTmpdir = true;
-});
+})

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -284,15 +284,15 @@ stdenv.mkDerivation (rec {
     if [[ ! -f "$out/bin/${targetPrefix}ghc-pkg" ]]; then
       echo "ERROR: Missing file $out/bin/${targetPrefix}ghc-pkg"
       exit 0
-    fi
+    fi    
     if [[ ! -d "$out/lib/${targetPrefix}ghc-${version}" ]]; then
       echo "ERROR: Missing directory $out/lib/${targetPrefix}ghc-${version}"
       exit 0
-    fi
+    fi    
     if (( $(ls -1 "$out/lib/${targetPrefix}ghc-${version}" | wc -l) < 30 )); then
       echo "ERROR: Expected more files in $out/lib/${targetPrefix}ghc-${version}"
       exit 0
-    fi
+    fi    
   '';
 
   passthru = {

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -131,109 +131,23 @@ let
 
   targetCC = builtins.head toolsForTarget;
 
-in let configured-src = stdenv.mkDerivation (rec {
-
-        version = ghc-version;
-
-        patches = ghc-patches;
-
-        name = "${targetPrefix}ghc-${ghc-version}-configured-src";
-
-  # Make sure we never relax`$PATH` and hooks support for compatability.
-  strictDeps = true;
-
-  nativeBuildInputs = [
-    perl autoconf automake m4 python3 sphinx
-    ghc bootPkgs.alex bootPkgs.happy bootPkgs.hscolour
-  ] ++ stdenv.lib.optional (patches != []) autoreconfHook;
-
-  # For building runtime libs
-  depsBuildTarget = toolsForTarget;
-
-  buildInputs = [ perl bash ] ++ (libDeps hostPlatform);
-
-  propagatedBuildInputs = [ targetPackages.stdenv.cc ]
-    ++ stdenv.lib.optional useLLVM llvmPackages.llvm;
-
-  depsTargetTarget = map stdenv.lib.getDev (libDeps targetPlatform);
-  depsTargetTargetPropagated = map (stdenv.lib.getOutput "out") (libDeps targetPlatform);
-
-  postPatch = "patchShebangs .";
-
-        src = fetchurl { inherit (src-spec) url sha256; };
-
-        # GHC is a bit confused on its cross terminology.
-        preConfigure = ''
-            for env in $(env | grep '^TARGET_' | sed -E 's|\+?=.*||'); do
-            export "''${env#TARGET_}=''${!env}"
-            done
-            # GHC is a bit confused on its cross terminology, as these would normally be
-            # the *host* tools.
-            export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
-            export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
-            # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
-            export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
-            export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
-            export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
-            export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
-            export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
-            export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
-            export STRIP="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}strip"
-
-            echo -n "${buildMK}" > mk/build.mk
-            sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
-        '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
-            export NIX_LDFLAGS+=" -rpath $out/lib/${targetPrefix}ghc-${version}"
-        '' + stdenv.lib.optionalString stdenv.isDarwin ''
-            export NIX_LDFLAGS+=" -no_dtrace_dof"
-        '' + stdenv.lib.optionalString targetPlatform.useAndroidPrebuilt ''
-            sed -i -e '5i ,("armv7a-unknown-linux-androideabi", ("e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64", "cortex-a8", ""))' llvm-targets
-        '' + stdenv.lib.optionalString targetPlatform.isMusl ''
-            echo "patching llvm-targets for musl targets..."
-            echo "Cloning these existing '*-linux-gnu*' targets:"
-            grep linux-gnu llvm-targets | sed 's/^/  /'
-            echo "(go go gadget sed)"
-            sed -i 's,\(^.*linux-\)gnu\(.*\)$,\0\n\1musl\2,' llvm-targets
-            echo "llvm-targets now contains these '*-linux-musl*' targets:"
-            grep linux-musl llvm-targets | sed 's/^/  /'
-
-            echo "And now patching to preserve '-musleabi' as done with '-gnueabi'"
-            # (aclocal.m4 is actual source, but patch configure as well since we don't re-gen)
-            for x in configure aclocal.m4; do
-                substituteInPlace $x \
-                --replace '*-android*|*-gnueabi*)' \
-                            '*-android*|*-gnueabi*|*-musleabi*)'
-            done
-        '';
-
-        configurePlatforms = [ "build" "host" "target" ];
-        # `--with` flags for libraries needed for RTS linker
-        configureFlags = [
-            "--datadir=$doc/share/doc/ghc"
-            "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
-        ] ++ stdenv.lib.optionals (targetLibffi != null) ["--with-system-libffi" "--with-ffi-includes=${targetLibffi.dev}/include" "--with-ffi-libraries=${targetLibffi.out}/lib"
-        ] ++ stdenv.lib.optional (!enableIntegerSimple) [
-            "--with-gmp-includes=${targetGmp.dev}/include" "--with-gmp-libraries=${targetGmp.out}/lib"
-        ] ++ stdenv.lib.optional (targetPlatform == hostPlatform && hostPlatform.libc != "glibc" && !targetPlatform.isWindows) [
-            "--with-iconv-includes=${libiconv}/include" "--with-iconv-libraries=${libiconv}/lib"
-        ] ++ stdenv.lib.optionals (targetPlatform != hostPlatform) [
-            "--enable-bootstrap-with-devel-snapshot"
-        ] ++ stdenv.lib.optionals (disableLargeAddressSpace) [
-            "--disable-large-address-space"
-        ] ++ stdenv.lib.optionals (targetPlatform.isAarch32) [
-            "CFLAGS=-fuse-ld=gold"
-            "CONF_GCC_LINKER_OPTS_STAGE1=-fuse-ld=gold"
-            "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"
-        ] ;
-
-        outputs = [ "out" ];
-        phases = [ "unpackPhase" "patchPhase" ]
-              ++ stdenv.lib.optional (ghc-patches != []) "autoreconfPhase"
-              ++ [ "configurePhase" "installPhase" ];
-        installPhase = "cp -r . $out";
-    });
-
-  drv =stdenv.mkDerivation (rec {
+  configured-src = import ./configured-src {
+    stdenv fetchurl
+    ghc-version ghc-patches src-spec
+    targetPrefix
+    targetPlatform hostPlatform
+    targetPackages
+    perl autoconf automake m4 python3 sphinx ghc bootPkgs
+    autoreconfHook toolsForTarget bash
+    libDeps
+    useLLVM llvmPackages
+    targetCC
+    enableIntegerSimple targetGmp
+    ncurses targetLibffi libiconv
+    disableLargeAddressSpace
+  };
+in
+stdenv.mkDerivation (rec {
   version = ghc-version;
   name = "${targetPrefix}ghc-${version}";
 
@@ -368,15 +282,15 @@ in let configured-src = stdenv.mkDerivation (rec {
     if [[ ! -f "$out/bin/${targetPrefix}ghc-pkg" ]]; then
       echo "ERROR: Missing file $out/bin/${targetPrefix}ghc-pkg"
       exit 0
-    fi    
+    fi
     if [[ ! -d "$out/lib/${targetPrefix}ghc-${version}" ]]; then
       echo "ERROR: Missing directory $out/lib/${targetPrefix}ghc-${version}"
       exit 0
-    fi    
+    fi
     if (( $(ls -1 "$out/lib/${targetPrefix}ghc-${version}" | wc -l) < 30 )); then
       echo "ERROR: Expected more files in $out/lib/${targetPrefix}ghc-${version}"
       exit 0
-    fi    
+    fi
   '';
 
   passthru = {
@@ -406,5 +320,3 @@ in let configured-src = stdenv.mkDerivation (rec {
   dontPatchELF = true;
   noAuditTmpdir = true;
 });
-
-in drv

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -132,7 +132,7 @@ let
   targetCC = builtins.head toolsForTarget;
 
   configured-src = import ./configured-src {
-    stdenv fetchurl
+    inherit stdenv fetchurl
     ghc-version ghc-patches src-spec
     targetPrefix
     targetPlatform hostPlatform

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -144,7 +144,7 @@ let
     targetCC
     enableIntegerSimple targetGmp
     ncurses targetLibffi libiconv
-    disableLargeAddressSpace
+    disableLargeAddressSpace;
   };
 in
 stdenv.mkDerivation (rec {

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -144,7 +144,9 @@ let
     targetCC
     enableIntegerSimple targetGmp
     ncurses targetLibffi libiconv
-    disableLargeAddressSpace;
+    disableLargeAddressSpace
+    buildMK
+    ;
   };
 in
 stdenv.mkDerivation (rec {

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -131,7 +131,7 @@ let
 
   targetCC = builtins.head toolsForTarget;
 
-  configured-src = import ./configured-src {
+  configured-src = import ./configured-src.nix {
     inherit stdenv fetchurl
     ghc-version ghc-patches src-spec
     targetPrefix


### PR DESCRIPTION
This was overdue for a long time. I think we should also split out the actual build expressions, and leave the default.nix to be configuration + calling configured-src, and then build-ghc expressions.