### PR TITLE
cleanGit: Detect when called inside a submodule

### DIFF
--- a/lib/clean-git.nix
+++ b/lib/clean-git.nix
@@ -53,9 +53,10 @@ let
   lines = s: filter (x : x != [] && x != "") (split "\n" s);
 
   origSrcSubDir = toString (src.origSrcSubDir or src);
+  directoryExists = path: builtins.pathExists (builtins.toPath path + "/.");
 in
 
-if builtins.pathExists (origSrcSubDir + "/.git")
+if directoryExists (origSrcSubDir + "/.git")
 then
   let
     hasIndex = builtins.pathExists (origSrcSubDir + "/.git/index");


### PR DESCRIPTION
If cleanGit is called inside a submodule, the true gitdir is not available, so
fall back to cleanSourceWith as if called outside the repository.

Fixes: #787 