### PR TITLE
Set strictDeps = true

### DIFF
--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -139,6 +139,8 @@ in let configured-src = stdenv.mkDerivation (rec {
 
         name = "${targetPrefix}ghc-${ghc-version}-configured-src";
 
+  # Make sure we never relax`$PATH` and hooks support for compatability.
+  strictDeps = true;
 
   nativeBuildInputs = [
     perl autoconf automake m4 python3 sphinx


### PR DESCRIPTION
This will prevent LD_FLAGS from leaking in. And potentially breaking cross compilation from macOS -> linux, when LD_FLAGS contains -framework items.