### PR TITLE
Use hackage version of haskell-language-server

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
 This file contains a summary of changes to Haskell.nix and `nix-tools`
 that will impact users.
 
+## Jan 25, 2021
+* Removed older versions of haskell-language-server from custom-tools
+  (0.8.0 is in hackage so we can still get that version).
+
 ## Jan 14, 2021
 * Added support for cross package refs (with a project).  Relative
   directory references between packages within a project should now

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 This file contains a summary of changes to Haskell.nix and `nix-tools`
 that will impact users.
 
-## Jan 25, 2021
+## Feb 8, 2021
 * Removed older versions of haskell-language-server from custom-tools
   (0.8.0 is in hackage so we can still get that version).
 

--- a/overlays/tools.nix
+++ b/overlays/tools.nix
@@ -48,7 +48,6 @@ in { haskell-nix = prev.haskell-nix // {
   # Tools better known by their exe name.
   toolPackageName = {
     cabal = "cabal-install";
-    haskell-language-server-wrapper = "haskell-language-server";
   };
 
   # Packages that are better known by their package name.  We are not

--- a/overlays/tools.nix
+++ b/overlays/tools.nix
@@ -48,6 +48,7 @@ in { haskell-nix = prev.haskell-nix // {
   # Tools better known by their exe name.
   toolPackageName = {
     cabal = "cabal-install";
+    haskell-language-server-wrapper = "haskell-language-server";
   };
 
   # Packages that are better known by their package name.  We are not
@@ -95,82 +96,9 @@ in { haskell-nix = prev.haskell-nix // {
   # to the `tools` attribute defined in `build.nix` to make
   # sure they are cached.
   custom-tools = {
-    ghcide.object-code = args:
-        (final.haskell-nix.cabalProject (args // {
-          name = "ghcide";
-          src = final.fetchFromGitHub {
-            owner = "mpickering";
-            repo = "ghcide";
-            rev = "706c59c97c25c66798815c1dc3ee6885a298918a";
-            sha256 = "0d158xifwvz0y69ah98ckxakzqpz229mq7rpf2bpbmwhnpw3jmm6";
-          };
-          modules = [({config, ...}: {
-            packages.ghcide.configureFlags = lib.optional (!final.stdenv.targetPlatform.isMusl)
-                                              "--enable-executable-dynamic";
-            nonReinstallablePkgs = [ "Cabal" "array" "base" "binary" "bytestring" "containers" "deepseq"
-                                     "directory" "filepath" "ghc" "ghc-boot" "ghc-boot-th" "ghc-compact"
-                                     "ghc-heap" "ghc-prim" "ghci" "haskeline" "hpc" "integer-gmp"
-                                     "libiserv" "mtl" "parsec" "pretty" "process" "rts" "stm"
-                                     "template-haskell" "terminfo" "text" "time" "transformers" "unix"
-                                     "xhtml"
-                                   ];
-          })];
-          pkg-def-extras = [
-                 (hackage: {
-              packages = {
-                "alex" = (((hackage.alex)."3.2.5").revisions).default;
-                "happy" = (((hackage.happy)."1.19.12").revisions).default;
-              };
-            })
-          ];
-        })).ghcide.components.exes.ghcide;
-
-    haskell-language-server = {
-      "0.5.1" = args:
-        (final.haskell-nix.cabalProject ( args // {
-          name = "haskell-language-server";
-          src = final.fetchFromGitHub {
-            owner = "haskell";
-            repo = "haskell-language-server";
-            rev = "0.5.1";
-            sha256 = "17nzgpiacmrvwsy2fjx6a6pcpkncqcwfhaijvajm16jpdgni8mik";
-            fetchSubmodules = true;
-          };
-          sha256map = {
-            "https://github.com/bubba/brittany.git"."c59655f10d5ad295c2481537fc8abf0a297d9d1c" = "1rkk09f8750qykrmkqfqbh44dbx1p8aq1caznxxlw8zqfvx39cxl";
-          };
-          # Plan issues with the benchmarks, can try removing later
-          configureArgs = "--disable-benchmarks";
-          modules = [{
-            # Tests don't pass for some reason, but this is a somewhat random revision.
-            packages.haskell-language-server.doCheck = false;
-          }];
-        })).haskell-language-server.components.exes.haskell-language-server;
-      # When adding new versions here, please set "latest" too the latest version
-      # so that `tools = { haskell-language-server = "latest"; }`
-      # will work the same way it does for tools that are in hackage.
-      "latest" = final.haskell-nix.custom-tools.haskell-language-server."0.8.0";
-    } // final.lib.mapAttrs (rev: sha256:
-      args:
-        (final.haskell-nix.cabalProject ( args // {
-          name = "haskell-language-server";
-          src = final.fetchFromGitHub {
-            owner = "haskell";
-            repo = "haskell-language-server";
-            inherit rev sha256;
-            fetchSubmodules = true;
-          };
-          sha256map = {
-            "https://github.com/bubba/brittany.git"."c59655f10d5ad295c2481537fc8abf0a297d9d1c" = "1rkk09f8750qykrmkqfqbh44dbx1p8aq1caznxxlw8zqfvx39cxl";
-            "https://github.com/bubba/hie-bios.git"."cec139a1c3da1632d9a59271acc70156413017e7" = "1iqk55jga4naghmh8zak9q7ssxawk820vw8932dhympb767dfkha";
-          };
-          # Plan issues with the benchmarks, can try removing later
-          configureArgs = "--disable-benchmarks";
-        })).haskell-language-server.components.exes.haskell-language-server
-    ) {
-      "0.6.0" = "027fq6752024wzzq9izsilm5lkq9gmpxf82rixbimbijw0yk4pwj";
-      "0.7.1" = "0gkzvjx4dgf53yicinqjshlj80gznx5khb62i7g3kqjr85iy0raa";
-      "0.8.0" = "0p6fqs07lajbi2g1wf4w3j5lvwknnk58n12vlg48cs4iz25gp588";
-    };
+    # Currently everything we want is in hackage.
+    # Before addy anything here consider uploading to hackage instead.
+    # If that is not possible look at the git history of this file to see examples
+    # of how to add a custom-tool.
   };
 }; }

--- a/overlays/tools.nix
+++ b/overlays/tools.nix
@@ -97,7 +97,7 @@ in { haskell-nix = prev.haskell-nix // {
   # sure they are cached.
   custom-tools = {
     # Currently everything we want is in hackage.
-    # Before addy anything here consider uploading to hackage instead.
+    # Before adding anything here consider uploading to hackage instead.
     # If that is not possible look at the git history of this file to see examples
     # of how to add a custom-tool.
   };


### PR DESCRIPTION
Removes the custom-tools as haskell-language-server is now in
hackage!

We considered also adding support for `-wrapper`, but decided it was better to fix emacs so that it works if just `haskell-language-server` is present.