### PR TITLE
Add `copyTextDir` and use on for cabal configure

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -78,9 +78,9 @@ let
   maybeCleanedSource =
     let
       name' = if name != null then "${name}-root-cabal-files" else "source-root-cabal-files";
-      filter = path: type: (!(src ? filter) || src.filter path type) && (
+      filter = path: type:
         type == "directory" ||
-        pkgs.lib.any (i: (pkgs.lib.hasSuffix i path)) [ ".cabal" "package.yaml" ]);
+        pkgs.lib.any (i: (pkgs.lib.hasSuffix i path)) [ ".cabal" "package.yaml" ];
     in
       # Using `copyTextDir` means that the resulting derivation is the same
       # for all hydra invocations and the same when run localy.  Increasing
@@ -93,7 +93,7 @@ let
           if haskellLib.canCleanSource src
             then haskellLib.cleanSourceWith {
               name = name';
-              inherit filter;
+              filter = path: type: (!(src ? filter) || src.filter path type) && filter path type;
               src = src.origSrc or src;
             }
             else src.origSrc or src;

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -76,14 +76,28 @@ let
   subDir' = src.origSubDir or "";
   subDir = pkgs.lib.strings.removePrefix "/" subDir';
   maybeCleanedSource =
-    if haskellLib.canCleanSource src
-      then (haskellLib.cleanSourceWith {
-        name = if name != null then "${name}-root-cabal-files" else "source-root-cabal-files";
-        src = src.origSrc or src;
-        filter = path: type: (!(src ? filter) || src.filter path type) && (
-          type == "directory" ||
-          pkgs.lib.any (i: (pkgs.lib.hasSuffix i path)) [ ".cabal" "package.yaml" ]); })
-      else src.origSrc or src;
+    let
+      name' = if name != null then "${name}-root-cabal-files" else "source-root-cabal-files";
+      filter = path: type: (!(src ? filter) || src.filter path type) && (
+        type == "directory" ||
+        pkgs.lib.any (i: (pkgs.lib.hasSuffix i path)) [ ".cabal" "package.yaml" ]);
+    in
+      # Using `copyTextDir` means that the resulting derivation is the same
+      # for all hydra invocations and the same when run localy.  Increasing
+      # cache hits and avoiding the number of times `cabal configure` must
+      # be run.
+      haskellLib.copyTextDir {
+        name = name';
+        inherit filter;
+        src =
+          if haskellLib.canCleanSource src
+            then haskellLib.cleanSourceWith {
+              name = name';
+              inherit filter;
+              src = src.origSrc or src;
+            }
+            else src.origSrc or src;
+    };
 
   # Using origSrcSubDir bypasses any cleanSourceWith so that it will work when
   # access to the store is restricted.  If origSrc was already in the store

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -327,7 +327,7 @@ in {
 
   # This is an efficient way to find the empty directories after
   # the filter is applied.  It visits every directory just once.
-  filterMap = { src, filter, basePath ? "" }: rec {
+  filterMap = { src, filter, basePath }: rec {
       # Filtered directory entries for this directory.
       dir = pkgs.lib.filterAttrs
           (name: filter (basePath + "/${name}"))
@@ -354,7 +354,8 @@ in {
         name ? "source"
       , src
       , filter ? path: type: true
-      , basePath ? ""
+      , basePath ? toString src
+      , subDir ? ""
       , filterMap ? haskellLib.filterMap { inherit src filter basePath; }
     }:
     pkgs.evalPackages.symlinkJoin {
@@ -366,12 +367,13 @@ in {
               inherit name filter;
               src = src + "/${name}";
               basePath = basePath + "/${name}";
+              subDir = subDir + "/${name}";
               filterMap = filterMap.subDirs.${name};
             }
             else pkgs.evalPackages.writeTextFile {
               inherit name;
               text = __readFile (src + "/${name}");
-              destination = basePath + "/${name}";
+              destination = subDir + "/${name}";
             }
         ) (filterMap.nonEmpty);
     };

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -336,7 +336,7 @@ in {
       nonEmpty = pkgs.lib.filterAttrs (name: _:
           !(subDirs.${name}.isEmpty or false)
         ) dir;
-      # Result of calling `filterMap` on all sub directories
+      # Result of calling `filterMap` on all sub directories.
       subDirs = pkgs.lib.mapAttrs (name: _:
         haskellLib.filterMap {
           inherit filter;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -357,10 +357,10 @@ in {
       , basePath ? ""
       , filterMap ? haskellLib.filterMap { inherit src filter basePath; }
     }:
-    pkgs.evalPackages.linkFarm name (
-      pkgs.lib.mapAttrsToList (name: type: {
-        inherit name;
-        path =
+    pkgs.evalPackages.symlinkJoin {
+      inherit name;
+      paths =
+        pkgs.lib.mapAttrsToList (name: type:
           if type == "directory"
             then haskellLib.copyTextDir {
               inherit name filter;
@@ -371,6 +371,8 @@ in {
             else pkgs.evalPackages.writeTextFile {
               inherit name;
               text = __readFile (src + "/${name}");
-            };
-        }) (filterMap.nonEmpty));
+              destination = basePath + "/${name}";
+            }
+        ) (filterMap.nonEmpty);
+    };
 }


### PR DESCRIPTION
`cabal configure` for some large haskell projects (such as
`cardano-node`) can take several minutes to run.

When building locally `cleanSourceWith` is used so that only changes to
`cabal.project` and `.cabal` cause `cabal configure` to be run again.

This does not work on hydra though and every commit will cause
`cabal configure` to be rerun during `eval`.  It also means that
local builds cannot reuse the results from hydra.

To fix this `copyTextDir` runs `__readFile` and `writeTextFile` on
the filtered subset of files (cabal.project and .cabal).

Even if the input path is a different store directory the resulting
derivation will be the same if the contents of the filtered subset
of files is the same.