### PR TITLE
Add inputs.nixpkgs to flake.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1608007629,
+        "narHash": "sha256-lipVFC/a2pzzA5X2ULj64je+fz1JIp2XRrB5qyoizpQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,12 @@
 {
   description = "Alternative Haskell Infrastructure for Nixpkgs";
 
-  outputs = { self }: let
+  inputs = {
+    # Note: keep this in sync with sources.json!
+    nixpkgs.url = github:NixOS/nixpkgs/f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693;
+  };
+
+  outputs = { self, nixpkgs, ... }: let
     config = import ./config.nix;
     # We can't import ./nix/sources.nix directly, because that uses nixpkgs to fetch by default,
     # and importing nixpkgs without specifying localSystem doesn't work on flakes.
@@ -29,7 +34,7 @@
           value = f name;
         }) lst);
     in genAttrs [ "x86_64-linux" "x86_64-darwin" ] (system:
-      import sources.nixpkgs
+      import nixpkgs
       (nixpkgsArgs // { localSystem = { inherit system; }; }));
   };
 }


### PR DESCRIPTION
This makes it easy for downstream consumers of the flake to keep their nixpkgs in sync with haskell.nix, and is pretty much necessary to use haskell.nix as an overlay with Flakes, if you also want to take advantage of the IOHK binary cache.

Note that this isn't a great solution, as the flake input branch needs to be kept in sync with the niv pin. There's probably a way to do this automatically (e.g., using `sources`), so I actually expect this PR to be rejected, but I wanted to get the ball rolling on improving the flake support in haskell.nix. Hopefully this will at least get a discussion started.