### PR TITLE
add pcap -> libpcap to the system pkgs map

### DIFF
--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -13,6 +13,7 @@ with pkgs;
   "stdc++-6" = null;
   ssl = [ openssl ];
   z = [ zlib ];
+  pcap = [ libpcap ];
   pthread = null; # available by default
   GL = [ libGL ];
   GLU = [ libGLU ];


### PR DESCRIPTION
With this, users don't need any special treatment in order to build the Haskell [pcap library](https://hackage.haskell.org/package/pcap)... except that the one on Hackage does not declare its pcap library dependency, so they need to either manually add the pcap dependency `pcap.components.library.libs = [libpcap]`, or use a fork like [this one](https://github.com/avieth/pcap/blob/avieth/new_pcap/pcap.cabal) in the cabal.project or stack.yaml.