### PR TITLE
Add vulkan to pkgconfig-map

### DIFF
--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -155,7 +155,7 @@ pkgs:
     "webkit2gtk-4.0"                     = [ pkgs."webkitgtk" ];
     "webkit2gtk-web-extension-4.0"       = [ pkgs."webkitgtk" ];
     "webkitgtk-3.0"                      = [ pkgs."webkitgtk24x-gtk3" ]; # These are the old APIs, of which 2.4 is the last provider, so map directly to that
-    "vulkan"                             = [ pkgs."vulkan-loader" ];
+    "vulkan"                             = [ pkgs."vulkan-loader" ]; # vulkan-loader provides vulkan.pc file for pkg-config.
     "X11"                                = [ pkgs.xorg."libX11" ];
     "x11"                                = [ pkgs.xorg."xlibsWrapper" ];
     "xau"                                = [ pkgs.xorg."libXau" ];

--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -155,6 +155,7 @@ pkgs:
     "webkit2gtk-4.0"                     = [ pkgs."webkitgtk" ];
     "webkit2gtk-web-extension-4.0"       = [ pkgs."webkitgtk" ];
     "webkitgtk-3.0"                      = [ pkgs."webkitgtk24x-gtk3" ]; # These are the old APIs, of which 2.4 is the last provider, so map directly to that
+    "vulkan"                             = [ pkgs."vulkan-loader" ];
     "X11"                                = [ pkgs.xorg."libX11" ];
     "x11"                                = [ pkgs.xorg."xlibsWrapper" ];
     "xau"                                = [ pkgs.xorg."libXau" ];


### PR DESCRIPTION
We somewhat discussed it in #674.

NixOS `vulkan-loader` [provides pkg-config](https://github.com/NixOS/nixpkgs/blob/nixos-20.09/pkgs/development/libraries/vulkan-loader/default.nix#L20) file. Now even [expipiplus1/vulkan](https://github.com/expipiplus1/vulkan/blob/master/vulkan.cabal#L503-L505) uses `pkgconfig-depends` on linux to find vulkan, so this is needed to build it.