### PR TITLE
Add a pkgconf alias for libusb1

### DIFF
--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -90,6 +90,7 @@ pkgs:
     "libsoup-gnome-2.4"                  = [ pkgs."libsoup" ];
     "libsystemd"                         = [ pkgs."systemd" ];
     "libudev"                            = [ pkgs."systemd" ];
+    "libusb-1.0"                         = [ pkgs."libusb1" ];
     "libxml-2.0"                         = [ pkgs."libxml2" ];
     "libzip"                             = [ pkgs."libzip" ];
     "libzmq"                             = [ pkgs."zeromq" ];


### PR DESCRIPTION
This is needed for building usb.components.library.