### PR TITLE
Use internalHackageIndexState to pin hoogle

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -40,7 +40,11 @@ let
 
   hoogleLocal = let
     nixpkgsHoogle = import (pkgs.path + /pkgs/development/haskell-modules/hoogle.nix);
-  in { packages ? [], hoogle ? pkgs.buildPackages.haskell-nix.tool "hoogle" "5.0.17.15" }:
+  in { packages ? [], hoogle ? pkgs.buildPackages.haskell-nix.tool "hoogle" {
+        version = "5.0.17.15";
+        index-state = pkgs.haskell-nix.internalHackageIndexState;
+      }
+    }:
     haskellLib.weakCallPackage pkgs nixpkgsHoogle { 
       # For musl we can use haddock from the buildGHC
       ghc = if stdenv.hostPlatform.isLinux && stdenv.targetPlatform.isMusl && !haskellLib.isNativeMusl


### PR DESCRIPTION
Without this pin the plan choosen with the latest hackage is currently
broken and the build fails with:

```
src/General/Web.hs:21:1: error:
    Could not find module ‘Data.Aeson.Encoding’
    Perhaps you meant
      Data.Aeson.Encode (from aeson-0.11.3.0)
      Data.ASN1.Encoding (needs flag -package-key asn1-encoding-0.9.6)
      Data.Text.Encoding (from text-1.2.3.1)
    Use -v to see a list of the files searched for.
   |
21 | import Data.Aeson.Encoding
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
```