### PR TITLE
Wrapped X11, added Xrender

### DIFF
--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -155,7 +155,7 @@ pkgs:
     "webkit2gtk-4.0"                     = [ pkgs."webkitgtk" ];
     "webkit2gtk-web-extension-4.0"       = [ pkgs."webkitgtk" ];
     "webkitgtk-3.0"                      = [ pkgs."webkitgtk24x-gtk3" ]; # These are the old APIs, of which 2.4 is the last provider, so map directly to that
-    "X11"                                = [ pkgs.xorg."libX11" ];
+    "X11"                                = [ pkgs.xorg."x11-haskell-wrapper" ];
     "x11"                                = [ pkgs.xorg."xlibsWrapper" ];
     "xau"                                = [ pkgs.xorg."libXau" ];
     "Xcursor"                            = [ pkgs.xorg."libXcursor" ];

--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -19,6 +19,7 @@ pkgs:
      alut = pkgs.freealut;
      X11 = pkgs.xorg.libX11;
      Xrandr = pkgs.xorg.libXrandr;
+     Xrender = pkgs.xorg.libXrender;
      Xext = pkgs.xorg.libXext;
      Xi = pkgs.xorg.libXi;
      Xxf86vm = pkgs.xorg.libXxf86vm;

--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -19,7 +19,8 @@ pkgs:
      alut = pkgs.freealut;
      X11 = pkgs.buildEnv {
        name = "x11-haskell-wrapper";
-       paths = with pkgs.xorg; [libX11 libXScrnSaver];
+       paths = with pkgs.xorg; [ libX11 libXScrnSaver libXinerama ]
+               ++ [ pkgs.xlibs.libXinerama.dev ];
      };
      Xrandr = pkgs.xorg.libXrandr;
      Xrender = pkgs.xorg.libXrender;

--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -17,7 +17,10 @@ pkgs:
      GL = pkgs.libGL;
      GLU = pkgs.libGLU;
      alut = pkgs.freealut;
-     X11 = pkgs.xorg.libX11;
+     X11 = pkgs.buildEnv {
+       name = "x11-haskell-wrapper";
+       paths = with pkgs.xorg; [libX11 libXScrnSaver];
+     };
      Xrandr = pkgs.xorg.libXrandr;
      Xrender = pkgs.xorg.libXrender;
      Xext = pkgs.xorg.libXext;


### PR DESCRIPTION
xmonad seems to expect X11 to come with `libXScrnSaver`, thus i created a wrapper around the initial lib. 

This seems like a hack, is there a better way to solve this?