### PR TITLE
`compiler-nix-name` fix for `shellFor` `tools`

### DIFF
--- a/overlays/tools.nix
+++ b/overlays/tools.nix
@@ -68,12 +68,15 @@ in { haskell-nix = prev.haskell-nix // {
   tools = lib.mapAttrs final.haskell-nix.tool;
 
   # Like `tools` but allows default ghc to be specified
-  toolsForGhc = ghc: toolSet:
+  toolsForGhc = ghcOverride: toolSet:
     final.haskell-nix.tools (
       lib.mapAttrs (name: versionOrArgs:
-        # Add default ghc if not specified in the args
-        { inherit ghc; }
-          // final.haskell-nix.haskellLib.versionOrArgsToArgs versionOrArgs
+        let args = final.haskell-nix.haskellLib.versionOrArgsToArgs versionOrArgs;
+        in
+          # Add default ghc if not specified in the args
+          (lib.optionalAttrs (!(args ? "compiler-nix-name" || args ? "ghc"))
+            { inherit ghcOverride; }
+          ) // args
       ) toolSet
     );
 


### PR DESCRIPTION
Currently the ghc version is picked to match the `shellFor` project
and you cannot replace it by specifying `compiler-nix-name`.
This change fixes that and also uses `ghcOverride` so warning to asking
for a `compiler-nix-name` is not displayed when the compiler has already
been picked (by the project that shellFor is for).