### PR TITLE
Fix haddock when pkgconfig is needed to configure

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -200,7 +200,7 @@ let
     inherit componentId component package flags commonConfigureFlags
       commonAttrs revision setupGhcOptions doHaddock
       doHoogle hyperlinkSource quickjump setupHaddockFlags
-      needsProfiling configFiles preHaddock postHaddock;
+      needsProfiling configFiles preHaddock postHaddock pkgconfig;
 
     componentDrv = drv;
   };

--- a/builder/haddock-builder.nix
+++ b/builder/haddock-builder.nix
@@ -96,6 +96,8 @@ let
       # If we don't have any source files, no need to run haddock
       [[ -n $(find . -name "*.hs" -o -name "*.lhs") ]] && {
       docdir="${docdir "$doc"}"
+      # This mkdir needed for packages like bytestring-builder which
+      # is empty when `bytestring >= 0.10.4`
       mkdir -p "$docdir"
 
       $SETUP_HS haddock \

--- a/builder/haddock-builder.nix
+++ b/builder/haddock-builder.nix
@@ -8,6 +8,7 @@
 , commonAttrs
 , preHaddock
 , postHaddock
+, pkgconfig
 , commonConfigureFlags
 
 , doHaddock
@@ -72,6 +73,11 @@ let
     outputs = ["out"]
     ++ lib.optional doHaddock' "doc";
 
+    propagatedBuildInputs = builtins.concatLists pkgconfig;
+  
+    buildInputs = component.libs
+      ++ map (d: d.components.library.haddock or d) component.depends;
+
     nativeBuildInputs =
       [ shellWrappers buildPackages.removeReferencesTo ]
       ++ componentDrv.executableToolDepends;
@@ -89,6 +95,8 @@ let
       runHook preHaddock
       # If we don't have any source files, no need to run haddock
       [[ -n $(find . -name "*.hs" -o -name "*.lhs") ]] && {
+      docdir="${docdir "$doc"}"
+      mkdir -p "$docdir"
 
       $SETUP_HS haddock \
         "--html" \


### PR DESCRIPTION
Packages like haskell-gi need pkgconfig at configue time to generate
source files we want to run haddock on.

This change also brings back a `mkdir` for the $docs that is needed
for haddock of bytesting-builder (it was removed when haddock the
haddock derivation was split out).