### PR TITLE
Fix hpc for cross-compiled builds

### DIFF
--- a/lib/cover-project.nix
+++ b/lib/cover-project.nix
@@ -55,9 +55,9 @@ let
   srcDirs = map (l: l.src.outPath) (projectLibs);
 
 in pkgs.runCommand "project-coverage-report"
-  ({ buildInputs = [ pkgs.buildPackages.zip ];
-     LANG        = "en_US.UTF-8";
-     LC_ALL      = "en_US.UTF-8";
+  ({ nativeBuildInputs = [ pkgs.buildPackages.zip ];
+     LANG = "en_US.UTF-8";
+     LC_ALL = "en_US.UTF-8";
   } // lib.optionalAttrs (stdenv.buildPlatform.libc == "glibc") {
     LOCALE_ARCHIVE = "${pkgs.buildPackages.glibcLocales}/lib/locale/locale-archive";
   })

--- a/lib/cover-project.nix
+++ b/lib/cover-project.nix
@@ -55,7 +55,8 @@ let
   srcDirs = map (l: l.src.outPath) (projectLibs);
 
 in pkgs.runCommand "project-coverage-report"
-  ({ LANG        = "en_US.UTF-8";
+  ({ buildInputs = [ pkgs.buildPackages.zip ];
+     LANG        = "en_US.UTF-8";
      LC_ALL      = "en_US.UTF-8";
   } // lib.optionalAttrs (stdenv.buildPlatform.libc == "glibc") {
     LOCALE_ARCHIVE = "${pkgs.buildPackages.glibcLocales}/lib/locale/locale-archive";
@@ -144,6 +145,9 @@ in pkgs.runCommand "project-coverage-report"
       findModules allMixModules "$out/share/hpc/vanilla/mix/" "*.mix"
 
       markup srcDirs mixDirs allMixModules "$markupOutDir" "$tixFile"
+
       echo "report coverage $markupOutDir/hpc_index.html" >> $out/nix-support/hydra-build-products
+      ( cd $out/share/hpc/vanilla/html ; zip -r $out/share/hpc/vanilla/html.zip . )
+      echo "file zip $out/share/hpc/vanilla/html.zip" >> $out/nix-support/hydra-build-products
     fi
   ''

--- a/lib/cover-project.nix
+++ b/lib/cover-project.nix
@@ -43,6 +43,11 @@ let
   </html>
   '';
 
+  ghc =
+    if (builtins.length coverageReports) > 0
+    then (builtins.head coverageReports).library.project.pkg-set.config.ghc.package or pkgs.ghc
+    else pkgs.ghc;
+
   libs = map (r: r.library) coverageReports;
 
   projectLibs = map (pkg: pkg.components.library) (lib.attrValues (haskellLib.selectProjectPackages ((lib.head libs).project.hsPkgs)));
@@ -55,15 +60,13 @@ let
   srcDirs = map (l: l.src.outPath) (projectLibs);
 
 in pkgs.runCommand "project-coverage-report"
-  ({ nativeBuildInputs = [ pkgs.buildPackages.zip ];
+  ({ nativeBuildInputs = [ (ghc.buildGHC or ghc) pkgs.buildPackages.zip ];
      LANG = "en_US.UTF-8";
      LC_ALL = "en_US.UTF-8";
   } // lib.optionalAttrs (stdenv.buildPlatform.libc == "glibc") {
     LOCALE_ARCHIVE = "${pkgs.buildPackages.glibcLocales}/lib/locale/locale-archive";
   })
   ''
-    local hpc=${pkgs.buildPackages.haskellPackages.ghc}/bin/hpc
-
     function markup() {
       local -n srcDs=$1
       local -n mixDs=$2
@@ -71,7 +74,7 @@ in pkgs.runCommand "project-coverage-report"
       local destDir=$4
       local tixFile=$5
 
-      local hpcMarkupCmd=("$hpc" "markup" "--destdir=$destDir")
+      local hpcMarkupCmd=("hpc" "markup" "--destdir=$destDir")
       for srcDir in "''${srcDs[@]}"; do
         hpcMarkupCmd+=("--srcdir=$srcDir")
       done
@@ -127,7 +130,7 @@ in pkgs.runCommand "project-coverage-report"
     if [ ''${#tixFiles[@]} -ne 0 ]; then
       # Create tix file with test run information for all packages
       tixFile="$out/share/hpc/vanilla/tix/all/all.tix"
-      hpcSumCmd=("$hpc" "sum" "--union" "--output=$tixFile")
+      hpcSumCmd=("hpc" "sum" "--union" "--output=$tixFile")
       hpcSumCmd+=("''${tixFiles[@]}")
       echo "''${hpcSumCmd[@]}"
       eval "''${hpcSumCmd[@]}"

--- a/lib/cover-project.nix
+++ b/lib/cover-project.nix
@@ -106,6 +106,7 @@ in pkgs.runCommand "project-coverage-report"
       popd
     }
 
+    mkdir -p $out/nix-support
     mkdir -p $out/share/hpc/vanilla/tix/all
     mkdir -p $out/share/hpc/vanilla/mix/
     mkdir -p $out/share/hpc/vanilla/html/
@@ -136,6 +137,7 @@ in pkgs.runCommand "project-coverage-report"
 
       # Markup a HTML coverage report for the entire project
       cp ${projectIndexHtml} $out/share/hpc/vanilla/html/index.html
+      echo "report coverage-per-package $out/share/hpc/vanilla/html/index.html" >> $out/nix-support/hydra-build-products
 
       local markupOutDir="$out/share/hpc/vanilla/html/all"
       local srcDirs=${toBashArray srcDirs}
@@ -146,5 +148,6 @@ in pkgs.runCommand "project-coverage-report"
       findModules allMixModules "$out/share/hpc/vanilla/mix/" "*.mix"
 
       markup srcDirs mixDirs allMixModules "$markupOutDir" "$tixFile"
+      echo "report coverage $markupOutDir/hpc_index.html" >> $out/nix-support/hydra-build-products
     fi
   ''

--- a/lib/cover.nix
+++ b/lib/cover.nix
@@ -99,6 +99,7 @@ in pkgs.runCommand (name + "-coverage-report")
 
     local mixDirs=${toBashArray mixDirs}
 
+    mkdir -p $out/nix-support
     mkdir -p $out/share/hpc/vanilla/mix/${name}
     mkdir -p $out/share/hpc/vanilla/tix/${name}
     mkdir -p $out/share/hpc/vanilla/html/${name}
@@ -161,5 +162,7 @@ in pkgs.runCommand (name + "-coverage-report")
 
       # Markup a HTML report, included modules from only this package
       markup srcDirs mixDirs pkgMixModules "$markupOutDir" "$sumTixFile"
+
+      echo "report coverage $markupOutDir/hpc_index.html" >> $out/nix-support/hydra-build-products
     fi
   ''

--- a/lib/cover.nix
+++ b/lib/cover.nix
@@ -22,7 +22,7 @@ let
   srcDirs = map (l: l.src.outPath) mixLibraries;
 
 in pkgs.runCommand (name + "-coverage-report")
-  ({buildInputs = [ pkgs.buildPackages.zip ];
+  ({nativeBuildInputs = [ pkgs.buildPackages.zip ];
     passthru = {
       inherit name library checks;
     };

--- a/lib/cover.nix
+++ b/lib/cover.nix
@@ -22,7 +22,8 @@ let
   srcDirs = map (l: l.src.outPath) mixLibraries;
 
 in pkgs.runCommand (name + "-coverage-report")
-  ({ passthru = {
+  ({buildInputs = [ pkgs.buildPackages.zip ];
+    passthru = {
       inherit name library checks;
     };
     # HPC will fail if the Haskell file contains non-ASCII characters,
@@ -162,6 +163,9 @@ in pkgs.runCommand (name + "-coverage-report")
       # Markup a HTML report, included modules from only this package
       markup srcDirs mixDirs pkgMixModules "$markupOutDir" "$sumTixFile"
 
+      # Provide a HTML zipfile and Hydra links
+      ( cd "$markupOutDir" ; zip -r $out/share/hpc/vanilla/${name}-html.zip . )
       echo "report coverage $markupOutDir/hpc_index.html" >> $out/nix-support/hydra-build-products
+      echo "file zip $out/share/hpc/vanilla/${name}-html.zip" >> $out/nix-support/hydra-build-products
     fi
   ''

--- a/lib/cover.nix
+++ b/lib/cover.nix
@@ -11,6 +11,8 @@
 # argument. Use a larger list of libraries if you would like the tests
 # of one local package to generate coverage for another.
 , mixLibraries ? [library]
+# hack for project-less projects
+, ghc ? library.project.pkg-set.config.ghc.package
 }:
 
 let
@@ -22,7 +24,7 @@ let
   srcDirs = map (l: l.src.outPath) mixLibraries;
 
 in pkgs.runCommand (name + "-coverage-report")
-  ({nativeBuildInputs = [ pkgs.buildPackages.zip ];
+  ({nativeBuildInputs = [ (ghc.buildGHC or ghc) pkgs.buildPackages.zip ];
     passthru = {
       inherit name library checks;
     };
@@ -37,8 +39,6 @@ in pkgs.runCommand (name + "-coverage-report")
     LOCALE_ARCHIVE = "${pkgs.buildPackages.glibcLocales}/lib/locale/locale-archive";
   })
   ''
-    local hpc=${pkgs.buildPackages.haskellPackages.ghc}/bin/hpc
-
     function markup() {
       local -n srcDs=$1
       local -n mixDs=$2
@@ -46,7 +46,7 @@ in pkgs.runCommand (name + "-coverage-report")
       local destDir=$4
       local tixFile=$5
 
-      local hpcMarkupCmd=("$hpc" "markup" "--destdir=$destDir")
+      local hpcMarkupCmd=("hpc" "markup" "--destdir=$destDir")
       for srcDir in "''${srcDs[@]}"; do
         hpcMarkupCmd+=("--srcdir=$srcDir")
       done
@@ -70,7 +70,7 @@ in pkgs.runCommand (name + "-coverage-report")
       local -n tixFs=$2
       local outFile="$3"
 
-      local hpcSumCmd=("$hpc" "sum" "--union" "--output=$outFile")
+      local hpcSumCmd=("hpc" "sum" "--union" "--output=$outFile")
 
       for module in "''${includedModules[@]}"; do
         hpcSumCmd+=("--include=$module")


### PR DESCRIPTION
1. Fix hpc for cross-compiled builds
2. Add report entries to Hydra build products.
