### PR TITLE
Changes to allow opencv to be built

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -31,6 +31,7 @@ let self =
 
 , dontPatchELF ? component.dontPatchELF
 , dontStrip ? component.dontStrip
+, hardeningDisable ? component.hardeningDisable
 
 , enableStatic ? component.enableStatic
 , enableShared ? ghc.enableShared && component.enableShared && !haskellLib.isCrossHost
@@ -376,5 +377,9 @@ let
     inherit
       preBuild postBuild
       preInstall postInstall;
-  });
+  }
+  // lib.optionalAttrs (hardeningDisable != []) {
+    inherit hardeningDisable;
+  }
+  );
 in drv; in self)

--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -380,6 +380,5 @@ let
   }
   // lib.optionalAttrs (hardeningDisable != []) {
     inherit hardeningDisable;
-  }
-  );
+  });
 in drv; in self)

--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -106,6 +106,7 @@ pkgs:
     "notify"                             = [ pkgs."libnotify" ];
     "odbc"                               = [ pkgs."unixODBC" ];
     "openblas"                           = [ pkgs."openblasCompat" ];
+    "opencv"                             = [ pkgs."opencv3" ];
     "panelw"                             = [ pkgs."ncurses" ];
     "pangocairo"                         = [ pkgs."pango" ];
     "pcap"                               = [ pkgs."libpcap" ];

--- a/modules/plan.nix
+++ b/modules/plan.nix
@@ -220,6 +220,10 @@ let
       type = nullOr uniqueStr;
       default = getDefaultOrNull def "postHaddock";
     };
+    hardeningDisable = mkOption {
+      type = listOfFilteringNulls str;
+      default = (def.hardeningDisable or []);
+    };
   };
 
 


### PR DESCRIPTION
The opencv library needs:

1. pkgconfig for opencv should return OpenCV 3, not OpenCV 2 (which is
   what pkgs.opencv is)

2. hardeningDisable = [ "bindnow" ] (as per
   https://github.com/LumiGuide/haskell-opencv/commit/5ea490af7662fe74b3740619963d37f1fd91e3d4#)

This commit fixes (1) by adding an entry to lib/pkgconf-nixpkgs-map.nix,
and partially fixes (2) by adding a new `hardeningDisable` option to the
set of package options. The user will still need to specify:

  packages.opencv.hardeningDisable = [ "bindnow" ];

I'm not sure if there's a place to specify this as default in haskell.nix.