### PR TITLE
Reduce `roots` to a single derivation.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 This file contains a summary of changes to Haskell.nix and `nix-tools`
 that will impact users.
 
+## July ?, 2020
+* Changed `haskell-nix.roots` and `p.roots` to single derivations.
+
 ## July 8, 2020
 * Removed `sources.nixpkgs-default`, use `sources.nixpkgs` instead.
 * Removed `./nixpkgs` directory, use  `(import ./. {}).sources`

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -620,14 +620,12 @@ final: prev: {
         withInputs = final.recurseIntoAttrs;
 
         # Add this to your tests to make all the dependencies of haskell.nix
-        # are tested and cached.
-        roots = compiler-nix-name: final.recurseIntoAttrs {
-          Level0 = roots' compiler-nix-name 0;
-          Level1 = roots' compiler-nix-name 1;
-          # Should be safe to use this now we have materialized everything
-          # except the tests
-          Level2 = roots' compiler-nix-name 2;
-        };
+        # are tested and cached. Consider using `p.roots` where `p` is a
+        # project as it will automatically match the `compiler-nix-name`
+        # of the project.
+        roots = compiler-nix-name: final.linkFarm "haskell-nix-roots-${compiler-nix-name}"
+          (final.lib.mapAttrsToList (name: path: { inherit name path; })
+            (roots' compiler-nix-name 2));
 
         roots' = compiler-nix-name: ifdLevel:
           	final.recurseIntoAttrs ({


### PR DESCRIPTION
This makes it less noisy when added to haskell.nix.  This change
also simplifies things to just use `ifdLevel` 2. In the past higher
`ifdLevels` were not always supersets of the lower levels.  This is
no longer the case so we can safely use just level 2.