### PR TITLE
Recognize NCSA license from SPDX identifier

### DIFF
--- a/lib/cabal-licenses.nix
+++ b/lib/cabal-licenses.nix
@@ -13,11 +13,11 @@ lib: with lib.licenses;
   "AGPL-3.0-or-later" = agpl3Plus;
   "Apache-2.0"        = asl20;
   "GPL-2.0-or-later AND BSD-3-Clause" = [gpl2Plus bsd3];
+  "NCSA" = ncsa;
   # Generic
   LicenseRef-Apache = "Apache";
   LicenseRef-GPL = "GPL";
   LicenseRef-LGPL = "LGPL";
-  LicenseRef-NCSA = ncsa;
   LicenseRef-PublicDomain = publicDomain;
   LicenseRef-OtherLicense = null;
   NONE = null;


### PR DESCRIPTION
Cabal recognizes the NCSA license from its SPDX identifier ("NCSA") and no
longer reports "LicenseRef-NCSA".