### PR TITLE
Try a more general way of constructing the job names for aggregation

### DIFF
--- a/ci-lib.nix
+++ b/ci-lib.nix
@@ -5,6 +5,37 @@ let
 in rec {
   inherit (import ./dimension.nix) dimension;
 
+  /*
+    Takes an attribute set and returns all the paths to derivations within it, i.e.
+    derivationPaths { a = { b = <drv>; }; c = <drv>; } == [ "a.b" "c" ]
+    This can be used with 'attrByPath' or the 'constitutents' of an aggregate Hydra job.
+  */
+  derivationPaths =
+    let
+      names = x: lib.filter (n: n != "recurseForDerivations" && n != "meta") (builtins.attrNames x);
+      go = nameSections: attrs:
+        builtins.concatMap
+          (n:
+            let
+              v = builtins.getAttr n attrs;
+              newNameSections = nameSections ++ [ n ];
+            in
+            if pkgs.lib.isDerivation v
+            then [ (builtins.concatStringsSep "." newNameSections) ]
+            else if builtins.isAttrs v
+            then go newNameSections v
+            else [ ]
+          )
+          (names attrs);
+    in
+    go [ ];
+
+  # Creates an aggregate job with the given name from every derivation in the attribute set.
+  derivationAggregate = name: attrs: pkgs.releaseTools.aggregate {
+    inherit name;
+    constituents = derivationPaths attrs;
+  };
+
   # A filter for removing packages that aren't supported on the current platform
   # according to 'meta.platforms'.
   platformFilterGeneric = pkgs: system:

--- a/release.nix
+++ b/release.nix
@@ -5,47 +5,19 @@
 , checkMaterialization ? false }:
 
 let
-  inherit (import ./ci-lib.nix) stripAttrsForHydra filterDerivations;
+  inherit (import ./ci-lib.nix) stripAttrsForHydra filterDerivations derivationAggregate;
   genericPkgs = import (import ./nix/sources.nix).nixpkgs {};
   lib = genericPkgs.lib;
   ci = import ./ci.nix { inherit supportedSystems ifdLevel checkMaterialization; restrictEval = true; };
   allJobs = stripAttrsForHydra (filterDerivations ci);
-  latestJobs = {
-    # All the jobs are included in the `requiredJobs`, but the ones
+	latestJobs = {
+    # All the jobs are included in the 'required' job, but the ones
     # added here will also included without aggregation, making it easier
     # to find a failing test.  Keep in mind though that adding too many
     # of these will slow down eval times.
     linux = allJobs.R2009.ghc8102.linux.native or {};
     darwin = allJobs.R2009.ghc8102.darwin.native or {};
   };
-  names = x: lib.filter (n: n != "recurseForDerivations" && n != "meta")
-    (builtins.attrNames x);
-  requiredJobs =
-    builtins.listToAttrs (
-      lib.concatMap (nixpkgsVer:
-        let nixpkgsJobs = allJobs.${nixpkgsVer};
-        in lib.concatMap (compiler-nix-name:
-          let ghcJobs = nixpkgsJobs.${compiler-nix-name};
-          in builtins.concatMap (platform:
-            let platformJobs = ghcJobs.${platform};
-            in builtins.map (crossPlatform: {
-              name = "required-${nixpkgsVer}-${compiler-nix-name}-${platform}-${crossPlatform}";
-              value = genericPkgs.releaseTools.aggregate {
-                name = "haskell.nix-${nixpkgsVer}-${compiler-nix-name}-${platform}-${crossPlatform}";
-                meta.description = "All ${nixpkgsVer} ${compiler-nix-name} ${platform} ${crossPlatform} jobs";
-                constituents = lib.collect (d: lib.isDerivation d) platformJobs.${crossPlatform};
-              };
-           }) (names platformJobs)
-         ) (names ghcJobs)
-        ) (names nixpkgsJobs)
-      ) (names allJobs));
-in latestJobs // requiredJobs // {
-    required = genericPkgs.releaseTools.aggregate {
-      name = "haskell.nix-required";
-      meta.description = "All jobs required to pass CI";
-      # Using the names here requires https://github.com/NixOS/hydra/issues/715
-      constituents = builtins.attrNames requiredJobs;
-    };
- }
+in latestJobs // { required = derivationAggregate "haskell.nix-required" allJobs; }
 
 

--- a/release.nix
+++ b/release.nix
@@ -10,14 +10,6 @@ let
   lib = genericPkgs.lib;
   ci = import ./ci.nix { inherit supportedSystems ifdLevel checkMaterialization; restrictEval = true; };
   allJobs = stripAttrsForHydra (filterDerivations ci);
-	latestJobs = {
-    # All the jobs are included in the 'required' job, but the ones
-    # added here will also included without aggregation, making it easier
-    # to find a failing test.  Keep in mind though that adding too many
-    # of these will slow down eval times.
-    linux = allJobs.R2009.ghc8102.linux.native or {};
-    darwin = allJobs.R2009.ghc8102.darwin.native or {};
-  };
-in latestJobs // { required = derivationAggregate "haskell.nix-required" allJobs; }
+in allJobs // { required = derivationAggregate "haskell.nix-required" allJobs; }
 
 


### PR DESCRIPTION
Borrow the trick I used in Plutus.

I wonder also whether going back to just `allJobs` instead of `latestJobs` would be fine, but maybe that will slow down evals.