### PR TITLE
Fix #836 (#836)

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -331,7 +331,7 @@ in {
                 extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc8101; };
 
                 bootPkgs = bootPkgs // {
-                  ghc = final.haskell-nix.compiler.ghc865;
+                  ghc = final.buildPackages.buildPackages.haskell-nix.compiler.ghc884;
                 };
                 inherit sphinx installDeps;
 
@@ -350,7 +350,7 @@ in {
                 extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc8102; };
 
                 bootPkgs = bootPkgs // {
-                  ghc = final.haskell-nix.compiler.ghc865;
+                  ghc = final.buildPackages.buildPackages.haskell-nix.compiler.ghc884;
                 };
                 inherit sphinx installDeps;
 

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -327,14 +327,11 @@ in {
 
                 ghc-patches = ghc-patches "8.8.4";
             };
-            ghc8101 =
-              let
-                buildPkgs = import final.path ((import ../. {}).nixpkgsArgs // { system = final.stdenv.system; });
-              in final.callPackage ../compiler/ghc {
+            ghc8101 = final.callPackage ../compiler/ghc {
                 extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc8101; };
 
                 bootPkgs = bootPkgs // {
-                  ghc = buildPkgs.haskell-nix.compiler.ghc884;
+                  ghc = final.haskell-nix.compiler.ghc865;
                 };
                 inherit sphinx installDeps;
 
@@ -349,14 +346,11 @@ in {
 
                 ghc-patches = ghc-patches "8.10.1";
             };
-            ghc8102 =
-              let
-                buildPkgs = import final.path ((import ../. {}).nixpkgsArgs // { system = final.stdenv.system; });
-              in final.callPackage ../compiler/ghc {
+            ghc8102 = final.callPackage ../compiler/ghc {
                 extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc8102; };
 
                 bootPkgs = bootPkgs // {
-                  ghc = buildPkgs.haskell-nix.compiler.ghc884;
+                  ghc = final.haskell-nix.compiler.ghc865;
                 };
                 inherit sphinx installDeps;
 


### PR DESCRIPTION
Naïve fix. Not sure if it is correct overall, but it works for me so far (though, my ghc8102 build has yet to finish).
There may be a reason why the `buildPkgs` was there, but I don't know why.