### PR TITLE
Throw better error when conf files are missing

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -373,6 +373,13 @@ let
                 echo 'ERROR: ${package.identifier.name} id could not be found with ${target-pkg-and-db}'
                 exit 1
               fi
+              if ver=$(${target-pkg-and-db} field ${package.identifier.name} version --simple-output); then
+                echo "constraint: ${package.identifier.name} == $ver" >> $out/exactDep/cabal.config
+                echo "constraint: ${package.identifier.name} installed" >> $out/exactDep/cabal.config
+              else
+                echo 'ERROR: ${package.identifier.name} version could not be found with ${target-pkg-and-db}'
+                exit 1
+              fi
             ''
             else
               # If the component name is not the package name this must be a sublib.
@@ -393,13 +400,6 @@ let
               fi
               '')
         }
-        if ver=$(${target-pkg-and-db} field ${package.identifier.name} version --simple-output); then
-          echo "constraint: ${package.identifier.name} == $ver" >> $out/exactDep/cabal.config
-          echo "constraint: ${package.identifier.name} installed" >> $out/exactDep/cabal.config
-        else
-          echo 'ERROR: ${package.identifier.name} version could not be found with ${target-pkg-and-db}'
-          exit 1
-        fi
       ''}
       ${(lib.optionalString (haskellLib.isTest componentId || haskellLib.isBenchmark componentId) ''
         mkdir -p $out/bin

--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -371,7 +371,7 @@ let
                 echo "package-id $id" >> $out/envDep
               else
                 echo 'ERROR: ${package.identifier.name} id could not be found with ${target-pkg-and-db}'
-                exit 0
+                exit 1
               fi
             ''
             else
@@ -389,7 +389,7 @@ let
                 echo "--dependency=${package.identifier.name}:''${name#z-${package.identifier.name}-z-}=$id" >> $out/exactDep/configure-flags
               else
                 echo 'ERROR: ${package.identifier.name} id could not be found with ${target-pkg-and-db}'
-                exit 0
+                exit 1
               fi
               '')
         }
@@ -398,7 +398,7 @@ let
           echo "constraint: ${package.identifier.name} installed" >> $out/exactDep/cabal.config
         else
           echo 'ERROR: ${package.identifier.name} version could not be found with ${target-pkg-and-db}'
-          exit 0
+          exit 1
         fi
       ''}
       ${(lib.optionalString (haskellLib.isTest componentId || haskellLib.isBenchmark componentId) ''

--- a/builder/make-config-files.nix
+++ b/builder/make-config-files.nix
@@ -109,6 +109,7 @@ let
           cp -f "''${files[@]}" $out/${packageCfgDir}
         else
           echo "$l/package.conf.d didn't contain any *.conf files!"
+          exit 1
         fi
       fi
     done

--- a/builder/make-config-files.nix
+++ b/builder/make-config-files.nix
@@ -93,12 +93,23 @@ let
 
     for l in "${cfgFiles}"; do
       if [ -n "$l" ]; then
-        cp -f "$l/${packageCfgDir}/"*.conf $out/${packageCfgDir}
+        files=("$l/${packageCfgDir}/"*.conf)
+        if (( ''${#files[@]} )); then
+          cp -f "''${files[@]}" $out/${packageCfgDir}
+        else
+          echo "$l/${packageCfgDir} didn't contain any *.conf files!"
+          exit 1
+        fi
       fi
     done
     for l in "${libs}"; do
       if [ -n "$l" ]; then
-        cp -f "$l/package.conf.d/"*.conf $out/${packageCfgDir}
+        files=("$l/package.conf.d/"*.conf)
+        if (( ''${#files[@]} )); then
+          cp -f "''${files[@]}" $out/${packageCfgDir}
+        else
+          echo "$l/package.conf.d didn't contain any *.conf files!"
+        fi
       fi
     done
 

--- a/ci.nix
+++ b/ci.nix
@@ -25,6 +25,7 @@
     # Update supported-ghc-versions.md to reflect any changes made here.
     {
       ghc865 = true;
+      ghc884 = false; # Just included because the native version is needed at eval time
     } // nixpkgs.lib.optionalAttrs (nixpkgsName == "R2009") {
       ghc883 = false;
       ghc884 = true;
@@ -51,7 +52,7 @@
       || (nixpkgsName == "R2003" && __elem compiler-nix-name ["ghc865"]))) {
     # Windows cross compilation is currently broken on macOS
     inherit (lib.systems.examples) mingwW64;
-  } // lib.optionalAttrs (system == "x86_64-linux") {
+  } // lib.optionalAttrs (system == "x86_64-linux" && nixpkgsName != "R2003") {
     # Musl cross only works on linux
     # aarch64 cross only works on linux
     inherit (lib.systems.examples) musl64 aarch64-multiplatform;

--- a/ci.nix
+++ b/ci.nix
@@ -52,9 +52,12 @@
       || (nixpkgsName == "R2003" && __elem compiler-nix-name ["ghc865"]))) {
     # Windows cross compilation is currently broken on macOS
     inherit (lib.systems.examples) mingwW64;
-  } // lib.optionalAttrs (system == "x86_64-linux" && nixpkgsName != "R2003") {
+  } // lib.optionalAttrs (system == "x86_64-linux"
+      && !(nixpkgsName == "R2003" && compiler-nix-name == "ghc884")) {
     # Musl cross only works on linux
     # aarch64 cross only works on linux
+    # We also skip these for the R2003 was build of ghc884 (we only need the
+    # native so ifdLevel 1 includes compiler needed in ifdLevel2 eval)
     inherit (lib.systems.examples) musl64 aarch64-multiplatform;
   };
   isDisabled = d:

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -285,19 +285,19 @@ stdenv.mkDerivation (rec {
     # Sanity checks for https://github.com/input-output-hk/haskell.nix/issues/660
     if ! "$out/bin/${targetPrefix}ghc" --version; then
       echo "ERROR: Missing file $out/bin/${targetPrefix}ghc"
-      exit 0
+      exit 1
     fi
     if ! "$out/bin/${targetPrefix}ghc-pkg" --version; then
       echo "ERROR: Missing file $out/bin/${targetPrefix}ghc-pkg"
-      exit 0
+      exit 1
     fi
     if [[ ! -d "$out/lib/${targetPrefix}ghc-${version}" ]]; then
       echo "ERROR: Missing directory $out/lib/${targetPrefix}ghc-${version}"
-      exit 0
+      exit 1
     fi
     if (( $(ls -1 "$out/lib/${targetPrefix}ghc-${version}" | wc -l) < 30 )); then
       echo "ERROR: Expected more files in $out/lib/${targetPrefix}ghc-${version}"
-      exit 0
+      exit 1
     fi
   '';
 

--- a/mk-local-hackage-repo/default.nix
+++ b/mk-local-hackage-repo/default.nix
@@ -31,7 +31,7 @@ ${
   pkgs.lib.optionalString (index ? outputHash) ''
     if [[ "${index.outputHash}" != "$index_sha256" ]]; then
       echo "ERROR See https://github.com/input-output-hk/haskell.nix/issues/884"
-      exit 0
+      exit 1
     fi
 ''}
 export index_length=$(stat --printf="%s" ${index})

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 3
+, ifdLevel ? 1
 , checkMaterialization ? false }:
 
 let

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 1
+, ifdLevel ? 2
 , checkMaterialization ? false }:
 
 let

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 2
+, ifdLevel ? 1
 , checkMaterialization ? false }:
 
 let

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 2
+, ifdLevel ? 3
 , checkMaterialization ? false }:
 
 let

--- a/test/index-state/default.nix
+++ b/test/index-state/default.nix
@@ -26,11 +26,11 @@ in
     buildCommand = ''
       if [[ "${version-before}" != "0.6.0.0" ]]; then
         echo 'Unexpected version ${version-before} (expected "0.6.0.0")'
-        exit 0
+        exit 1
       fi
       if [[ "${version-after}" != "0.6.0.1" ]]; then
         echo 'Unexpected version ${version-after} (expected "0.6.0.1")'
-        exit 0
+        exit 1
       fi
 
       touch $out


### PR DESCRIPTION
Previously, if some directories were missing .conf files, an error like
this would be thrown:

    cp: missing destination file operand after '/nix/store/pnmrz06g0sa4s3yx53hgmr9k8jrh6ww0-ouroboros-network-framework-lib-ouroboros-network-framework-0.1.0.0-haddock-config/lib/ghc-8.6.5/package.conf.d'

While normally this shouldn't occur, I've seen it happen in CI anyways,
with the problem disappearing if the store path that's missing the files
was rebuilt a couple times.

With this commit, it becomes much easier to figure out which store path
is missing the files, which would be very hard to figure out from the
previous message.

Hopefully this helps with debugging future such random failures.