### PR TITLE
Only include hoogle once in shell

### DIFF
--- a/builder/shell-for.nix
+++ b/builder/shell-for.nix
@@ -124,7 +124,6 @@ in
 
     buildInputs = systemInputs
       ++ mkDrvArgs.buildInputs or []
-      ++ lib.optional withHoogle' hoogleIndex
       ++ lib.concatMap (s: s.buildInputs) otherShells;
     nativeBuildInputs = [ ghcEnv ]
       ++ nativeBuildInputs


### PR DESCRIPTION
Currently hoogle gets symlinked into ghcEnv and that is included
in the `nativeBuildInputs` of the shell.  In addition it the same
`hoogle` is included in `buildInputs` directly.

This is not a big problem for nix-shell, but it prevents
the using the following to install the shell in a docker
container:

```
nix-env -f shell.nix -iA buildInputs
nix-env -f shell.nix -iA nativeBuildInputs
```

Gives errors like:
```
error: packages '/nix/store/r3zx73r5y52mqz8p54pxr68pjfc5l0l8-hoogle-local-0.1/bin/hoogle' and '/nix/store/crbhp4wr84fihg9akqh6r6an6s7qb77s-ghc-shell-for-fp-course-ghc-8.8.4-env/bin/hoogle' have the same priority 5; use 'nix-env --set-flag priority NUMBER INSTALLED_PKGNAME' to change the priority of one of the conflicting packages (0 being the highest priority)
```