### PR TITLE
Remove pj.hsPkgs.${n} functions in favour of pj.${n}

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 This file contains a summary of changes to Haskell.nix and `nix-tools`
 that will impact users.
 
+## Nov 24, 2020
+* project.hsPkgs.${n} has been deprecated in favour of project.${n}.
+
 ## Oct 31, 2020
 * Passing `tools.hoogle` to `shellFor` with a value suitable for `haskel-nix.tool` will
   use the specified `hoogle` inside `shellFor`. This allows for materialization

--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,18 @@
 This file contains a summary of changes to Haskell.nix and `nix-tools`
 that will impact users.
 
+## Nov 25, 2020
+* The `shellFor` `makeConfigFiles` `ghcWithHoogle` and `ghcWithPackages`
+  functions have been removed from `project.hsPkgs`.  Instead access
+  them from `project` itself (e.g. change `p.hsPkgs.shellFor` to `p.shellFor`).
+* The reflex-platform like `project.shells.ghc` has been removed.
+  If needed, add something like `p // { shells.ghc = p.shellFor {} }`
+  to `shell.nix`.
+
 ## Nov 24, 2020
 * Added `${targetPrefix}cabal` wrapper script for running cross
   compilers in `shellFor`.
 * `otherShells` arg added to `shellFor`.
-* project.hsPkgs.${n} has been deprecated in favour of project.${n}.
 
 ## Oct 31, 2020
 * Passing `tools.hoogle` to `shellFor` with a value suitable for `haskel-nix.tool` will

--- a/docs/reference/library.md
+++ b/docs/reference/library.md
@@ -112,16 +112,16 @@ will be passed to it:
 
 # Top-level attributes
 
-## project
+## project'
 
 Function that accepts attribute set with a `src` attribute and looks for `stack.yaml` file relative to it.
 
-If file exists, it calls [stackProject](#stackproject) function. Otherwise it will call [cabalProject](#cabalproject) function.
+If file exists, it calls [stackProject](#stackproject') function. Otherwise it will call [cabalProject](#cabalproject') function.
 
 **Example**:
 
 ```nix
-pkgs.haskell-nix.project {
+pkgs.haskell-nix.project' {
   # 'cleanGit' cleans a source directory based on the files known by git
   src = pkgs.haskell-nix.haskellLib.cleanGit {
     name = "haskell-nix-project";
@@ -130,7 +130,7 @@ pkgs.haskell-nix.project {
 }
 ```
 
-## stackProject
+## stackProject'
 
 A function calling [callStackToNix](#callstacktonix) with all arguments.
 
@@ -142,14 +142,13 @@ Then feeding its result into [mkStackPkgSet](#mkstackpkgset) passing also
 | Attribute         | Type                                             | Description                                                                |
 |-------------------|--------------------------------------------------|----------------------------------------------------------------------------|
 | `hsPkgs`          | Attrset of [Haskell Packages](#haskell-package)  | Buildable packages, created from `packages`                                |
-| `pkg-set`         | Attrset                                          | [`pkgSet`](#package-set)                                                   |
 | `stack-nix`       |                                                  | `projectNix` attribute of [`callStackToNix`](#callstacktonix) return value |
 | `shellFor`        | Function                                         | [`shellFor`](#shellfor)                                                    |
 | `ghcWithHoogle`   | Function                                         | [`ghcWithHoogle`](#ghcwithhoogle)                                          | 
 | `ghcWithPackages` | Function                                         | [`ghcWithPackages`](#ghcwithpackages)                                      |
 
 
-## cabalProject
+## cabalProject'
 
 A function calling [callCabalProjectToNix](#callcabalprojecttonix) with all arguments.
 
@@ -161,14 +160,18 @@ Then feeding its result into [mkCabalProjectPkgSet](#mkcabalprojectpkgset) passi
 | Attribute         | Type                                             | Description                                                                 |
 |-------------------|--------------------------------------------------|-----------------------------------------------------------------------------|
 | `hsPkgs`          | Attrset of [Haskell Packages](#haskell-package)  | Buildable packages, created from `packages`                                 |
-| `pkg-set`         | Attrset                                          | [`pkgSet`](#package-set)                                                    |
 | `plan-nix`        |                                                  | `projectNix` attribute of [`callCabalProjectToNix`](#callcabalprojecttonix) return value  |
 | `index-state`     |                                                  | `index-state` attribute of [`callCabalProjectToNix`](#callcabalprojecttonix) return value |
 | `shellFor`        | Function                                         | [`shellFor`](#shellfor)                                                     |
 | `ghcWithHoogle`   | Function                                         | [`ghcWithHoogle`](#ghcwithhoogle)                                           | 
 | `ghcWithPackages` | Function                                         | [`ghcWithPackages`](#ghcwithpackages)                                       |
 
+## project, cabalProject and stackProject
 
+These versions of the function are the same as project', cabalProject'
+and stackProject', but `hsPkgs` attributes are also included in the
+return value directly.  That way a package can be referenced as
+`(project {...}).foo` instead of `(project' {...}).hsPkgs.foo`.
 
 ## mkStackPkgSet
 
@@ -404,9 +407,11 @@ Sub-component types identify [components](#component) and are one of:
  - `tests`
  - `benchmarks`
 
-# Package-set functions
+# Project functions
 
-These functions exist within the `hsPkgs` package set.
+These functions are included in the `project` return values.
+They also exist within the `hsPkgs` package set of the project,
+but in the future they may be remove them from `hsPkgs`.
 
 ## shellFor
 

--- a/docs/reference/library.md
+++ b/docs/reference/library.md
@@ -410,8 +410,8 @@ Sub-component types identify [components](#component) and are one of:
 # Project functions
 
 These functions are included in the `project` return values.
-They also exist within the `hsPkgs` package set of the project,
-but in the future they may be remove them from `hsPkgs`.
+In the past they also existed within `project.hsPkgs`,
+but have now been removed from there.
 
 ## shellFor
 

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -531,7 +531,7 @@ final: prev: {
           final.lib.fix (project':
             let project = project' // { recurseForDerivations = false; };
             in rawProject // rec {
-              hsPkgs = (final.lib.mapAttrs (n: package':
+              hsPkgs = final.lib.mapAttrs (n: package':
                 if package' == null
                   then null
                   else
@@ -554,23 +554,13 @@ final: prev: {
                         ghc = project.pkg-set.config.ghc.package;
                       });
                     }
-                ) rawProject.hsPkgs
-                // (final.lib.mapAttrs (n:
-                      __trace "project.hsPkgs.${n} has been deprecated in favour of project.${n}"
-                    ) {
-                      # These are functions not packages
-                      inherit (rawProject.hsPkgs) shellFor makeConfigFiles ghcWithHoogle ghcWithPackages;
-                    }
-                  )
-              );
+                ) (builtins.removeAttrs rawProject.hsPkgs
+                  # These are functions not packages
+                  [ "shellFor" "makeConfigFiles" "ghcWithHoogle" "ghcWithPackages" ]);
 
             projectCoverageReport = haskellLib.projectCoverageReport (map (pkg: pkg.coverageReport) (final.lib.attrValues (haskellLib.selectProjectPackages hsPkgs)));
 
             inherit (rawProject.hsPkgs) makeConfigFiles ghcWithHoogle ghcWithPackages shellFor;
-
-            # Provide `nix-shell -A shells.ghc` for users migrating from the reflex-platform.
-            # But we should encourage use of `nix-shell -A shellFor`
-            shells.ghc = project.shellFor {};
           });
 
         cabalProject =

--- a/test/cabal-simple/default.nix
+++ b/test/cabal-simple/default.nix
@@ -26,7 +26,7 @@ in recurseIntoAttrs {
   };
 
   # Used for testing externally with nix-shell (../tests.sh).
-  test-shell = packages.shellFor { tools = { cabal = "3.2.0.0"; }; };
+  test-shell = project.shellFor { tools = { cabal = "3.2.0.0"; }; };
 
   run = stdenv.mkDerivation {
     name = "cabal-simple-test";

--- a/test/shell-for-setup-deps/default.nix
+++ b/test/shell-for-setup-deps/default.nix
@@ -13,7 +13,7 @@ let
     }];
   };
 
-  env = project.hsPkgs.shellFor {};
+  env = project.shellFor {};
 
 # Making this work for cross compilers will be difficult as setup-deps are
 # built for the build platform and the shell will be for the host platform.


### PR DESCRIPTION
Applies to:

 * makeConfigFiles
 * ghcWithHoogle
 * ghcWithPackages
 * shellFor