### PR TITLE
Fix for gi-harfbuzz 0.0.3

### DIFF
--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -61,6 +61,7 @@ pkgs:
     "gtk-x11-2.0"                        = [ pkgs."gtk_x11" ];
     "gtkglext-1.0"                       = [ pkgs.gnome2.gtkglext pkgs.gtk2 ];
     "gtksourceview-3.0"                  = [ pkgs."gtksourceview3" ];
+    "harfbuzz-gobject"                   = [ pkgs."harfbuzz" ];
     "hidapi-libusb"                      = [ pkgs."hidapi" ];
     "icudata"                            = [ pkgs."icu" ];
     "icui18n"                            = [ pkgs."icu" ];


### PR DESCRIPTION
It adds `pkgconfig-depends: harfbuzz-gobject >= 1`.  In nixpkgs
this is in the `harfbuzz` derivation so we need a mapping.