### PR TITLE
Make haskell.nix quieter

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -76,9 +76,8 @@ let self =
 
 let
   # TODO fix cabal wildcard support so hpack wildcards can be mapped to cabal wildcards
-  cleanSrc = if cabal-generator == "hpack" && !(package.cleanHpack or false)
-    then builtins.trace ("Cleaning component source not supported for hpack package: " + name) src
-    else haskellLib.cleanCabalComponent package component src;
+  canCleanSource = !(cabal-generator == "hpack" && !(package.cleanHpack or false));
+  cleanSrc = if canCleanSource then haskellLib.cleanCabalComponent package component src else src;
 
   nameOnly = "${package.identifier.name}-${componentId.ctype}-${componentId.cname}";
 
@@ -287,6 +286,9 @@ let
       ++ (lib.optional keepSource "source");
 
     configurePhase =
+      (lib.optionalString (!canCleanSource) ''
+      echo "Cleaning component source not supported, leaving it un-cleaned"
+      '') +
       (lib.optionalString keepSource ''
         cp -r . $source
         cd $source

--- a/builder/shell-for.nix
+++ b/builder/shell-for.nix
@@ -3,18 +3,13 @@
 { # `packages` function selects packages that will be worked on in the shell itself.
   # These packages will not be built by `shellFor`, but their
   # dependencies will be included in the shell's `ghc-pkg list`.
-  packages ? ps:
-    let
-      selected = haskellLib.selectLocalPackages ps;
-    in
-      builtins.trace ("Shell for " + toString (builtins.attrNames selected))
-        (builtins.attrValues selected)
+  packages ? ps: builtins.attrValues (haskellLib.selectLocalPackages ps)
   # `components` function selects components that will be worked on in the shell itself.
   # By default `shellFor` will include the dependencies of all of the components
   # in the selected packages.  If only as subset of the components will be
   # worked on in the shell then we can pass a different `components` function
   # to select those.
-, components ? ps: lib.concatMap haskellLib.getAllComponents (packages hsPkgs) 
+, components ? ps: lib.concatMap haskellLib.getAllComponents (packages hsPkgs)
   # Additional packages to be added unconditionally
 , additional ? _: []
 , withHoogle ? true
@@ -143,7 +138,10 @@ in
                 "$@"
               '');
     phases = ["installPhase"];
-    installPhase = "echo $nativeBuildInputs $buildInputs > $out";
+    installPhase = ''
+      echo "${"Shell for " + toString (builtins.map (p : p.identifier.name) selectedPackages)}"
+      echo $nativeBuildInputs $buildInputs > $out
+    '';
     LANG = "en_US.UTF-8";
     LOCALE_ARCHIVE = lib.optionalString (stdenv.hostPlatform.libc == "glibc") "${glibcLocales}/lib/locale/locale-archive";
 

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -111,8 +111,9 @@ let
     then index-state
     else if cabalProjectIndexState != null
     then cabalProjectIndexState
-    else builtins.trace ("Using latest index state" + (if name == null then "" else " for " + name) + "!")
-      (pkgs.lib.last (builtins.attrNames index-state-hashes));
+    else
+      let latest-index-state = pkgs.lib.last (builtins.attrNames index-state-hashes);
+      in builtins.trace ("No index state specified" + (if name == null then "" else " for " + name) + ", using the latest index state that we know about (${latest-index-state})!") latest-index-state;
 
   index-state-pinned = index-state != null || cabalProjectIndexState != null;
 
@@ -422,6 +423,8 @@ let
     ''}
     export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
     export GIT_SSL_CAINFO=${cacert}/etc/ssl/certs/ca-bundle.crt
+
+    echo "Using index-state ${index-state-found}"
     HOME=${
       # This creates `.cabal` directory that is as it would have
       # been at the time `cached-index-state`.  We may include
@@ -437,8 +440,7 @@ let
             # Setting the desired `index-state` here in case it was not
             # from the cabal.project file. This will further restrict the
             # packages used by the solver (cached-index-state >= index-state-found).
-            builtins.trace ("Using index-state: ${index-state-found}" + (if name == null then "" else " for " + name))
-              index-state-found} \
+           index-state-found} \
         -w ${
           # We are using `-w` rather than `--with-ghc` here to override
           # the `with-compiler:` in the `cabal.project` file.


### PR DESCRIPTION
Removes the three most common trace messages discussed in https://github.com/input-output-hk/haskell.nix/issues/527.