### PR TITLE
Use the source sub directory when running tests

### DIFF
--- a/lib/check.nix
+++ b/lib/check.nix
@@ -28,6 +28,12 @@ in stdenv.mkDerivation ({
   # component and we want it to quietly succeed.
   buildPhase = ''
     mkdir $out
+    ${
+      # Change to the source sub directory if there is one.
+      lib.optionalString (drv ? srcSubDir) ''
+        cd ${lib.removePrefix "/" drv.srcSubDir}
+      ''
+    }
 
     runHook preCheck
 

--- a/lib/check.nix
+++ b/lib/check.nix
@@ -30,7 +30,7 @@ in stdenv.mkDerivation ({
     mkdir $out
     ${
       # Change to the source sub directory if there is one.
-      lib.optionalString (drv ? srcSubDir) ''
+      lib.optionalString (drv.srcSubDir or "" != "") ''
         cd ${lib.removePrefix "/" drv.srcSubDir}
       ''
     }


### PR DESCRIPTION
When running a test we should do it in the same sub directory the
test is built in.