### PR TITLE
Add projectCross to projects (like pkgsCross)

### DIFF
--- a/docs/reference/library.md
+++ b/docs/reference/library.md
@@ -165,6 +165,7 @@ Then feeding its result into [mkCabalProjectPkgSet](#mkcabalprojectpkgset) passi
 | `shellFor`        | Function                                         | [`shellFor`](#shellfor)                                                     |
 | `ghcWithHoogle`   | Function                                         | [`ghcWithHoogle`](#ghcwithhoogle)                                           | 
 | `ghcWithPackages` | Function                                         | [`ghcWithPackages`](#ghcwithpackages)                                       |
+| `projectCross`    | Attrset                                          | Like `pkgs.pkgsCross.X` from nixpkgs `p.projectCross.X` returns the project results for cross compilation to X.  So `p.projectCross.ghcjs.hsPkgs` is the same as `hsPkgs` but compiled with ghcjs |
 
 ## project, cabalProject and stackProject
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -77,6 +77,13 @@ To build an executable:
 nix-build -A your-package-name.components.exes.your-exe-name
 ```
 
+To cross compile use the `projectCross` attribute:
+
+```
+nix-build -A projectCross.ghcjs.hsPkgs.your-package-name.components.exes.your-exe-name
+nix-build -A projectCross.mingwW64.hsPkgs.your-package-name.components.exes.your-exe-name
+```
+
 To open a shell for use with `cabal` run:
 
 ```shell

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -520,6 +520,8 @@ final: prev: {
                   tool = final.buildPackages.haskell-nix.tool pkg-set.config.compiler.nix-name;
                   tools = final.buildPackages.haskell-nix.tools pkg-set.config.compiler.nix-name;
                   roots = final.haskell-nix.roots pkg-set.config.compiler.nix-name;
+                  projectFunction = haskell-nix: haskell-nix.cabalProject';
+                  projectArgs = args';
                 };
             in project;
 
@@ -560,6 +562,10 @@ final: prev: {
 
             projectCoverageReport = haskellLib.projectCoverageReport (map (pkg: pkg.coverageReport) (final.lib.attrValues (haskellLib.selectProjectPackages hsPkgs)));
 
+            projectCross = (final.lib.mapAttrs (_: pkgs:
+                rawProject.projectFunction pkgs.haskell-nix rawProject.projectArgs
+              ) final.pkgsCross) // { recurseForDerivations = false; };
+
             inherit (rawProject.hsPkgs) makeConfigFiles ghcWithHoogle ghcWithPackages shellFor;
           });
 
@@ -592,6 +598,8 @@ final: prev: {
                   tool = final.buildPackages.haskell-nix.tool pkg-set.config.compiler.nix-name;
                   tools = final.buildPackages.haskell-nix.tools pkg-set.config.compiler.nix-name;
                   roots = final.haskell-nix.roots pkg-set.config.compiler.nix-name;
+                  projectFunction = haskell-nix: haskell-nix.stackProject';
+                  projectArgs = args;
                 };
             in project;
 


### PR DESCRIPTION
This change adds a `projectCross` attribute to the return value of
the project functions.  It is similar to `pkgs.pkgsCross` and makes
it easier to build cross compiled versions of project (or get
a cross compile with `p.projectCross.${platform}.shellFor`).