### PR TITLE
Fix propagation of pkgconfig and frameworks

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -215,12 +215,14 @@ stdenv.mkDerivation ({
 
   enableParallelBuilding = true;
 
+  propagatedBuildInputs =
+       frameworks # Frameworks will be needed at link time
+    # Not sure why pkgconfig needs to be propagatedBuildInputs but
+    # for gi-gtk-hs it seems to help.
+    ++ builtins.concatLists pkgconfig;
+  
   buildInputs = component.libs
-    ++ frameworks
-    ++ builtins.concatLists pkgconfig
-    # Note: This is a hack until we can fix properly. See:
-    # https://github.com/haskell-gi/haskell-gi/issues/226
-    ++ lib.optional (lib.strings.hasPrefix "gi-" fullName) gobject-introspection;
+    ++ map (d: d.components.library or d) component.depends;
 
   nativeBuildInputs =
     [shellWrappers buildPackages.removeReferencesTo]

--- a/builder/hspkg-builder.nix
+++ b/builder/hspkg-builder.nix
@@ -84,6 +84,7 @@ let
       component = components.setup // {
         depends = config.setup-depends ++ components.setup.depends ++ package.setup-depends;
         extraSrcFiles = components.setup.extraSrcFiles ++ [ "Setup.hs" "Setup.lhs" ];
+        pkgconfig = if components ? library then components.library.pkgconfig or [] else [];
       };
       inherit package name src flags revision patches defaultSetupSrc;
       inherit (pkg) preUnpack postUnpack;

--- a/package-set.nix
+++ b/package-set.nix
@@ -13,7 +13,7 @@ in pkgs.lib.evalModules {
         # as well as pkgconfPkgs, which are used to resolve pkgconfig name to nixpkgs names.  We simply
         # augment the existing pkgs set with the specific mappings:
         pkgs = pkgs // (import ./lib/system-nixpkgs-map.nix pkgs);
-        pkgconfPkgs = pkgs // (import ./lib/pkgconf-nixpkgs-map.nix pkgs);
+        pkgconfPkgs = import ./lib/pkgconf-nixpkgs-map.nix pkgs;
 
         inherit buildModules;
       };


### PR DESCRIPTION
pkgconfig-depends that make use of propagatedBuildInputs and frameworks
are not propagated to the exe component that links them. This seems
to be because our libraries do not not include their dependencies
as `buildInputs`.  To make this work it also seems to be necessary
for pkgconfig depends themselves to be `propagaedBuildInputs`.