### PR TITLE
Use ghc865 to build ghc8102-experimental

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -376,7 +376,8 @@ in {
                 extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc8102-experimental; };
 
                 bootPkgs = bootPkgs // {
-                  ghc = final.buildPackages.buildPackages.haskell-nix.compiler.ghc884;
+                  # Not using 8.8 due to https://gitlab.haskell.org/ghc/ghc/-/issues/18143
+                  ghc = final.buildPackages.buildPackages.haskell-nix.compiler.ghc865;
                 };
                 inherit sphinx installDeps;
 


### PR DESCRIPTION
This change was made to ghc8102 already, but got missed on
ghc102-experimental