### PR TITLE
Allowing projects with odbc or hdbc-odbc to be built

### DIFF
--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -73,7 +73,7 @@ with pkgs;
   boost_wave = [ boost ];
   boost_wserialization = [ boost ];
   tensorflow = [ libtensorflow ];
-  odbc = [ unixODBC ];
+  odbc = [ freetds ];
   opencv = [ opencv3 ];
   icuuc = [ icu ];
   icui18n = [ icu ];

--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -73,6 +73,7 @@ with pkgs;
   boost_wave = [ boost ];
   boost_wserialization = [ boost ];
   tensorflow = [ libtensorflow ];
+  odbc = [ unixODBC ];
   opencv = [ opencv3 ];
   icuuc = [ icu ];
   icui18n = [ icu ];

--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -73,6 +73,9 @@ with pkgs;
   boost_wave = [ boost ];
   boost_wserialization = [ boost ];
   tensorflow = [ libtensorflow ];
+  # odbc package requires both freetds (https://github.com/fpco/odbc/commit/9457377089dbe84d8c329560fa1bc1a2797c821d)
+  # and unixODBC packages to be installed in order to successfully
+  # compile C sources (https://github.com/fpco/odbc/blob/master/cbits/odbc.c)
   odbc = [ freetds unixODBC ];
   opencv = [ opencv3 ];
   icuuc = [ icu ];

--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -73,7 +73,7 @@ with pkgs;
   boost_wave = [ boost ];
   boost_wserialization = [ boost ];
   tensorflow = [ libtensorflow ];
-  odbc = [ freetds ];
+  odbc = [ freetds unixODBC ];
   opencv = [ opencv3 ];
   icuuc = [ icu ];
   icui18n = [ icu ];


### PR DESCRIPTION
Problem:

I made such https://github.com/maksar/hcards reproducible example, which demonstrates, that haskell.nix could not build projects with `odbc` dependency it it. That happens due to https://github.com/fpco/odbc/blob/master/odbc.cabal#L29 (there is no system package with such name).

Haskell.nix was complaining:
```
The Nixpkgs package set does not contain the package: odbc (system dependency).
You may need to augment the system package mapping in haskell.nix so that it can be found.
```
despite the https://github.com/input-output-hk/haskell.nix/blob/e6fc81b36e725312d18ff7d7e02629a22c302676/lib/pkgconf-nixpkgs-map.nix#L108 mapping

Solution:

https://webchat.freenode.net pointed to me to another mapping: https://github.com/input-output-hk/haskell.nix/blob/e6fc81b36e725312d18ff7d7e02629a22c302676/lib/system-nixpkgs-map.nix which also lacks `odbc` it it, so I started experimenting.

Adding `odbc = [ unixODBC ];` was not enough. Since `unixODBC` does not provide `odbcss.h` header file, compilation of `cbits` from `odbc` failed. Turns out, it is `freetds` package, that provides the header. After looking at https://github.com/fpco/odbc/blob/master/cbits/odbc.c#L4-L14 I realized that both packages are needed.

With such change, `nix build` is finally successful and I can continue my journey to the strange world of using SQLServer with haskell on UNIX ;)