### PR TITLE
hlint does not need reinstallableLibGhc any more

### DIFF
--- a/overlays/hackage-quirks.nix
+++ b/overlays/hackage-quirks.nix
@@ -31,7 +31,6 @@ in { haskell-nix = prev.haskell-nix // {
     };
 
     hlint = {
-      modules = [ { reinstallableLibGhc = true; } ];
       pkg-def-extras = [
         (hackage: {
           packages = {


### PR DESCRIPTION
Since reinstallableLibGhc is currently broken for ghc 8.10.2
it seems like a good idea to turn it off.