### PR TITLE
Add support for "latest" as a version

### DIFF
--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -459,29 +459,35 @@ final: prev: {
         hackage-project =
             { name
             , compiler-nix-name
-            , version
+            , version ? "latest"
             , revision ? "default"
             , ... }@args':
-            let args = { caller = "hackage-project"; } // args';
+            let version' = if version == "latest"
+                  then builtins.head (
+                    builtins.sort
+                      (a: b: builtins.compareVersions a b > 0)
+                      (builtins.attrNames hackage.${name}))
+                  else version;
+                args = { caller = "hackage-project"; } // args';
                 tarball = final.pkgs.fetchurl {
-                  url = "mirror://hackage/${name}-${version}.tar.gz";
-                  inherit (hackage.${name}.${version}) sha256; };
-                rev = hackage.${name}.${version}.revisions.${revision};
+                  url = "mirror://hackage/${name}-${version'}.tar.gz";
+                  inherit (hackage.${name}.${version'}) sha256; };
+                rev = hackage.${name}.${version'}.revisions.${revision};
                 cabalFile = final.pkgs.fetchurl {
-                  url = "https://hackage.haskell.org/package/${name}-${version}/revision/${toString rev.revNum}.cabal";
+                  url = "https://hackage.haskell.org/package/${name}-${version'}/revision/${toString rev.revNum}.cabal";
                   inherit (rev) sha256;
                 };
                 revSuffix = final.lib.optionalString (rev.revNum > 0) "-r${toString rev.revNum}";
-            in let src = final.buildPackages.pkgs.runCommand "${name}-${version}${revSuffix}-src" { } (''
+            in let src = final.buildPackages.pkgs.runCommand "${name}-${version'}${revSuffix}-src" { } (''
                   tmp=$(mktemp -d)
                   cd $tmp
                   tar xzf ${tarball}
-                  mv "${name}-${version}" $out
+                  mv "${name}-${version'}" $out
                 '' + final.lib.optionalString (rev.revNum > 0) ''
                   cp ${cabalFile} $out/${name}.cabal
                 '');
           in cabalProject' (
-            (final.haskell-nix.hackageQuirks { inherit name version; }) //
+            (final.haskell-nix.hackageQuirks { inherit name; version = version'; }) //
               builtins.removeAttrs args [ "version" "revision" ] // { inherit src; });
 
         # This function is like `cabalProject` but it makes the plan-nix available

--- a/overlays/tools.nix
+++ b/overlays/tools.nix
@@ -163,6 +163,9 @@ in { haskell-nix = prev.haskell-nix // {
           # Plan issues with the benchmarks, can try removing later
           configureArgs = "--disable-benchmarks";
         })).haskell-language-server.components.exes.haskell-language-server;
+      # When adding new versions here, please set "latest" too the latest version
+      # so that `tools = { haskell-language-server = "latest"; }`
+      # will work the same way it does for tools that are in hackage.
       "latest" = final.haskell-nix.custom-tools.haskell-language-server."0.6.0";
     };
   };

--- a/overlays/tools.nix
+++ b/overlays/tools.nix
@@ -163,6 +163,7 @@ in { haskell-nix = prev.haskell-nix // {
           # Plan issues with the benchmarks, can try removing later
           configureArgs = "--disable-benchmarks";
         })).haskell-language-server.components.exes.haskell-language-server;
+      "latest" = final.haskell-nix.custom-tools.haskell-language-server."0.6.0";
     };
   };
 }; }


### PR DESCRIPTION
When using `shellFor { tools = { x = "1.2.3"; }; }` it can be a pain
to have to check if you have the latest version of `x` or if a new
one has been introduced.  This change adds support for passing
`"latest"` as the version number to anything built on top of the
`haskell-nix.hackage-project` function.  When `"latest"` is used
the newest version in the hackage.nix snapshot will be selected.