### PR TITLE
(Re)Apply workaround for single-user sandbox perm issue

### DIFF
--- a/overlays/ghc-packages.nix
+++ b/overlays/ghc-packages.nix
@@ -33,6 +33,7 @@ let
       }) files);
     in final.evalPackages.runCommand "${name}${ext}" {} ''
       cp -Lr ${links} $out
+      chmod -R +w $out
     '';
 
   # Combine the all the boot package nix files for a given ghc
@@ -102,7 +103,7 @@ in rec {
           if dir == "libraries/ghc-boot"
             then final.evalPackages.runCommand "ghc-boot-src" {} ''
               cp -Lr ${value.passthru.configured-src}/${dir} $out
-              chmod -R +w $out/GHC
+              chmod -R +w $out
               cp -Lr ${value.generated}/libraries/ghc-boot/dist-install/build/GHC/* $out/GHC
             ''
             else if dir == "compiler"


### PR DESCRIPTION
Fixes the following error that occurs on single-user nix installations when
compiling an otherwise trivial cabalProject/stackProject:

> error: moving build output '/nix/store/d5zpqajgysbk38iqgcjwgqx44amqh9pw-ghc-boot-src' from the sandbox to the Nix store: Permission denied

Tested on ghc-8.4 where there is nothing in the cache.
Materialisation of ghc(-boot-src) also still works/works again.

See https://github.com/input-output-hk/haskell.nix/issues/466
and the previous attempt to fix this
at https://github.com/input-output-hk/haskell.nix/pull/399
(d3905d62b5c5ca7f671f5a301c4fcab433ebf68c..8561498e7d9237cc271f9ffd7bff19e3293122b0)