### PR TITLE
Allow source spec to be a file

### DIFF
--- a/compiler/ghc/configured-src.nix
+++ b/compiler/ghc/configured-src.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (rec {
     patches = ghc-patches;
     name = "${targetPrefix}ghc-${ghc-version}-configured-src";
 
-    # Make sure we never relax`$PATH` and hooks support for compatibility.
+    # Make sure we never relax`$PATH` and hooks support for compatability.
     strictDeps = true;
 
     nativeBuildInputs = [
@@ -40,7 +40,9 @@ stdenv.mkDerivation (rec {
 
     postPatch = "patchShebangs .";
 
-    src = fetchurl { inherit (src-spec) url sha256; };
+    src = if src-spec ? file
+        then src-spec.file
+        else fetchurl { inherit (src-spec) url sha256; };
 
     # GHC is a bit confused on its cross terminology.
     preConfigure = ''

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -18,8 +18,8 @@ let
     else
       pkgs.fetchzip { inherit (spec) url sha256; };
 
-  fetch_git = spec:
-    builtins.fetchGit { url = spec.repo; inherit (spec) rev ref; };
+  fetch_git = pkgs: spec:
+    pkgs.fetchgit { url = spec.repo; inherit (spec) rev deepClone sha256; };
 
   fetch_builtin-tarball = spec:
     builtins.trace
@@ -73,7 +73,7 @@ let
       abort "ERROR: niv spec ${name} does not have a 'type' attribute"
     else if spec.type == "file" then fetch_file pkgs spec
     else if spec.type == "tarball" then fetch_tarball pkgs spec
-    else if spec.type == "git" then fetch_git spec
+    else if spec.type == "git" then fetch_git pkgs spec
     else if spec.type == "builtin-tarball" then fetch_builtin-tarball spec
     else if spec.type == "builtin-url" then fetch_builtin-url spec
     else


### PR DESCRIPTION
This allows us to provide a path or file (to unpack) instead of a fetchurl item.

(cherry picked from commit 828a04f6076e40c8fb419069543493adb8ec0eff)