### PR TITLE
Guard against #884 by checking sha256

### DIFF
--- a/mk-local-hackage-repo/default.nix
+++ b/mk-local-hackage-repo/default.nix
@@ -24,11 +24,15 @@ export expires="4000-01-01T00:00:00Z"
 ln -sf ${index} $out/01-index.tar.gz
 export index_md5=$(nix-hash --flat --type md5 ${index})
 export index_sha256=$(nix-hash --flat --type sha256 ${index})
-${ pkgs.lib.optionalString (index ? outputHash) ''
-  if [[ "${index.outputHash}" != "$index_sha256" ]]; then
-    echo "ERROR See https://github.com/input-output-hk/haskell.nix/issues/884"
-    exit 0
-  fi
+${
+  # When possible check the hash we calculate here against the `outputHash`
+  # of the index derivation (when the `extra-hackages` feature is used the index
+  # may not have an outputHash).
+  pkgs.lib.optionalString (index ? outputHash) ''
+    if [[ "${index.outputHash}" != "$index_sha256" ]]; then
+      echo "ERROR See https://github.com/input-output-hk/haskell.nix/issues/884"
+      exit 0
+    fi
 ''}
 export index_length=$(stat --printf="%s" ${index})
 

--- a/mk-local-hackage-repo/default.nix
+++ b/mk-local-hackage-repo/default.nix
@@ -24,6 +24,12 @@ export expires="4000-01-01T00:00:00Z"
 ln -sf ${index} $out/01-index.tar.gz
 export index_md5=$(nix-hash --flat --type md5 ${index})
 export index_sha256=$(nix-hash --flat --type sha256 ${index})
+${ pkgs.lib.optionalString (index ? outputHash) ''
+  if [[ "${index.outputHash}" != "$index_sha256" ]]; then
+    echo "ERROR See https://github.com/input-output-hk/haskell.nix/issues/884"
+    exit 0
+  fi
+''}
 export index_length=$(stat --printf="%s" ${index})
 
 substituteAll ${./root.json} $out/root.json


### PR DESCRIPTION
Not sure what caused #884, but this check should prevent the
erroneous output from making it into the binary cache if it happens
again.