### PR TITLE
Add another check for #660 issues

### DIFF
--- a/builder/make-config-files.nix
+++ b/builder/make-config-files.nix
@@ -119,13 +119,6 @@ in
     ''}
 
     for p in ${lib.concatStringsSep " " libDeps}; do
-      ${ # Sanity check for https://github.com/input-output-hk/haskell.nix/issues/660
-      ''
-      if [[ ! -s $p/envDep ]]; then
-        echo "ERROR: Missing or empty file $p/envDep"
-        exit 0
-      fi
-      ''}
       cat $p/envDep >> $out/ghc-environment
       ${ lib.optionalString component.doExactConfig ''
         cat $p/exactDep/configure-flags >> $out/configure-flags

--- a/builder/make-config-files.nix
+++ b/builder/make-config-files.nix
@@ -119,6 +119,13 @@ in
     ''}
 
     for p in ${lib.concatStringsSep " " libDeps}; do
+      ${ # Sanity check for https://github.com/input-output-hk/haskell.nix/issues/660
+      ''
+      if [[ ! -s $p/envDep ]]; then
+        echo "ERROR: Missing or empty file $p/envDep"
+        exit 0
+      fi
+      ''}
       cat $p/envDep >> $out/ghc-environment
       ${ lib.optionalString component.doExactConfig ''
         cat $p/exactDep/configure-flags >> $out/configure-flags


### PR DESCRIPTION
Currently if the `ghc-pkg` fails during the last stage of building a library component
(perhaps because of https://github.com/NixOS/nix/issues/719) the failure is ignored.
This seems to be the most likely cause of the bad `config` derivation.

This change should cause the derivation build to fail instead of making invalid
files when this happens.