### PR TITLE
Fix issue where subDir was applied twice

### DIFF
--- a/lib/clean-cabal-component.nix
+++ b/lib/clean-cabal-component.nix
@@ -58,16 +58,20 @@ in
         hsSourceDirs = builtins.map (d: combinePaths subDir d) component.hsSourceDirs
           ++ (if component.hsSourceDirs == [] then [subDir] else []);
         includeDirs = builtins.map (d: combinePaths subDir d) component.includeDirs;
-        dirsNeeded = builtins.map (d: combinePaths subDir d) (
+        # paths that will be needed (used to check if a parent dir should be included)
+        dirsNeeded =
+          # These already include subDir
              [dataDir]
           ++ hsSourceDirs
           ++ includeDirs
-          ++ package.licenseFiles
-          ++ package.extraSrcFiles
-          ++ component.extraSrcFiles
-          ++ package.extraDocFiles
           ++ builtins.map (f: dataDir + f) package.dataFiles
-          ++ otherSourceFiles);
+          ++ otherSourceFiles
+          ++ builtins.map (d: combinePaths subDir d) (
+               # These need the subDir added
+               package.licenseFiles
+            ++ package.extraSrcFiles
+            ++ component.extraSrcFiles
+            ++ package.extraDocFiles);
         fileMatch = dir: list:
           let
             prefixes = builtins.map (f: combinePaths dir f) (


### PR DESCRIPTION
This was breaking cleaning of components when a parent dir was needed.

So `hs-source-dirs: x` was ok, `hs-source-dirs: x/y` would fail.