### PR TITLE
Don't reference scripts directly in materialization messages

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -369,6 +369,7 @@ let
     inherit materialized;
     sha256 = plan-sha256;
     sha256Arg = "plan-sha256";
+    this = "project.plan-nix" + (if name != null then " for ${name}" else "");
     # Before pinning stuff down we need an index state to use
     reasonNotSafe =
       if !index-state-pinned

--- a/lib/call-stack-to-nix.nix
+++ b/lib/call-stack-to-nix.nix
@@ -34,6 +34,7 @@ let
     sha256 = stack-sha256;
     sha256Arg = "stack-sha256";
     reasonNotSafe = null;
+    this = "project.stack-nix" + (if name != null then " for ${name}" else "");
   } // pkgs.lib.optionalAttrs (checkMaterialization != null) {
     inherit checkMaterialization;
   }) (runCommand (if name == null then "stack-to-nix-pkgs" else name + "-stack-to-nix-pkgs") {

--- a/lib/materialize.nix
+++ b/lib/materialize.nix
@@ -7,6 +7,9 @@
                  # the output. If this is set but does not exist
                  # the derivation will fail but with a message
                  # advising how to populate it.
+, this ? "this"
+                # A name to use when referring to the thing currently being
+                # materialized. Clients can pass in an attribute name or similar.
 , reasonNotSafe ? null
                  # Some times there a reasont the derivation will
                  # not produce output that can be safely materialized.
@@ -35,8 +38,8 @@ let
 
   unchecked =
     let
-      sha256message = "To make this a fixed-output derivation but not materialized, set `${sha256Arg}` to the output of ${calculateMaterializedSha}";
-      materializeMessage = "To materialize the output entirely, pass a writable path as the `materialized` argument and pass that path to ${generateMaterialized}";
+      sha256message = "To make ${this} a fixed-output derivation but not materialized, set `${sha256Arg}` to the output of the 'calculateMaterializedSha' script in 'passthru'.";
+      materializeMessage = "To materialize ${this} entirely, pass a writable path as the `materialized` argument and run the 'updateMaterialized' script in 'passthru'.";
     in if reasonNotSafe != null
       then
         # Warn the user if they tried to pin stuff down when it is not safe


### PR DESCRIPTION
Instead, give a hint as to how to get the appropriate scripts
as attributes.

Fixes #456, #877.