### PR TITLE
Try re-enabling terminfo on musl

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 3
+, ifdLevel ? 1
 # Whether or not we are evaluating in restricted mode. This is true in Hydra, but not in Hercules.
 , restrictEval ? false
 , checkMaterialization ? false }:

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -37,8 +37,8 @@
 
 , enableLibraryProfiling ? true
 
-, # Whether to build terminfo.  Musl fails to build terminfo as ncurses seems to be linked to glibc
-  enableTerminfo ? !stdenv.targetPlatform.isWindows && !stdenv.targetPlatform.isMusl
+, # Whether to build terminfo. 
+  enableTerminfo ? !stdenv.targetPlatform.isWindows
 
 , # What flavour to build. An empty string indicates no
   # specific flavour and falls back to ghc default values.


### PR DESCRIPTION
I have no idea if this is still broken, seems easiest to just try.

I want this since it's the only thing making my musl and linux plans
differ.