### PR TITLE
LicenseRef-OtherLicense is not `free = false`

### DIFF
--- a/lib/cabal-licenses.nix
+++ b/lib/cabal-licenses.nix
@@ -14,6 +14,8 @@ in licenses // {
       shortName = "Other License";
       fullName = "Unidentified Other License";
       url = "https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/";
+      # Not setting `free` here. The license may or may not be `free`.
+      # See https://github.com/input-output-hk/haskell.nix/pull/1006
     };
   NONE = null;
 }

--- a/lib/cabal-licenses.nix
+++ b/lib/cabal-licenses.nix
@@ -14,7 +14,6 @@ in licenses // {
       shortName = "Other License";
       fullName = "Unidentified Other License";
       url = "https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/";
-      free = false;
     };
   NONE = null;
 }


### PR DESCRIPTION
The [dependent-map](https://hackage.haskell.org/package/dependent-map)
package for instance is not clear on which free license applies to
which parts of the code, but that does not mean it is not free.

`cabal2nix` maps LicenseRef-OtherLicense to `meta.license = "unknown"`

`cabal-to-nix` and `haskell.nix` map it to a more detailed attribute
set but it includes `free = false` and that causes packages like
`dependent-map` to fail to install when `allowUnfree` has not been set.

This change removes the `free` attribute altogether, which seems more
principled than asserting that the `OtherLicense` cannot be `free`.