### PR TITLE
Use configuration-nix to include freetds dependency of the odbc package

### DIFF
--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -73,10 +73,9 @@ with pkgs;
   boost_wave = [ boost ];
   boost_wserialization = [ boost ];
   tensorflow = [ libtensorflow ];
-  # odbc package requires both freetds (https://github.com/fpco/odbc/commit/9457377089dbe84d8c329560fa1bc1a2797c821d)
-  # and unixODBC packages to be installed in order to successfully
+  # odbc package requires unixODBC packages to be installed in order to successfully
   # compile C sources (https://github.com/fpco/odbc/blob/master/cbits/odbc.c)
-  odbc = [ freetds unixODBC ];
+  odbc = [ unixODBC ];
   opencv = [ opencv3 ];
   icuuc = [ icu ];
   icui18n = [ icu ];

--- a/modules/configuration-nix.nix
+++ b/modules/configuration-nix.nix
@@ -7,7 +7,7 @@
   # terminfo doesn't list libtinfo in its cabal file. We could ignore
   # this if we used the terminfo shipped with GHC, but this package is
   # reinstallable so we'd rather have it defined in the plan.
-  packages.terminfo.components.library.libs = [pkgs.ncurses];
+  packages.terminfo.components.library.libs = [ pkgs.ncurses ];
 
   # The `extra-libraries` field in `X11.cabal` does not include Xss and Xinerama
   # see https://github.com/input-output-hk/haskell.nix/pull/988
@@ -15,6 +15,10 @@
     pkgs.xorg.libXScrnSaver
     pkgs.xorg.libXinerama
   ];
+
+  # odbc needs this package to provide odbcss.h on Linux and macOS, see
+  # https://github.com/fpco/odbc#common-issues
+  packages.odbc.components.library.libs = [ pkgs.freetds ];
 
   # These packages have `license: LGPL` in their .cabal file, but
   # do not specify the version.  Setting the version here on


### PR DESCRIPTION
I think this is more correct: other package that depend on the system
odbc package may not need freetds, the problem is that the Haskell odbc
package doesn't declare its dependency on freetds.

(I checked and the odbc library still builds with this change.)