### PR TITLE
Expose sources for flakes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
       overlays = [ self.overlay ];
     };
   in {
+    inherit sources;
     # Using the eval-on-build version here as the plan is that
     # `builtins.currentSystem` will not be supported in flakes.
     # https://github.com/NixOS/rfcs/pull/49/files#diff-a5a138ca225433534de8d260f225fe31R429


### PR DESCRIPTION
The legacyPackages only gives access to the default nixpkgs version, not
any of the others.

With this change it's possible to select the nixpkgs one wants to use
with:

```
pkgs = import haskell-nix.sources.nixpkgs-2003 {
  config = import (haskell-nix + "/config.nix");
  overlays = [ haskell-nix.overlay ];
  localSystem.system = system;
};
```

From a `flake.nix`.