### PR TITLE
flake: export internal functions for more flexibility

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,27 +1,34 @@
 {
   description = "Alternative Haskell Infrastructure for Nixpkgs";
 
-  outputs = { self }: let
-    config = import ./config.nix;
-    # We can't import ./nix/sources.nix directly, because that uses nixpkgs to fetch by default,
-    # and importing nixpkgs without specifying localSystem doesn't work on flakes.
-    sources = let
-      sourcesInfo =
-        builtins.fromJSON (builtins.readFile ./nix/sources.json);
-      fetch = sourceInfo:
-        builtins.fetchTarball { inherit (sourceInfo) url sha256; };
-    in builtins.mapAttrs (_: fetch) sourcesInfo;
+  outputs = { self }:
+  {
 
-    nixpkgsArgs = {
-      inherit config;
-      overlays = [ self.overlay ];
+    internal = rec {
+      config = import ./config.nix;
+      # We can't import ./nix/sources.nix directly, because that uses nixpkgs to fetch by default,
+      # and importing nixpkgs without specifying localSystem doesn't work on flakes.
+      sources = let
+        sourcesInfo =
+          builtins.fromJSON (builtins.readFile ./nix/sources.json);
+          fetch = sourceInfo:
+          builtins.fetchTarball { inherit (sourceInfo) url sha256; };
+      in builtins.mapAttrs (_: fetch) sourcesInfo;
+
+      nixpkgsArgs = {
+        inherit config;
+        overlays = [ self.overlay ];
+      };
+
+      overlaysOverrideable = import ./overlays;
     };
-  in {
+
     # Using the eval-on-build version here as the plan is that
     # `builtins.currentSystem` will not be supported in flakes.
     # https://github.com/NixOS/rfcs/pull/49/files#diff-a5a138ca225433534de8d260f225fe31R429
     overlay = self.overlays.combined-eval-on-build;
-    overlays = import ./overlays { sourcesOverride = sources; };
+    overlays = self.internal.overlaysOverrideable { sourcesOverride = self.sources; };
+
     legacyPackages = let
       genAttrs = lst: f:
         builtins.listToAttrs (map (name: {
@@ -29,7 +36,7 @@
           value = f name;
         }) lst);
     in genAttrs [ "x86_64-linux" "x86_64-darwin" ] (system:
-      import sources.nixpkgs
-      (nixpkgsArgs // { localSystem = { inherit system; }; }));
+      import self.internal.sources.nixpkgs
+      (self.internal.nixpkgsArgs // { localSystem = { inherit system; }; }));
   };
 }


### PR DESCRIPTION
As of d014079 (#953), haskell.nix internals (such as unapplied
./overlays, sources, etc) are not exported in flake.nix. This makes
it harder to override things when using haskell.nix as a flake.

The use-case I have in mind is to pin haskell.nix itself to prevent
unnecessary GHC rebuilds/redownloads and update only
hackage&stackage. This could be done with a following overlay:

    (haskell-nix.overlays {
      sourcesOverride = haskell-nix.sources // {
        inherit hackage stackage;
      };
    }).combined-eval-on-build

However, this is not the case as of the aforementioned commit. Now, to
do this one has to import ./nix/sources.json, reimplementing what's
already done in haskell.nix, and also import ./overlays. With this
commit, previous snippet turns into the following:

    (haskell-nix.internal.overlaysOverrideable {
      sourcesOverride = haskell-nix.internal.sources // {
        inherit hackage stackage;
      };
    }).combined-eval-on-build

`nix flake check` will now warn us of "unknown flake output
'internal'", but I think it is fine (e.g. nixpkgs has an unknown flake
output as well)
