### PR TITLE
fix link to troubleshooting section

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -33,7 +33,7 @@ nix.binaryCaches = [
 ];
 ```
 
-This can be tricky to get setup properly. If you're still having trouble getting cache hits, consult the corresponding [troubleshooting section](../reference/troubleshooting#why-am-i-building-ghc).
+This can be tricky to get setup properly. If you're still having trouble getting cache hits, consult the corresponding [troubleshooting section](../../troubleshooting#why-am-i-building-ghc).
 
 ## Scaffolding
 


### PR DESCRIPTION
Fixes link to the troubleshooting section in https://input-output-hk.github.io/haskell.nix/tutorials/getting-started/#setting-up-the-binary-cache (removes `/tutorials/reference` part of url to fix the link)