### PR TITLE
Add sourcesOverride

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -40,7 +40,7 @@ let haskellNix = {
 # If no arguments, then you get V1
 # I'd like to make importing directly issue a warning, but I couldn't figure out a way to make it happen
 in haskellNixV1 // {
-  __functor = _: { version ? 2, ... }@args:
+  __functor = _: { version ? 2, sourcesOverride ? {}, ... }@args:
     if version == 1
     then builtins.trace v1DeprecationMessage haskellNixV1
     else if version == 2


### PR DESCRIPTION
Without it, it appears we are ignoring sourcesOverride. This is rather puzzling to me in nix.
You appear to need it being explicilty listed for `--arg` to work.