### PR TITLE
Fix #824 (#824)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     # Using the eval-on-build version here as the plan is that
     # `builtins.currentSystem` will not be supported in flakes.
     # https://github.com/NixOS/rfcs/pull/49/files#diff-a5a138ca225433534de8d260f225fe31R429
-    overlay = (self.overlays {}).combined-eval-on-build;
+    overlay = (self.overlays {sourcesOverride = self.sources;}).combined-eval-on-build;
     overlays = import ./overlays;
     config = import ./config.nix;
     # We can't import ./nix/sources.nix directly, because that uses nixpkgs to fetch by default,


### PR DESCRIPTION
This is an attempt to fix https://github.com/input-output-hk/haskell.nix/issues/824 by reusing `self.sources` in `overlays/haskell.nix` instead of `nix/sources.nix`.
I'm not sure at all if this is a correct fix, but it works for me.