### PR TITLE
Use "latest" to choose versions to cache

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -21,9 +21,9 @@ in rec {
 
   tools = pkgs.lib.optionalAttrs (ifdLevel >= 3) (
     pkgs.recurseIntoAttrs {
-      ghcide-020 = tool compiler-nix-name "ghcide" "0.2.0";
-      cabal-32 = tool compiler-nix-name "cabal" "3.2.0.0";
-      hls-051 = tool compiler-nix-name "haskell-language-server" "0.5.1";
+      cabal-latest = tool compiler-nix-name "cabal" "latest";
+      hls-latest = tool compiler-nix-name "haskell-language-server" "latest";
+      hlint-latest = tool compiler-nix-name "hlint" "latest";
     }
   );
 


### PR DESCRIPTION
Cache the latest `cabal` `haskell-language-server` and `hlint`