### PR TITLE
Fix coverageReport for package with no lib

### DIFF
--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -530,11 +530,12 @@ final: prev: {
 
                       coverageReport = haskellLib.coverageReport (rec {
                         name = package.identifier.name + "-" + package.identifier.version;
-                        inherit (components) library;
+                        library = if components ? library then components.library else null;
                         checks = final.lib.filter (final.lib.isDerivation) (final.lib.attrValues package'.checks);
                         mixLibraries = final.lib.concatMap
                           (pkg: final.lib.optional (pkg.components ? library) pkg.components.library)
                             (final.lib.attrValues (haskellLib.selectProjectPackages project.hsPkgs));
+                        ghc = project.pkg-set.config.ghc.package;
                       });
                     }
                 ) rawProject.hsPkgs


### PR DESCRIPTION
This is a fix for:

```
in job ‘native.haskellPackages.cardano-node-chairman.coverageReport.x86_64-darwin’:
attribute 'library' missing, at /nix/store/71ipkirsqkcmbd99q46rpg0z31zrr24p-haskell.nix-src/overlays/haskell.nix:531:72
```