### PR TITLE
Update specific package building tutorial

### DIFF
--- a/docs/tutorials/building-package-from-stackage-hackage.md
+++ b/docs/tutorials/building-package-from-stackage-hackage.md
@@ -6,7 +6,7 @@
 To build a package, say [lens][], from a Stackage snapshot, say
 [lts-13.28][], you could run:
 ```bash
-nix build '(with import <nixpkgs> (import (builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz")).nixpkgsArgs; haskell-nix.snapshots."lts-13.28").lens.components.library'
+nix build '(with import <nixpkgs> (import (builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz") {}).nixpkgsArgs; haskell-nix.snapshots."lts-13.28").lens.components.library'
 ```
 This would build the (public) library component of the [lens][] package as
 fixed by the [lts-13.28][] stackage snapshot. Nightly snapshots like
@@ -17,7 +17,7 @@ fixed by the [lts-13.28][] stackage snapshot. Nightly snapshots like
 To build any package from hackage, say [lens][], at any version, say 4.17.1,
 you could run:
 ```bash
-nix build '(with import <nixpkgs> (import (builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz")).nixpkgsArgs; (haskell-nix.hackage-package { name = "lens"; version = "4.17.1"; })).components.library'
+nix build '(with import <nixpkgs> (import (builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz") {}).nixpkgsArgs; (haskell-nix.hackage-package { name = "lens"; version = "4.17.1"; compiler-nix-name = "ghc8102"; })).components.library'
 ```
 This would build the (public) library component of the [lens-4.17.1][] package
 from hackage.
@@ -28,7 +28,7 @@ The dependencies would be resolved against the most recent
 [hackage-index-state][] which comes with your [haskell.nix][] checkout via the
 [hackage.nix][] pin.  A specific one can be specified as well:
 ```bash
-nix build '(with import <nixpkgs> (import (builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz")).nixpkgsArgs; (haskell-nix.hackage-package { name = "lens"; version = "4.17.1"; index-state = "2019-07-14T00:00:00Z"; })).components.library'
+nix build '(with import <nixpkgs> (import (builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz") {}).nixpkgsArgs; (haskell-nix.hackage-package { name = "lens"; version = "4.17.1"; compiler-nix-name = "ghc8102"; index-state = "2019-07-14T00:00:00Z"; })).components.library'
 ```
 This would use the hackage index as of `2019-07-14T00:00:00Z` to produce a
 build plan for the [lens-4.17.1][] package.


### PR DESCRIPTION
Haskell.nix's `default.nix` is now a function that needs to be called
and `hackage-package` can no longer rely on the default internal GHC so
`compiler-nix-name` needs to be specified explicitly.

This tutorial got outdated. The haskell.nix revision *could* be pinned to avoid confusion/frustration for new users.
OTOH relying on master means complaints arise sooner and we're forced to keep the examples up to date. Working examples for an old revision would only delay the moment of confusion/frustration to when the users switch to a more recent revision.