### PR TITLE
Fix stack.yaml filtering when resolver file is in a subdirectory

### DIFF
--- a/lib/stack-cache-generator.nix
+++ b/lib/stack-cache-generator.nix
@@ -34,7 +34,8 @@ let
           filter = path: type:
             let
               origSrc = if src ? _isLibCleanSourceWith then src.origSrc else src;
-              relPath = pkgs.lib.removePrefix (toString origSrc + "/") path;
+              origSubDir = if src ? _isLibCleanSourceWithEx then src.origSubDir else "";
+              relPath = pkgs.lib.removePrefix (toString origSrc + origSubDir + "/") path;
 
               # checks if path1 is a parent directory for path2
               isParent = path1: path2: pkgs.lib.hasPrefix "${path1}/" path2;

--- a/lib/stack-cache-generator.nix
+++ b/lib/stack-cache-generator.nix
@@ -32,8 +32,17 @@ let
         then haskellLib.cleanSourceWith {
           inherit src;
           filter = path: type:
-               pkgs.lib.hasSuffix ("/" + stackYaml) path
-            || (resolver != null && pkgs.lib.hasSuffix ("/" + resolver) path);
+            let
+              origSrc = if src ? _isLibCleanSourceWith then src.origSrc else src;
+              relPath = pkgs.lib.removePrefix (toString origSrc + "/") path;
+
+              # checks if path1 is a parent directory for path2
+              isParent = path1: path2: pkgs.lib.hasPrefix "${path1}/" path2;
+
+            in
+              (relPath == stackYaml)
+              || (resolver != null && (relPath == resolver || isParent relPath resolver))
+            ;
         }
         else src;
 

--- a/test/default.nix
+++ b/test/default.nix
@@ -158,6 +158,7 @@ let
     builder-haddock = callTest ./builder-haddock {};
     stack-simple = callTest ./stack-simple {};
     stack-local-resolver = callTest ./stack-local-resolver {};
+    stack-local-resolver-subdir = callTest ./stack-local-resolver-subdir {};
     stack-remote-resolver = callTest ./stack-remote-resolver {};
     shell-for-setup-deps = callTest ./shell-for-setup-deps { inherit compiler-nix-name; };
     setup-deps = import ./setup-deps { inherit pkgs compiler-nix-name; };

--- a/test/stack-local-resolver-subdir/.gitignore
+++ b/test/stack-local-resolver-subdir/.gitignore
@@ -1,0 +1,2 @@
+/.stack-work/
+/*.cabal

--- a/test/stack-local-resolver-subdir/default.nix
+++ b/test/stack-local-resolver-subdir/default.nix
@@ -1,0 +1,14 @@
+{ project', recurseIntoAttrs, testSrc }:
+
+let
+  project = project' {
+    src = testSrc "stack-local-resolver-subdir";
+  };
+  packages = project.hsPkgs;
+
+in recurseIntoAttrs {
+  ifdInputs = {
+    inherit (project) stack-nix;
+  };
+  inherit (packages.stack-local-resolver.components) library;
+}

--- a/test/stack-local-resolver-subdir/package.yaml
+++ b/test/stack-local-resolver-subdir/package.yaml
@@ -1,0 +1,7 @@
+name: stack-local-resolver
+
+dependencies:
+- base
+
+library:
+  source-dirs: src

--- a/test/stack-local-resolver-subdir/snapshot/snapshot.yaml
+++ b/test/stack-local-resolver-subdir/snapshot/snapshot.yaml
@@ -1,0 +1,4 @@
+name: local-snapshot
+resolver: lts-14.13
+
+packages: []

--- a/test/stack-local-resolver-subdir/src/Lib.hs
+++ b/test/stack-local-resolver-subdir/src/Lib.hs
@@ -1,0 +1,6 @@
+module Lib
+    ( someFunc
+    ) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/test/stack-local-resolver-subdir/stack.yaml
+++ b/test/stack-local-resolver-subdir/stack.yaml
@@ -1,0 +1,4 @@
+resolver: snapshot/snapshot.yaml
+
+packages:
+- .


### PR DESCRIPTION
`maybeCleanedSource` tries to include the resolver file into the cleaned
source, if a resolver is specified, but it was only working when the
file was in the root of the project, because all directories would be
filtered out.

I didn't test it extensively, there maybe some other cases when it does not work, for example for non-normalized paths. But it does fix the case when the resolver is not in the root directory.