### PR TITLE
map blas => openblasCompat

### DIFF
--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -78,6 +78,7 @@ pkgs:
      vulkan = pkgs.vulkan-loader;
      sodium = pkgs.libsodium;
      gfortran = pkgs.gfortran.cc.lib;
+     blas = pkgs.openblasCompat;
    }
 # -- windows
 // { advapi32 = null; gdi32 = null; imm32 = null; msimg32 = null;


### PR DESCRIPTION
This should fix build of libraries like [hmatrix-morpheus](https://hackage.haskell.org/package/hmatrix-morpheus) and other machine learning stuff.