### PR TITLE
Add internal- variants of cabal-install and nix-tools to roots

### DIFF
--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -692,8 +692,12 @@ final: prev: {
               final.ghc-extra-projects.${compiler-nix-name}.plan-nix;
           } // final.lib.optionalAttrs (ifdLevel > 1) {
             # Things that require two levels of IFD to build (inputs should be in level 1)
+            # The internal versions of nix-tools and cabal-install are occasionally used,
+            # but definitely need to be cached in case they are used.
             nix-tools = final.buildPackages.haskell-nix.nix-tools.${compiler-nix-name};
+            internal-nix-tools = final.buildPackages.haskell-nix.internal-nix-tools;
             cabal-install = final.buildPackages.haskell-nix.cabal-install.${compiler-nix-name};
+            internal-cabal-install = final.buildPackages.haskell-nix.internal-cabal-install;
           } // final.lib.optionalAttrs (ifdLevel > 1 && !final.stdenv.hostPlatform.isGhcjs) {
             # GHCJS builds its own template haskell runner.
             # These seem to be the only things we use from `ghc-extra-packages`


### PR DESCRIPTION
Not caching these makes it easy to have an uncached dependency on GHC
8.8.4 (which is the compiler used to build them).

Fixes #967.