### PR TITLE
fix: remove numa support for armv6l

### DIFF
--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -126,7 +126,7 @@ let
     ++ [targetLibffi]
     ++ stdenv.lib.optional (!enableIntegerSimple) gmp
     ++ stdenv.lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv
-    ++ stdenv.lib.optional platform.isLinux numactl;
+    ++ stdenv.lib.optional (platform.isLinux && !platform.isAarch32) numactl;
 
   toolsForTarget =
     if hostPlatform == buildPlatform then


### PR DESCRIPTION
There is no support for NUMA on Armv6l (such as in the Raspberry Pi). Having a dependency on numactl at the compiler-level seems to also enable numa support for the generated programs as well. Even if it's not used, dependency on libnuma prevents the generated executables to launch without an error indicating that libnuma could not be found in the system.

My testing environment is a Raspberry Pi 3 with a heavily customized Linux distribution, without libnuma as it is flagged as not supported on arm processors. While I can't find any definitive sources on that, it seems that it is at least the case for armv6l. It doesn't seem true however for Aarch64, so this commit only removes the numa dependency for Aarch32. Perhaps it would be possible to still generate the libnuma on those systems, but would it be useful if the target CPUs ultimately don't support it?