### PR TITLE
Include hls 0.5.1 in cache

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -23,6 +23,7 @@ in rec {
     pkgs.recurseIntoAttrs {
       ghcide-020 = tool compiler-nix-name "ghcide" "0.2.0";
       cabal-32 = tool compiler-nix-name "cabal" "3.2.0.0";
+      hls-051 = tool compiler-nix-name "haskell-language-server" "0.5.1";
     }
   );
 

--- a/overlays/tools.nix
+++ b/overlays/tools.nix
@@ -91,6 +91,9 @@ in { haskell-nix = prev.haskell-nix // {
     );
 
   # Tools not in hackage yet
+  # When adding custom tools here, consider adding them
+  # to the `tools` attribute defined in `build.nix` to make
+  # sure they are cached.
   custom-tools = {
     ghcide.object-code = args:
         (final.haskell-nix.cabalProject (args // {


### PR DESCRIPTION
#880 added haskell language server as a custom tool (at least until it makes it into hackage).  This change makes sure it will also be in the binary cache for the nixpkgs and GHC versions we build on CI.