### PR TITLE
nixpkgs 20.09 pkg-config has a prefix

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -92,8 +92,7 @@ let
     ] ++ commonConfigureFlags);
 
   # From nixpkgs 20.09, the pkg-config exe has a prefix matching the ghc one
-  pkgConfigHasPrefix = !(lib.strings.hasPrefix "19."   lib.nixpkgsVersion
-                      || lib.strings.hasPrefix "20.03" lib.nixpkgsVersion);
+  pkgConfigHasPrefix = builtins.compareVersions lib.nixpkgsVersion "20.09" >= 0;
 
   commonConfigureFlags = ([
       # GHC

--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -100,7 +100,7 @@ let
       "--with-ghc=${ghc.targetPrefix}ghc"
       "--with-ghc-pkg=${ghc.targetPrefix}ghc-pkg"
       "--with-hsc2hs=${ghc.targetPrefix}hsc2hs"
-    ] ++ lib.optional pkgConfigHasPrefix
+    ] ++ lib.optional (pkgConfigHasPrefix && pkgconfig != [])
       "--with-pkg-config=${ghc.targetPrefix}pkg-config"
       ++ lib.optionals (stdenv.hasCC or (stdenv.cc != null))
     ( # CC

--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -92,8 +92,8 @@ let
     ] ++ commonConfigureFlags);
 
   # From nixpkgs 20.09, the pkg-config exe has a prefix matching the ghc one
-  pkgConfigHasPrefix = !lib.strings.hasPrefix "19."   lib.nixpkgsVersion
-                    && !lib.strings.hasPrefix "20.03" lib.nixpkgsVersion;
+  pkgConfigHasPrefix = !(lib.strings.hasPrefix "19."   lib.nixpkgsVersion
+                      || lib.strings.hasPrefix "20.03" lib.nixpkgsVersion);
 
   commonConfigureFlags = ([
       # GHC
@@ -102,7 +102,7 @@ let
       "--with-hsc2hs=${ghc.targetPrefix}hsc2hs"
     ] ++ lib.optional pkgConfigHasPrefix
       "--with-pkg-config=${ghc.targetPrefix}pkg-config"
-    ) ++ lib.optionals (stdenv.hasCC or (stdenv.cc != null))
+      ++ lib.optionals (stdenv.hasCC or (stdenv.cc != null))
     ( # CC
       [ "--with-gcc=${stdenv.cc.targetPrefix}cc"
       ] ++

--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -91,12 +91,18 @@ let
       "$(cat ${configFiles}/configure-flags)"
     ] ++ commonConfigureFlags);
 
+  # From nixpkgs 20.09, the pkg-config exe has a prefix matching the ghc one
+  pkgConfigHasPrefix = !lib.strings.hasPrefix "19."   lib.nixpkgsVersion
+                    && !lib.strings.hasPrefix "20.03" lib.nixpkgsVersion;
+
   commonConfigureFlags = ([
       # GHC
       "--with-ghc=${ghc.targetPrefix}ghc"
       "--with-ghc-pkg=${ghc.targetPrefix}ghc-pkg"
       "--with-hsc2hs=${ghc.targetPrefix}hsc2hs"
-    ] ++ lib.optionals (stdenv.hasCC or (stdenv.cc != null))
+    ] ++ lib.optional pkgConfigHasPrefix
+      "--with-pkg-config=${ghc.targetPrefix}pkg-config"
+    ) ++ lib.optionals (stdenv.hasCC or (stdenv.cc != null))
     ( # CC
       [ "--with-gcc=${stdenv.cc.targetPrefix}cc"
       ] ++

--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -92,7 +92,7 @@ let
     ] ++ commonConfigureFlags);
 
   # From nixpkgs 20.09, the pkg-config exe has a prefix matching the ghc one
-  pkgConfigHasPrefix = builtins.compareVersions lib.nixpkgsVersion "20.09" >= 0;
+  pkgConfigHasPrefix = builtins.compareVersions lib.nixpkgsVersion "20.09pre" >= 0;
 
   commonConfigureFlags = ([
       # GHC

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 3
+, ifdLevel ? 1
 , checkMaterialization ? false }:
 
 let

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 1
+, ifdLevel ? 2
 , checkMaterialization ? false }:
 
 let

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 2
+, ifdLevel ? 3
 , checkMaterialization ? false }:
 
 let


### PR DESCRIPTION
From nixpkgs 20.09, the pkg-config exe has a prefix matching the ghc one