### PR TITLE
flake: remove outdated edition field.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,6 @@
 {
   description = "Alternative Haskell Infrastructure for Nixpkgs";
 
-  edition = 201909;
-
   outputs = { self }: {
     # Using the eval-on-build version here as the plan is that
     # `builtins.currentSystem` will not be supported in flakes.


### PR DESCRIPTION
The flake edition attribute has been deprecated and removed from Nix.

See:
- https://github.com/NixOS/nix/commit/e5ea01c1a8bbd328dcc576928bf3e4271cb55399
- https://github.com/NixOS/nix/commit/b875b8f45c8d73c26e2cf13843fa25cc6762eebc