### PR TITLE
don't try to set enableRelocatableStaticLibs = false on aarch32 in overlays/ghc.nix

### DIFF
--- a/overlays/ghc.nix
+++ b/overlays/ghc.nix
@@ -3,8 +3,6 @@ final: prev: with prev;
    let
     ghcPkgOverrides = {
         enableIntegerSimple = false;
-      } // lib.optionalAttrs final.stdenv.hostPlatform.isAarch32 {
-        enableRelocatableStaticLibs = false;
       };
     ghcDrvOverrides = drv: {
         hardeningDisable = (drv.hardeningDisable or []) ++ [ "stackprotector" "format" ] ++ lib.optionals prev.stdenv.hostPlatform.isAarch32 [ "pic" "pie" ];


### PR DESCRIPTION
as that parameter is no longer recognized and it's already disabled by the compiler/ghc/default.nix default for enableRelocatedStaticLibs (c.f. https://github.com/input-output-hk/haskell.nix/blob/master/compiler/ghc/default.nix#L32)

I think this might be a remnant from the pre-1.0/overlays version. let me know if there are more guidelines on PRs that you'd like me to follow, I didn't see any obviously