### PR TITLE
Drop 19.09 support

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -9,7 +9,6 @@
   inherit (import ./ci-lib.nix) dimension platformFilterGeneric filterAttrsOnlyRecursive;
   sources = import ./nix/sources.nix {};
   nixpkgsVersions = {
-    "R1909" = "nixpkgs-1909";
     "R2003" = "nixpkgs-2003";
     "R2009" = "nixpkgs-2009";
   };

--- a/docs/dev/nixpkgs-pin.md
+++ b/docs/dev/nixpkgs-pin.md
@@ -1,25 +1,17 @@
 # Haskell.nix Nixpkgs Pin
 
-Haskell.nix contains a Nixpkgs pin in
-[`nixpkgs/github.json`](https://github.com/input-output-hk/haskell.nix/blob/master/nixpkgs/github.json).
-This is the version of Nixpkgs used for builds of `nix-tools` and
-running the tests.
+Haskell.nix contains several Nixpkgs pins imanaged by `niv` in
+`nix/sources.json`.
+
+These are used in testing various versions of nixpkgs.
 
 To use haskell.nix the `config` and `overlays` need to be applied to
 Nixpkgs.  Users should probably pin a suitable version of nixpkgs, although things might not work for them if their Nixpkgs version is
 too different.
 
 We aim to keep this pin somewhere on a channel of the **Nixpkgs latest
-stable release**. That is currently 19.09.
+stable release**. That is currently 20.09.
 
 We also execute tests on MacOS (darwin). The darwin channel is usually
-behind the NixOS channel. So we choose the `nixpkgs-19.09-darwin`
-channel:
-
-```
-nix-prefetch-git https://github.com/NixOS/nixpkgs-channels refs/heads/nixpkgs-19.09-darwin
-```
-
-Keep the URL in `github.json` pointing at
-<https://github.com/NixOS/nixpkgs>. Case matters because the Hydra
-trusted URL whitelist is case-sensitive.
+behind the NixOS channel. So we follow the `nixpkgs-20.09-darwin`
+channel.

--- a/docs/tutorials/development.md
+++ b/docs/tutorials/development.md
@@ -100,7 +100,7 @@ selects packages from the larger package set.
 # shell.nix
 let
   haskellNix = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz) {};
-  nixpkgs = import haskellNix.sources.nixpkgs-1909 haskellNix.nixpkgsArgs;
+  nixpkgs = import haskellNix.sources.nixpkgs haskellNix.nixpkgsArgs;
   haskell = nixpkgs.haskell-nix;
 in
   haskell.haskellPackages.ghcWithPackages (ps: with ps;
@@ -119,7 +119,7 @@ project.
 ```nix
 let
   haskellNix = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz) {};
-  nixpkgs = import haskellNix.sources.nixpkgs-1909 haskellNix.nixpkgsArgs;
+  nixpkgs = import haskellNix.sources.nixpkgs haskellNix.nixpkgsArgs;
   haskell = nixpkgs.haskell-nix;
 in
   haskell.snapshots."lts-13.18".alex.components.exes.alex

--- a/lib/clean-source-haskell.nix
+++ b/lib/clean-source-haskell.nix
@@ -35,21 +35,7 @@ rec {
         src = lib.cleanSource src;
         inherit name;
       };
-      # Copy function from 19.09 for compatibility with 19.03.
-      # Does require at least Nix 2.0.
-      compat = let
-        isFiltered = src ? _isLibCleanSourceWith;
-        origSrc = if isFiltered then src.origSrc else src;
-        filter' = name: type: haskellSourceFilter name type && lib.cleanSourceFilter name type;
-        name' = if name != null then name else if isFiltered then src.name else baseNameOf src;
-      in {
-        inherit origSrc;
-        filter = filter';
-        outPath = builtins.path { filter = filter'; path = origSrc; name = name'; };
-        _isLibCleanSourceWith = true;
-        name = name';
-      };
     in
       if (builtins.typeOf src) == "path"
-      then (if lib.versionAtLeast lib.version "19.09" then clean else compat) else src;
+      then clean else src;
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,19 +65,6 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/732684b720f829056dcb62380c2c17e4d3ebd947.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
-    "nixpkgs-1909": {
-        "branch": "nixpkgs-19.09-darwin",
-        "builtin": false,
-        "description": "Nix Packages collection",
-        "homepage": null,
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "9237a09d8edbae9951a67e9a3434a07ef94035b7",
-        "sha256": "05bizymljzzd665bpsjbhxamcgzq7bkjjzjfapkl2nicy774ak4x",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/9237a09d8edbae9951a67e9a3434a07ef94035b7.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "nixpkgs-2003": {
         "branch": "nixpkgs-20.03-darwin",
         "builtin": false,

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -17,7 +17,6 @@ let
     emscripten = import ./emscripten.nix;
     nix-prefetch-git-minimal = import ./nix-prefetch-git-minimal.nix;
     gobject-introspection = import ./gobject-introspection.nix;
-    shims = import ./shims.nix;
     eval-on-current = import ./eval-on-current.nix;
     eval-on-build = import ./eval-on-build.nix;
     ghcjs = import ./ghcjs.nix;
@@ -51,7 +50,6 @@ let
     nix-prefetch-git-minimal
     ghcjs
     gobject-introspection
-    shims
     # Restore nixpkgs haskell and haskellPackages
     (_: prev: { inherit (prev.haskell-nix-prev) haskell haskellPackages; })
   ];

--- a/overlays/musl.nix
+++ b/overlays/musl.nix
@@ -1,13 +1,4 @@
 final: prev: prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl ({
-  # On nixpkgs 19.09 openssl is configured as `linux-generic64` instead
-  # of `linux-x86_64` and as a result the `asm` parts of of openssl
-  # are not built.  Because the `no_asm` configure flag is also not passed
-  # the c versions of the functions are also not included.
-  openssl = prev.openssl.overrideAttrs (attrs:
-    prev.lib.optionalAttrs prev.stdenv.hostPlatform.isx86_64 {
-      configureScript = "./Configure linux-x86_64";
-    });
-
   # Prevent pkgsMusl.pkgsStatic chain
   busybox-sandbox-shell = prev.busybox-sandbox-shell.override { inherit (final) busybox; };
 

--- a/overlays/shims.nix
+++ b/overlays/shims.nix
@@ -1,9 +1,0 @@
-# Shims to make older versions of nixpkgs work
-final: prev: {
-  # nixpkgs 19.09 and older does not have runCommandLocal
-  runCommandLocal = prev.runCommandLocal or (name: env:
-    final.runCommand name ({
-      preferLocalBuild = true;
-      allowSubstitutes = false;
-    } // env));
-}


### PR DESCRIPTION
This is a year old. NixOS doesn't even support the last stable release,
let alone the one before that.

Also cuts our CI size by a third, which is always nice.