### PR TITLE
x509-system: use /usr/bin/security on macOS.

### DIFF
--- a/overlays/darwin.nix
+++ b/overlays/darwin.nix
@@ -1,3 +1,21 @@
-final: prev: {
-
+final: prev:
+{
+  haskell-nix = prev.haskell-nix // ({
+    defaultModules = prev.haskell-nix.defaultModules ++ [
+      ({ pkgs, buildModules, config, lib, ... }:
+        {
+          packages = { } // pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.isDarwin && !pkgs.stdenv.cc.nativeLibc)
+            {
+              # Workaround for broken nixpkgs darwin.security_tool in
+              # Mojave. This mirrors the workaround in nixpkgs
+              # haskellPackages.
+              #
+              # ref:
+              # https://github.com/NixOS/nixpkgs/pull/47676
+              # https://github.com/NixOS/nixpkgs/issues/45042
+              x509-system.components.library.preBuild = "substituteInPlace System/X509/MacOS.hs --replace security /usr/bin/security";
+            };
+        })
+    ];
+  });
 }

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -10,6 +10,7 @@ let
     bootstrap = import ./bootstrap.nix;
     ghc = import ./ghc.nix;
     ghc-packages = import ./ghc-packages.nix;
+    darwin = import ./darwin.nix;
     windows = import ./windows.nix;
     armv6l-linux = import ./armv6l-linux.nix;
     musl = import ./musl.nix;
@@ -42,6 +43,7 @@ let
     bootstrap
     ghc
     ghc-packages
+    darwin
     windows
     armv6l-linux
     musl


### PR DESCRIPTION
This mirrors the workaround in nixpkgs for haskellPackages.

ref: https://github.com/NixOS/nixpkgs/pull/47676