### PR TITLE
Suggest adding Hydra substituter in docs

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -24,6 +24,13 @@ $ cachix use iohk
 Configured https://iohk.cachix.org binary cache in ~/.config/nix/nix.conf
 ```
 
+Note: `haskell.nix` currently uses multiple CI providers to build derivations and store outputs. To improve your chances of getting a cache hit, you might want to add the following additional substituter to `~/.config/nix/nix.conf`:
+
+```
+trusted-public-keys = [...] hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= [...]
+substituters = [...] https://hydra.iohk.io [...]
+```
+
 ## Scaffolding
 
 The following work with `stack.yaml` and `cabal.project` based


### PR DESCRIPTION
It seems [Hercules CI](https://hercules-ci.com/github/input-output-hk/haskell.nix) is having some problems, which means build outputs might not be available via the Cachix substituter.