### PR TITLE
Fix types of some meta attributes

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -228,8 +228,8 @@ let
     );
 
     meta = {
-      homepage = package.homepage;
-      description = package.synopsis;
+      homepage = package.homepage or "";
+      description = package.synopsis or "";
       license =
         let
           license-map = import ../lib/cabal-licenses.nix lib;

--- a/builder/setup-builder.nix
+++ b/builder/setup-builder.nix
@@ -48,8 +48,8 @@ let
       };
 
       meta = {
-        homepage = package.homepage;
-        description = package.synopsis;
+        homepage = package.homepage or "";
+        description = package.synopsis or "";
         license =
           let
             license-map = import ../lib/cabal-licenses.nix lib;


### PR DESCRIPTION
These can't be null. They could perhaps be absent, but I can't figure
out how to set an attribute only if something else isn't null in a nice
way, and having it be the empty string seems fine.

Fixes #804.