### PR TITLE
backport ghc!3227

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -135,6 +135,8 @@ in {
                 ++ final.lib.optional (versionAtLeast "8.6.4" && final.stdenv.isDarwin) ./patches/ghc/ghc-macOS-loadArchive-fix.patch
                 ++ final.lib.optional (versionAtLeast "8.4.4" && versionLessThan "8.10" && final.stdenv.isDarwin) ./patches/ghc/ghc-darwin-gcc-version-fix.patch
                 ++ final.lib.optional (versionAtLeast "8.10.1" && final.stdenv.isDarwin) ./patches/ghc/ghc-8.10-darwin-gcc-version-fix.patch
+                # backport of https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3227
+                ++ fromUntil "8.8" "8.12"      ./patches/ghc/67738db10010fd28a8e997b5c8f83ea591b88a0e.patch
                 ;
         in ({
             ghc844 = final.callPackage ../compiler/ghc {

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -136,6 +136,10 @@ in {
                 ++ final.lib.optional (versionAtLeast "8.4.4" && versionLessThan "8.10" && final.stdenv.isDarwin) ./patches/ghc/ghc-darwin-gcc-version-fix.patch
                 ++ final.lib.optional (versionAtLeast "8.10.1" && final.stdenv.isDarwin) ./patches/ghc/ghc-8.10-darwin-gcc-version-fix.patch
                 # backport of https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3227
+                # the first one is a prerequisite.
+                # both are trimmed to only include the make build system part and not the
+                # hadrian one.
+                ++ fromUntil "8.8" "8.12"      ./patches/ghc/bec76733b818b0489ffea0834ab6b1560207577c.patch
                 ++ fromUntil "8.8" "8.12"      ./patches/ghc/67738db10010fd28a8e997b5c8f83ea591b88a0e.patch
                 ;
         in ({

--- a/overlays/patches/ghc/67738db10010fd28a8e997b5c8f83ea591b88a0e.patch
+++ b/overlays/patches/ghc/67738db10010fd28a8e997b5c8f83ea591b88a0e.patch
@@ -1,0 +1,107 @@
+From 67738db10010fd28a8e997b5c8f83ea591b88a0e Mon Sep 17 00:00:00 2001
+From: Travis Whitaker <pi.boy.travis@gmail.com>
+Date: Wed, 6 May 2020 04:14:47 +0000
+Subject: [PATCH] Build a threaded stage 1 if the bootstrapping GHC supports
+ it.
+
+---
+ compiler/ghc.mk                  |  6 ++++++
+ configure.ac                     | 15 +++++++++++++++
+ ghc/ghc.mk                       |  9 ++++++++-
+ mk/config.mk.in                  |  3 +++
+ 8 files changed, 98 insertions(+), 21 deletions(-)
+
+diff --git a/compiler/ghc.mk b/compiler/ghc.mk
+index 6a2dadc820..6e86b73e8d 100644
+--- a/compiler/ghc.mk
++++ b/compiler/ghc.mk
+@@ -194,6 +194,12 @@ ifeq "$(GhcThreaded)" "YES"
+ compiler_stage2_CONFIGURE_OPTS += --ghc-option=-optc-DTHREADED_RTS
+ endif
+
++# If the bootstrapping GHC supplies the threaded RTS, then we can have a
++# threaded stage 1 too.
++ifeq "$(GhcThreadedRts)" "YES"
++compiler_stage1_CONFIGURE_OPTS += --ghc-option=-optc-DTHREADED_RTS
++endif
++
+ ifeq "$(GhcWithNativeCodeGen)" "YES"
+ compiler_stage1_CONFIGURE_OPTS += --flags=ncg
+ compiler_stage2_CONFIGURE_OPTS += --flags=ncg
+diff --git a/configure.ac b/configure.ac
+index a621814700..bac2cfde5e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -124,6 +124,9 @@ AC_ARG_VAR(CC_STAGE0, [C compiler command (bootstrap)])
+ AC_ARG_VAR(LD_STAGE0, [Linker command (bootstrap)])
+ AC_ARG_VAR(AR_STAGE0, [Archive command (bootstrap)])
+
++dnl RTS ways supplied by the bootstrapping compiler.
++AC_ARG_VAR(RTS_WAYS_STAGE0, [RTS ways])
++
+ if test "$WithGhc" != ""; then
+   FPTOOLS_GHC_VERSION([GhcVersion], [GhcMajVersion], [GhcMinVersion], [GhcPatchLevel])dnl
+
+@@ -151,6 +154,17 @@ if test "$WithGhc" != ""; then
+   fi
+   BOOTSTRAPPING_GHC_INFO_FIELD([AR_OPTS_STAGE0],[ar flags])
+   BOOTSTRAPPING_GHC_INFO_FIELD([ArSupportsAtFile_STAGE0],[ar supports at file])
++  BOOTSTRAPPING_GHC_INFO_FIELD([RTS_WAYS_STAGE0],[RTS ways])
++
++  dnl Check whether or not the bootstrapping GHC has a threaded RTS. This
++  dnl determines whether or not we can have a threaded stage 1.
++  dnl See Note [Linking ghc-bin against threaded stage0 RTS] in
++  dnl hadrian/src/Settings/Packages.hs for details.
++  if echo ${RTS_WAYS_STAGE0} | grep '.*thr.*' 2>&1 >/dev/null; then
++      AC_SUBST(GhcThreadedRts, YES)
++  else
++      AC_SUBST(GhcThreadedRts, NO)
++  fi
+ fi
+
+ dnl ** Must have GHC to build GHC
+@@ -1454,6 +1468,7 @@ Configure completed successfully.
+ echo "\
+    Bootstrapping using   : $WithGhc
+       which is version   : $GhcVersion
++      with threaded RTS? : $GhcThreadedRts
+ "
+
+ if test "x$CcLlvmBackend" = "xYES"; then
+diff --git a/ghc/ghc.mk b/ghc/ghc.mk
+index 8c112a054f..5512d50710 100644
+--- a/ghc/ghc.mk
++++ b/ghc/ghc.mk
+@@ -66,8 +66,15 @@ else
+ ghc_stage2_CONFIGURE_OPTS += -f-threaded
+ ghc_stage3_CONFIGURE_OPTS += -f-threaded
+ endif
+-# Stage-0 compiler isn't guaranteed to have a threaded RTS.
++
++# If stage 0 supplies a threaded RTS, we can use it for stage 1.
++# See Note [Linking ghc-bin against threaded stage0 RTS] in
++# hadrian/src/Settings/Packages.hs for details.
++ifeq "$(GhcThreadedRts)" "YES"
++ghc_stage1_MORE_HC_OPTS += -threaded
++else
+ ghc_stage1_CONFIGURE_OPTS += -f-threaded
++endif
+
+ ifeq "$(GhcProfiled)" "YES"
+ ghc_stage2_PROGRAM_WAY = p
+diff --git a/mk/config.mk.in b/mk/config.mk.in
+index 791dc5acc0..250d41ebe6 100644
+--- a/mk/config.mk.in
++++ b/mk/config.mk.in
+@@ -199,6 +199,9 @@ endif
+ # `GhcUnregisterised` mode doesn't allow that.
+ GhcWithSMP := $(strip $(if $(filter YESNO, $(ArchSupportsSMP)$(GhcUnregisterised)),YES,NO))
+
++# Whether or not the bootstrapping GHC supplies a threaded RTS.
++GhcThreadedRts = @GhcThreadedRts@
++
+ # Whether to include GHCi in the compiler.  Depends on whether the RTS linker
+ # has support for this OS/ARCH combination.
+
+--
+2.25.0

--- a/overlays/patches/ghc/bec76733b818b0489ffea0834ab6b1560207577c.patch
+++ b/overlays/patches/ghc/bec76733b818b0489ffea0834ab6b1560207577c.patch
@@ -1,0 +1,43 @@
+From bec76733b818b0489ffea0834ab6b1560207577c Mon Sep 17 00:00:00 2001
+From: Ben Gamari <ben@smart-cactus.org>
+Date: Wed, 15 Jan 2020 14:57:08 -0500
+Subject: [PATCH] Fix GhcThreaded setting
+
+This adopts a patch from NetBSD's packaging fixing the `GhcThreaded`
+option of the make build system. In addition we introduce a `ghcThreaded`
+option in hadrian's `Flavour` type.
+
+Also fix Hadrian's treatment of the `Use Threaded` entry in `settings`.
+Previously it would incorrectly claim `Use Threaded = True` if we were
+building the `threaded` runtime way. However, this is inconsistent with
+the `make` build system, which defines it to be whether the `ghc`
+executable is linked against the threaded runtime.
+
+Fixes #17692.
+---
+ ghc/ghc.mk                       | 6 ++++++
+ hadrian/doc/user-settings.md     | 2 ++
+ hadrian/src/Flavour.hs           | 2 ++
+ hadrian/src/Rules/Generate.hs    | 2 +-
+ hadrian/src/Settings/Default.hs  | 1 +
+ hadrian/src/Settings/Packages.hs | 4 +++-
+ 6 files changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/ghc/ghc.mk b/ghc/ghc.mk
+index 3bff2f58c93..8c112a054f9 100644
+--- a/ghc/ghc.mk
++++ b/ghc/ghc.mk
+@@ -61,7 +61,13 @@ ifeq "$(GhcThreaded)" "YES"
+ # Use threaded RTS with GHCi, so threads don't get blocked at the prompt.
+ ghc_stage2_MORE_HC_OPTS += -threaded
+ ghc_stage3_MORE_HC_OPTS += -threaded
++else
++# Opt out from threaded GHC. See ghc-bin.cabal.in
++ghc_stage2_CONFIGURE_OPTS += -f-threaded
++ghc_stage3_CONFIGURE_OPTS += -f-threaded
+ endif
++# Stage-0 compiler isn't guaranteed to have a threaded RTS.
++ghc_stage1_CONFIGURE_OPTS += -f-threaded
+
+ ifeq "$(GhcProfiled)" "YES"
+ ghc_stage2_PROGRAM_WAY = p


### PR DESCRIPTION
This essentially backports the following two commits (make build system parts only)

- https://github.com/ghc/ghc/commit/bec76733b818b0489ffea0834ab6b1560207577c
- https://github.com/ghc/ghc/commit/67738db10010fd28a8e997b5c8f83ea591b88a0e

fixes #584