### PR TITLE
Move more CI to 20.09

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -24,14 +24,12 @@
     # Update supported-ghc-versions.md to reflect any changes made here.
     {
       ghc865 = true;
-    } // nixpkgs.lib.optionalAttrs (nixpkgsName == "R2003") {
+    } // nixpkgs.lib.optionalAttrs (nixpkgsName == "R2009") {
       ghc883 = false;
       ghc884 = true;
       ghc8101 = false;
       ghc8102 = true;
       ghc8102-experimental = true;
-    } // nixpkgs.lib.optionalAttrs (nixpkgsName == "R2009") {
-      ghc8102 = true;
     });
   systems = nixpkgs: nixpkgs.lib.filterAttrs (_: v: builtins.elem v supportedSystems) {
     # I wanted to take these from 'lib.systems.examples', but apparently there isn't one for linux!
@@ -42,7 +40,7 @@
     # We need to use the actual nixpkgs version we're working with here, since the values
     # of 'lib.systems.examples' are not understood between all versions
     let lib = nixpkgs.lib;
-    in lib.optionalAttrs (nixpkgsName == "R2003" && (__elem compiler-nix-name ["ghc865" "ghc884"])) {
+    in lib.optionalAttrs (nixpkgsName == "R2009" && (__elem compiler-nix-name ["ghc865" "ghc884"])) {
     inherit (lib.systems.examples) ghcjs;
   } // lib.optionalAttrs (system == "x86_64-linux" && (nixpkgsName == "R2009" || (!(__elem compiler-nix-name ["ghc8101" "ghc8102" "ghc8102-experimental"])))) {
     # Windows cross compilation is currently broken on macOS

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,16 +53,16 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixpkgs-20.03-darwin",
+        "branch": "nixpkgs-20.09-darwin",
         "builtin": false,
         "description": "Nix Packages collection",
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "732684b720f829056dcb62380c2c17e4d3ebd947",
-        "sha256": "1fyrgpgpn906c96bhm4ad5n4qq27flhnfpiv395iryk3zsyig4dk",
+        "rev": "07e5844fdf6fe99f41229d7392ce81cfe191bcfc",
+        "sha256": "0p2z6jidm4rlp2yjfl553q234swj1vxl8z0z8ra1hm61lfrlcmb9",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/732684b720f829056dcb62380c2c17e4d3ebd947.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/07e5844fdf6fe99f41229d7392ce81cfe191bcfc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-2003": {
@@ -81,6 +81,7 @@
     "nixpkgs-2009": {
         "branch": "nixpkgs-20.09-darwin",
         "description": "Nix Packages collection",
+        "builtin": false,
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",

--- a/release.nix
+++ b/release.nix
@@ -16,9 +16,9 @@ in allJobs // {
     required = genericPkgs.releaseTools.aggregate {
       name = "haskell.nix-required";
       meta.description = "All jobs required to pass CI";
-      # Hercules will require all of these, we just require the 20.03 jobs
+      # Hercules will require all of these, we just require the 20.09 jobs
       # to avoid stressing Hydra too much
-      constituents = lib.collect lib.isDerivation allJobs.R2003.ghc865.linux.native;
+      constituents = lib.collect lib.isDerivation allJobs.R2009.ghc865.linux.native;
     };
   }
 


### PR DESCRIPTION
Move more of the CI to primarily test 20.09.

Also move the "nixpkgs" source to 20.09. I don't really know why we have this as a separate `niv` source that can get out of sync from "latest nixpkgs stable"...