### PR TITLE
Fix broken link to official nixpkgs guide to Haskell infrastructure

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,6 @@
 - Overridable configuration
 - Cross compile Haskell packages
 
-[^1]: See [Nixpkgs current Users' Guide to Haskell Infrastructure](https://nixos.org/nixpkgs/manual/#users-guide-to-the-haskell-infrastructure) for comparison.
+[^1]: See [Nixpkgs current Users' Guide to Haskell Infrastructure](https://haskell4nix.readthedocs.io/) for comparison.
 
 


### PR DESCRIPTION
The current link is broken. The closest substitute would be
> https://nixos.org/manual/nixpkgs/stable/#haskell

but it just forwards you to https://haskell4nix.readthedocs.io/, so that's what I plugged in directly.