### PR TITLE
Fix missing attribute error in gobject introspection overlay

### DIFF
--- a/overlays/gobject-introspection.nix
+++ b/overlays/gobject-introspection.nix
@@ -3,7 +3,7 @@ final: prev: {
   # As of nixpkgs 20.09 harfbuzz is built with mesonFlags and hopefully includes
   # gobject introspection correctly.  Older nixpkgs will have configureFlags to update.
   harfbuzz = prev.harfbuzz.overrideAttrs (attr: final.lib.optionalAttrs (attr ? configureFlags) {
-    configureFlags = attr.configureFlags ++ [ "--enable-introspection=yes" "--with-gobject=yes" ];
-    buildInputs = attr.buildInputs ++ [ final.pkgs.gobject-introspection ];
+    configureFlags = attr.configureFlags or [] ++ [ "--enable-introspection=yes" "--with-gobject=yes" ];
+    buildInputs = attr.buildInputs or [] ++ [ final.pkgs.gobject-introspection ];
   });
 }


### PR DESCRIPTION
When running haskell.nix over a pinned checkout of nixpkgs-20.09 (nixos/nixpkgs@2fbcd0b9df95306199407e36a038d2cc3aa24786) we received the error 
```
error: attribute 'configureFlags' missing, at /nix/store/7xs98z1m5idlc6vi475bacq7aqili646-haskell-nix-src/overlays/gobject-introspection.nix:4:22
```

This appears to be the appropriate fix