### PR TITLE
Add cross compile cabal wrapper

### DIFF
--- a/builder/shell-for.nix
+++ b/builder/shell-for.nix
@@ -127,7 +127,22 @@ in
     nativeBuildInputs = [ ghcEnv ]
       ++ nativeBuildInputs
       ++ mkDrvArgs.nativeBuildInputs or []
-      ++ lib.attrValues (buildPackages.haskell-nix.tools compiler.nix-name tools);
+      ++ lib.attrValues (buildPackages.haskell-nix.tools compiler.nix-name tools)
+      # If this shell is a cross compilation shell include
+      # wrapper script for running cabal build with appropriat args.
+      ++ lib.optional (ghcEnv.targetPrefix != "") (
+            buildPackages.writeShellScriptBin "${ghcEnv.targetPrefix}cabal" ''
+              cabal \
+                --with-ghc=${ghcEnv.targetPrefix}ghc \
+                --with-ghc-pkg=${ghcEnv.targetPrefix}ghc-pkg \
+                --with-hsc2hs=${ghcEnv.targetPrefix}hsc2hs \
+                ${lib.optionalString (ghcEnv.targetPrefix == "js-unknown-ghcjs-") ''
+                  --with-ghcjs=${ghcEnv.targetPrefix}ghc \
+                  --with-ghcjs-pkg=${ghcEnv.targetPrefix}ghc-pkg \
+                  --ghcjs \
+                ''} $(builtin type -P "${ghcEnv.targetPrefix}pkg-config" &> /dev/null && echo "--with-pkg-config=${ghcEnv.targetPrefix}pkg-config") \
+                "$@"
+              '');
     phases = ["installPhase"];
     installPhase = "echo $nativeBuildInputs $buildInputs > $out";
     LANG = "en_US.UTF-8";

--- a/builder/shell-for.nix
+++ b/builder/shell-for.nix
@@ -132,7 +132,7 @@ in
       # wrapper script for running cabal build with appropriate args.
       ++ lib.optional (ghcEnv.targetPrefix != "") (
             buildPackages.writeShellScriptBin "${ghcEnv.targetPrefix}cabal" ''
-              cabal \
+              exec cabal \
                 --with-ghc=${ghcEnv.targetPrefix}ghc \
                 --with-ghc-pkg=${ghcEnv.targetPrefix}ghc-pkg \
                 --with-hsc2hs=${ghcEnv.targetPrefix}hsc2hs \

--- a/builder/shell-for.nix
+++ b/builder/shell-for.nix
@@ -129,7 +129,7 @@ in
       ++ mkDrvArgs.nativeBuildInputs or []
       ++ lib.attrValues (buildPackages.haskell-nix.tools compiler.nix-name tools)
       # If this shell is a cross compilation shell include
-      # wrapper script for running cabal build with appropriat args.
+      # wrapper script for running cabal build with appropriate args.
       ++ lib.optional (ghcEnv.targetPrefix != "") (
             buildPackages.writeShellScriptBin "${ghcEnv.targetPrefix}cabal" ''
               cabal \

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
 This file contains a summary of changes to Haskell.nix and `nix-tools`
 that will impact users.
 
+## Nov 24, 2020
+* Added `${targetPrefix}cabal` wrapper script for running cross
+  compilers in `shellFor`.
+
 ## Oct 31, 2020
 * Passing `tools.hoogle` to `shellFor` with a value suitable for `haskel-nix.tool` will
   use the specified `hoogle` inside `shellFor`. This allows for materialization


### PR DESCRIPTION
Adds a `${targetPrefix}cabal` script to `shellFor` that passes the
necessary `--with-X` args to `cabal.