### PR TITLE
Cache ghc883 and ghc8101 again (without tests)

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -32,7 +32,7 @@
     # We need to use the actual nixpkgs version we're working with here, since the values
     # of 'lib.systems.examples' are not understood between all versions
     let lib = nixpkgs.lib;
-    in lib.optionalAttrs (system == "x86_64-linux" && compiler-nix-name != "ghc8102") {
+    in lib.optionalAttrs (system == "x86_64-linux" && compiler-nix-name != "ghc8101" && compiler-nix-name != "ghc8102") {
     # Windows cross compilation is currently broken on macOS
     inherit (lib.systems.examples) mingwW64;
   } // lib.optionalAttrs (system == "x86_64-linux") {

--- a/ci.nix
+++ b/ci.nix
@@ -21,6 +21,7 @@
     # have a ./materialized/ghcXXX directory containing the materialized
     # cabal-install and nix-tools plans.  When removing a ghc version
     # from here (so that is no longer cached) also remove ./materialized/ghcXXX.
+    # Update supported-ghc-versions.md to reflect any changes made here.
     {
       ghc865 = true;
     } // nixpkgs.lib.optionalAttrs (nixpkgsName == "R2003") {

--- a/ci.nix
+++ b/ci.nix
@@ -15,14 +15,20 @@
   compilerNixNames = nixpkgsName: nixpkgs: builtins.mapAttrs (compiler-nix-name: runTests: {
     inherit (import ./default.nix { inherit checkMaterialization; }) nixpkgsArgs;
     inherit runTests;
-  }) ({
-    ghc865 = true;
-  } // nixpkgs.lib.optionalAttrs (nixpkgsName == "R2003") {
-    ghc883 = false;
-    ghc884 = true;
-    ghc8101 = false;
-    ghc8102 = true;
-  });
+  }) (
+    # GHC version to cache and whether to run the tests against them.
+    # This list of GHC versions should include everything for which we
+    # have a ./materialized/ghcXXX directory containing the materialized
+    # cabal-install and nix-tools plans.  When removing a ghc version
+    # from here (so that is no longer cached) also remove ./materialized/ghcXXX.
+    {
+      ghc865 = true;
+    } // nixpkgs.lib.optionalAttrs (nixpkgsName == "R2003") {
+      ghc883 = false;
+      ghc884 = true;
+      ghc8101 = false;
+      ghc8102 = true;
+    });
   systems = nixpkgs: nixpkgs.lib.filterAttrs (_: v: builtins.elem v supportedSystems) {
     # I wanted to take these from 'lib.systems.examples', but apparently there isn't one for linux!
     linux = "x86_64-linux";

--- a/ci.nix
+++ b/ci.nix
@@ -12,12 +12,16 @@
     "R1909" = "nixpkgs-1909";
     "R2003" = "nixpkgs-2003";
   };
-  compilerNixNames = nixpkgsName: nixpkgs: builtins.mapAttrs (compiler-nix-name: _:
-    (import ./default.nix { inherit checkMaterialization; }).nixpkgsArgs) ({
-    ghc865 = {};
+  compilerNixNames = nixpkgsName: nixpkgs: builtins.mapAttrs (compiler-nix-name: runTests: {
+    inherit (import ./default.nix { inherit checkMaterialization; }) nixpkgsArgs;
+    inherit runTests;
+  }) ({
+    ghc865 = true;
   } // nixpkgs.lib.optionalAttrs (nixpkgsName == "R2003") {
-    ghc884 = {};
-    ghc8102 = {};
+    ghc883 = false;
+    ghc884 = true;
+    ghc8101 = false;
+    ghc8102 = true;
   });
   systems = nixpkgs: nixpkgs.lib.filterAttrs (_: v: builtins.elem v supportedSystems) {
     # I wanted to take these from 'lib.systems.examples', but apparently there isn't one for linux!
@@ -41,7 +45,7 @@ dimension "Nixpkgs version" nixpkgsVersions (nixpkgsName: nixpkgs-pin:
   let pinnedNixpkgsSrc = sources.${nixpkgs-pin};
       # We need this for generic nixpkgs stuff at the right version
       genericPkgs = import pinnedNixpkgsSrc {};
-  in dimension "GHC version" (compilerNixNames nixpkgsName genericPkgs) (compiler-nix-name: nixpkgsArgs:
+  in dimension "GHC version" (compilerNixNames nixpkgsName genericPkgs) (compiler-nix-name: {nixpkgsArgs, runTests}:
     dimension "System" (systems genericPkgs) (systemName: system:
       let pkgs = import pinnedNixpkgsSrc (nixpkgsArgs // { inherit system; });
           build = import ./build.nix { inherit pkgs ifdLevel compiler-nix-name; };
@@ -50,8 +54,10 @@ dimension "Nixpkgs version" nixpkgsVersions (nixpkgsName: nixpkgs-pin:
         # Native builds
         # TODO: can we merge this into the general case by picking an appropriate "cross system" to mean native?
         native = pkgs.recurseIntoAttrs ({
-          inherit (build) tests tools maintainer-scripts maintainer-script-cache;
+          roots = pkgs.haskell-nix.roots' compiler-nix-name ifdLevel;
           ghc = pkgs.buildPackages.haskell-nix.compiler."${compiler-nix-name}";
+        } // pkgs.lib.optionalAttrs runTests {
+          inherit (build) tests tools maintainer-scripts maintainer-script-cache;
         } // pkgs.lib.optionalAttrs (ifdLevel >= 1) {
           iserv-proxy = pkgs.ghc-extra-packages."${compiler-nix-name}".iserv-proxy.components.exes.iserv-proxy;
         } // pkgs.lib.optionalAttrs (ifdLevel >= 3) {
@@ -63,21 +69,17 @@ dimension "Nixpkgs version" nixpkgsVersions (nixpkgsName: nixpkgs-pin:
         # Cross builds
         let pkgs = import pinnedNixpkgsSrc (nixpkgsArgs // { inherit system crossSystem; });
             build = import ./build.nix { inherit pkgs ifdLevel compiler-nix-name; };
-        in pkgs.recurseIntoAttrs (pkgs.lib.optionalAttrs (ifdLevel >= 1) {
-          ghc = pkgs.buildPackages.haskell-nix.compiler."${compiler-nix-name}";
-          # TODO: look into cross compiling ghc itself
-          # ghc = pkgs.haskell-nix.compiler."${compiler-nix-name}";
-          # TODO: look into making tools work when cross compiling
-          # inherit (build) tools;
-          # Tests are broken on aarch64 cross https://github.com/input-output-hk/haskell.nix/issues/513
-          tests =
-            if (crossSystemName != "aarch64-multiplatform")
-              then build.tests
-              else pkgs.recurseIntoAttrs {
-                # Even on aarch64 we still want to build the pinned files
-                inherit (build.tests) roots;
-              };
-        } // pkgs.lib.optionalAttrs (ifdLevel >= 2) {
+        in pkgs.recurseIntoAttrs (pkgs.lib.optionalAttrs (ifdLevel >= 1) ({
+            roots = pkgs.haskell-nix.roots' compiler-nix-name ifdLevel;
+            ghc = pkgs.buildPackages.haskell-nix.compiler."${compiler-nix-name}";
+            # TODO: look into cross compiling ghc itself
+            # ghc = pkgs.haskell-nix.compiler."${compiler-nix-name}";
+            # TODO: look into making tools work when cross compiling
+            # inherit (build) tools;
+          } // pkgs.lib.optionalAttrs (runTests && crossSystemName != "aarch64-multiplatform") {
+            # Tests are broken on aarch64 cross https://github.com/input-output-hk/haskell.nix/issues/513
+            inherit (build) tests;
+        }) // pkgs.lib.optionalAttrs (ifdLevel >= 2) {
           remote-iserv = pkgs.ghc-extra-packages."${compiler-nix-name}".remote-iserv.components.exes.remote-iserv;
           iserv-proxy = pkgs.ghc-extra-packages."${compiler-nix-name}".iserv-proxy.components.exes.iserv-proxy;
         } // pkgs.lib.optionalAttrs (ifdLevel >= 3) {

--- a/docs/adding-new-ghc.md
+++ b/docs/adding-new-ghc.md
@@ -10,6 +10,8 @@ Check the LLVM version that should be used in the
 
 ## Update the list of cached GHC versions in `ci.nix`
 
+## Update [supported ghc versions](supported-ghc-versions.md) document
+
 ## Add the materialized files
 
 In the haskell.nix repo run:

--- a/docs/adding-new-ghc.md
+++ b/docs/adding-new-ghc.md
@@ -8,8 +8,9 @@ you update the `spec.sha256` or the other versions source will be used.
 Check the LLVM version that should be used in the
 [ghc wiki](https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/compiler/backends/llvm/installing).
 
+## Update the list of cached GHC versions in `ci.nix`
 
-## Update the materialized files
+## Add the materialized files
 
 In the haskell.nix repo run:
 

--- a/docs/supported-ghc-versions.md
+++ b/docs/supported-ghc-versions.md
@@ -1,0 +1,32 @@
+# Supported GHC Versions
+
+The following versions of GHC built on the CI servers and should be included
+in the cache (for the default haskell.nix `nixpkgs`).
+
+* 8.6.5 `compiler-nix-name = "ghc865";`
+* 8.8.3 `compiler-nix-name = "ghc883";`
+* 8.8.4 `compiler-nix-name = "ghc884";`
+* 8.10.1 `compiler-nix-name = "ghc8101";`
+* 8.10.2 `compiler-nix-name = "ghc8102";`
+
+Full test suite is run against 8.6.5, 8.8.4 and 8.10.2.
+
+See [ci.nix](https://github.com/input-output-hk/haskell.nix/blob/master/ci.nix)
+for the list of tested GHC versions.
+
+The following GHC versions are not included in CI and will not be cached:
+
+* 8.4.4 `compiler-nix-name = "ghc844";`
+* 8.6.1 `compiler-nix-name = "ghc861";`
+* 8.6.2 `compiler-nix-name = "ghc862";`
+* 8.6.3 `compiler-nix-name = "ghc863";`
+* 8.6.4 `compiler-nix-name = "ghc864";`
+* 8.8.1 `compiler-nix-name = "ghc881";`
+* 8.8.2 `compiler-nix-name = "ghc882";`
+
+See [overlays/bootstrap.nix](https://github.com/input-output-hk/haskell.nix/blob/master/overlays/bootstrap.nix)
+for a list of all the valid `compiler-nix-names`.
+
+See also:
+
+* [Instructions on adding new ghc versions](adding-new-ghc.md).

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluting
 # on a machine with e.g. no way to build the Darwin IFDs you need! 
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 3
+, ifdLevel ? 0
 , checkMaterialization ? false }:
 
 let

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluting
 # on a machine with e.g. no way to build the Darwin IFDs you need! 
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 2
+, ifdLevel ? 3
 , checkMaterialization ? false }:
 
 let

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluting
 # on a machine with e.g. no way to build the Darwin IFDs you need! 
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 1
+, ifdLevel ? 2
 , checkMaterialization ? false }:
 
 let

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluting
 # on a machine with e.g. no way to build the Darwin IFDs you need! 
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 0
+, ifdLevel ? 1
 , checkMaterialization ? false }:
 
 let

--- a/test/default.nix
+++ b/test/default.nix
@@ -214,11 +214,7 @@ let
   # - input ifdLevel is 3 or greater: return allTests
   optionalIfdTests = ifdLevel:
     pkgs.lib.optionalAttrs (ifdLevel > 1) (allTestsWithIfdInputs ifdLevel);
-in
-
-pkgs.recurseIntoAttrs {
-  roots = haskell-nix.roots' compiler-nix-name ifdLevel;
-} // optionalIfdTests ifdLevel
+in optionalIfdTests ifdLevel
 
 ## more possible test cases
 # 1. fully static linking

--- a/test/default.nix
+++ b/test/default.nix
@@ -214,7 +214,7 @@ let
   # - input ifdLevel is 3 or greater: return allTests
   optionalIfdTests = ifdLevel:
     pkgs.lib.optionalAttrs (ifdLevel > 1) (allTestsWithIfdInputs ifdLevel);
-in optionalIfdTests ifdLevel
+in pkgs.recurseIntoAttrs (optionalIfdTests ifdLevel)
 
 ## more possible test cases
 # 1. fully static linking


### PR DESCRIPTION
When ghc 8.8.4 and ghc 8.10.2 were added we stopped building the older
versions on ci.  This changes adds them back but does not run all
the tests on them.