### PR TITLE
Use internal nix-tools and cabal-install in call-cabal-projet-to-nix

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -21,8 +21,8 @@ in
 , caller               ? "callCabalProjectToNix" # Name of the calling funcion for better warning messages
 , ghc           ? null # Deprecated in favour of `compiler-nix-name`
 , ghcOverride   ? null # Used when we need to set ghc explicitly during bootstrapping
-, nix-tools     ? evalPackages.haskell-nix.nix-tools.${compiler-nix-name}     # When building cabal projects we use the nix-tools
-, cabal-install ? evalPackages.haskell-nix.cabal-install.${compiler-nix-name} # and cabal-install compiled with matching ghc version
+, nix-tools     ? evalPackages.haskell-nix.internal-nix-tools     # When building cabal projects we use the internal nix-tools
+, cabal-install ? evalPackages.haskell-nix.internal-cabal-install # and cabal-install
 , configureArgs ? "" # Extra arguments to pass to `cabal v2-configure`.
                      # `--enable-tests --enable-benchmarks` are included by default.
                      # If the tests and benchmarks are not needed and they


### PR DESCRIPTION
This is mostly just to kick of discussion, this might well be the wrong thing to do.

Recently, I tried bumping our compiler version. And, as usual, I had to wait a long time before I could eval, because I had to build the nix-tools and cabal-install for the new compiler version.

But: why? This is *the* big thing eval-time dependency, so always using a version that should be cached is a big win. I think the main argument is what @hamishmack said in https://github.com/input-output-hk/haskell.nix/pull/738:

>  Less overhead on macOS where dynamic linking pulls in the compiler used for nix-tools and cabal-install.
> Yes that is my main concern. On macOS it is likely build or download a whole extra GHC. If the user tries to solve that by passing in your own nix-tools to cabalProject but then everything in the cache that depends on nix-tools does not match.

I don't have a counter-argument to this except to say that the prize (making it much more likely that eval-time deps are cached) seems big enough that it's worth bearing some coost.