### PR TITLE
Fix dumby GHC 8.10 Booter Version

### DIFF
--- a/materialized/dummy-ghc/aarch64-unknown-linux-gnu-aarch64-unknown-linux-gnu-ghc-8.10.1-x86_64-linux/ghc/info
+++ b/materialized/dummy-ghc/aarch64-unknown-linux-gnu-aarch64-unknown-linux-gnu-ghc-8.10.1-x86_64-linux/ghc/info
@@ -43,7 +43,7 @@
  ,("RTS expects libdw","NO")
  ,("Project version","8.10.1")
  ,("Project Git commit id","5c3cadf5db0d7eb859ff2c278ab07585c7df17b5")
- ,("Booter version","8.8.4")
+ ,("Booter version","8.6.5")
  ,("Stage","1")
  ,("Build platform","x86_64-unknown-linux")
  ,("Host platform","x86_64-unknown-linux")

--- a/materialized/dummy-ghc/aarch64-unknown-linux-gnu-aarch64-unknown-linux-gnu-ghc-8.10.2-x86_64-linux/ghc/info
+++ b/materialized/dummy-ghc/aarch64-unknown-linux-gnu-aarch64-unknown-linux-gnu-ghc-8.10.2-x86_64-linux/ghc/info
@@ -44,7 +44,7 @@
  ,("RTS expects libdw","NO")
  ,("Project version","8.10.2")
  ,("Project Git commit id","29204b1c4f52ea34d84da33593052ee839293bf2")
- ,("Booter version","8.8.4")
+ ,("Booter version","8.6.5")
  ,("Stage","1")
  ,("Build platform","x86_64-unknown-linux")
  ,("Host platform","x86_64-unknown-linux")

--- a/materialized/dummy-ghc/ghc-8.10.1-x86_64-darwin/ghc/info
+++ b/materialized/dummy-ghc/ghc-8.10.1-x86_64-darwin/ghc/info
@@ -43,7 +43,7 @@
  ,("RTS expects libdw","NO")
  ,("Project version","8.10.1")
  ,("Project Git commit id","5c3cadf5db0d7eb859ff2c278ab07585c7df17b5")
- ,("Booter version","8.8.4")
+ ,("Booter version","8.6.5")
  ,("Stage","2")
  ,("Build platform","x86_64-apple-darwin")
  ,("Host platform","x86_64-apple-darwin")

--- a/materialized/dummy-ghc/ghc-8.10.1-x86_64-linux/ghc/info
+++ b/materialized/dummy-ghc/ghc-8.10.1-x86_64-linux/ghc/info
@@ -43,7 +43,7 @@
  ,("RTS expects libdw","NO")
  ,("Project version","8.10.1")
  ,("Project Git commit id","5c3cadf5db0d7eb859ff2c278ab07585c7df17b5")
- ,("Booter version","8.8.4")
+ ,("Booter version","8.6.5")
  ,("Stage","2")
  ,("Build platform","x86_64-unknown-linux")
  ,("Host platform","x86_64-unknown-linux")

--- a/materialized/dummy-ghc/ghc-8.10.2-x86_64-darwin/ghc/info
+++ b/materialized/dummy-ghc/ghc-8.10.2-x86_64-darwin/ghc/info
@@ -44,7 +44,7 @@
  ,("RTS expects libdw","NO")
  ,("Project version","8.10.2")
  ,("Project Git commit id","29204b1c4f52ea34d84da33593052ee839293bf2")
- ,("Booter version","8.8.4")
+ ,("Booter version","8.6.5")
  ,("Stage","2")
  ,("Build platform","x86_64-apple-darwin")
  ,("Host platform","x86_64-apple-darwin")

--- a/materialized/dummy-ghc/ghc-8.10.2-x86_64-linux/ghc/info
+++ b/materialized/dummy-ghc/ghc-8.10.2-x86_64-linux/ghc/info
@@ -44,7 +44,7 @@
  ,("RTS expects libdw","NO")
  ,("Project version","8.10.2")
  ,("Project Git commit id","29204b1c4f52ea34d84da33593052ee839293bf2")
- ,("Booter version","8.8.4")
+ ,("Booter version","8.6.5")
  ,("Stage","2")
  ,("Build platform","x86_64-unknown-linux")
  ,("Host platform","x86_64-unknown-linux")

--- a/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-8.10.1-x86_64-linux/ghc/info
+++ b/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-8.10.1-x86_64-linux/ghc/info
@@ -43,7 +43,7 @@
  ,("RTS expects libdw","NO")
  ,("Project version","8.10.1")
  ,("Project Git commit id","5c3cadf5db0d7eb859ff2c278ab07585c7df17b5")
- ,("Booter version","8.8.4")
+ ,("Booter version","8.6.5")
  ,("Stage","2")
  ,("Build platform","x86_64-unknown-linux")
  ,("Host platform","x86_64-unknown-linux")

--- a/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-8.10.2-x86_64-linux/ghc/info
+++ b/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-8.10.2-x86_64-linux/ghc/info
@@ -44,7 +44,7 @@
  ,("RTS expects libdw","NO")
  ,("Project version","8.10.2")
  ,("Project Git commit id","29204b1c4f52ea34d84da33593052ee839293bf2")
- ,("Booter version","8.8.4")
+ ,("Booter version","8.6.5")
  ,("Stage","2")
  ,("Build platform","x86_64-unknown-linux")
  ,("Host platform","x86_64-unknown-linux")


### PR DESCRIPTION
We switched the booter ghc version from 8.8.4 to 8.6.5, but did not
update the dummy ghc info.  This causes problems when checking
materialization.