### PR TITLE
doc/tutorial: Update materialization examples

### DIFF
--- a/docs/tutorials/materialization.md
+++ b/docs/tutorials/materialization.md
@@ -44,67 +44,70 @@ file that looks like this:
 let inherit (import ./. {}) sources nixpkgsArgs;
     pkgs = import sources.nixpkgs nixpkgsArgs;
     hlint = pkgs.haskell-nix.hackage-package {
-      compiler-nix-name = "ghc884";
+      compiler-nix-name = "ghc8102";
       name = "hlint";
       version = "2.2.11";
     };
-in hlint.components.exes.hlint
+in hlint
 ```
 
 Building this may result in a lot of output, but if you build
 it again it should give just:
 
 ```
-$ nix-build hlint.nix
-trace: Using latest index state for hlint!
-trace: Using index-state: 2020-04-15T00:00:00Z for hlint
-/nix/store/rnfz66v7k8i38c8rsmchzsyqjrmrbdpk-hlint-2.2.11-exe-hlint
+$ nix-build hlint.nix -A components.exes.hlint
+trace: No index state specified for hlint, using the latest index state that we know about (2021-01-04T00:00:00Z)!
+/nix/store/2ybrfmcp79gg75ad4pr1cbxjak70yg8b-hlint-exe-hlint-2.2.11
 ```
 
-To materialize the nix files we need to take care to pin down the
-inputs.  For cabal projects this means we must specify the
-`index-state` of hackage we want to use:
+To materialize the Nix files we need to take care to pin down the inputs. Stack
+projects have their inputs pinned through specifying the snapshot. For cabal
+projects this means we must specify the `index-state` of hackage we want to
+use:
 
 ```nix
 let inherit (import ./. {}) sources nixpkgsArgs;
     pkgs = import sources.nixpkgs nixpkgsArgs;
     hlint = pkgs.haskell-nix.hackage-package {
-      compiler-nix-name = "ghc884";
+      compiler-nix-name = "ghc8102";
       name = "hlint";
       version = "2.2.11";
-      index-state = "2020-04-15T00:00:00Z";
+      index-state = "2021-01-04T00:00:00Z";
     };
-in hlint.components.exes.hlint
+in hlint
 ```
 
-Now if we build again we get a hint telling use how to
-calculate a suitable sha256 hash to turn the derivation
-containing the nix files into a fixed output derivation:
+Now if we build again we get a hint telling use how to calculate a suitable
+sha256 hash to turn the derivation containing the Nix files into a fixed-output
+derivation:
 
 ```
-$ nix-build hlint.nix
-trace: Using index-state: 2020-04-15T00:00:00Z for hlint
-trace: Get `plan-sha256` with `nix-hash --base32 --type sha256 /nix/store/8z6p4237rin3c6c1lmjwshmj8rdqrhw2-hlint-plan-to-nix-pkgs/`
-/nix/store/rnfz66v7k8i38c8rsmchzsyqjrmrbdpk-hlint-2.2.11-exe-hlint
+$ nix-build hlint.nix -A components.exes.hlint
+trace: To make project.plan-nix for hlint a fixed-output derivation but not materialized, set `plan-sha256` to the output of the 'calculateMaterializedSha' script in 'passthru'.
+trace: To materialize project.plan-nix for hlint entirely, pass a writable path as the `materialized` argument and run the 'updateMaterialized' script in 'passthru'.
+/nix/store/2ybrfmcp79gg75ad4pr1cbxjak70yg8b-hlint-exe-hlint-2.2.11
 
-$ nix-hash --base32 --type sha256 /nix/store/8z6p4237rin3c6c1lmjwshmj8rdqrhw2-hlint-plan-to-nix-pkgs/
-02hasr27a994sml1fzf8swb716lm6lgixxr53y0gxkhw437xkck4
+$ nix-build hlint.nix -A project.plan-nix.passthru.calculateMaterializedSha | bash
+trace: To make project.plan-nix for hlint a fixed-output derivation but not materialized, set `plan-sha256` to the output of the 'calculateMaterializedSha' script in 'passthru'.
+trace: To materialize project.plan-nix for hlint entirely, pass a writable path as the `materialized` argument and run the 'updateMaterialized' script in 'passthru'.
+04hdgqwpaswmyb0ili7fwi6czzihd6x0jlvivw52d1i7wv4gaqy7
 ```
 
-We can add the hash as `plan-sha256` or (`stack-sha256` for
-stack projects)
+For a Stack project all occurences of `plan-nix` and `plan-sha256` are replaced
+by `stack-nix` and `stack-sha256`, respectively.  We can add the hash as
+`plan-sha256`:
 
 ```nix
 let inherit (import ./. {}) sources nixpkgsArgs;
     pkgs = import sources.nixpkgs nixpkgsArgs;
     hlint = pkgs.haskell-nix.hackage-package {
-      compiler-nix-name = "ghc884";
+      compiler-nix-name = "ghc8102";
       name = "hlint";
       version = "2.2.11";
-      index-state = "2020-04-15T00:00:00Z";
-      plan-sha256 = "02hasr27a994sml1fzf8swb716lm6lgixxr53y0gxkhw437xkck4";
+      index-state = "2021-01-04T00:00:00Z";
+      plan-sha256 = "04hdgqwpaswmyb0ili7fwi6czzihd6x0jlvivw52d1i7wv4gaqy7";
     };
-in hlint.components.exes.hlint
+in hlint
 ```
 
 Just adding the hash might help reuse of the cached Nix expressions, but Nix
@@ -116,10 +119,9 @@ downloaded.
 Running `nix-build` again gives us a hint on what we can do next:
 
 ```
-$ nix-build hlint.nix
-trace: Using index-state: 2020-04-15T00:00:00Z for hlint
-trace: To materialize, point `materialized` to a copy of /nix/store/kk047cqsjvbj4w8psv4l05abdcnyrqdc-hlint-plan-to-nix-pkgs
-/nix/store/rnfz66v7k8i38c8rsmchzsyqjrmrbdpk-hlint-2.2.11-exe-hlint
+$ nix-build hlint.nix -A components.exes.hlint
+trace: To materialize project.plan-nix for hlint entirely, pass a writable path as the `materialized` argument and run the 'updateMaterialized' script in 'passthru'.
+/nix/store/2ybrfmcp79gg75ad4pr1cbxjak70yg8b-hlint-exe-hlint-2.2.11
 ```
 
 To capture the Nix expressions we can do something like:
@@ -128,26 +130,24 @@ To capture the Nix expressions we can do something like:
 let inherit (import ./. {}) sources nixpkgsArgs;
     pkgs = import sources.nixpkgs nixpkgsArgs;
     hlint = pkgs.haskell-nix.hackage-package {
-      compiler-nix-name = "ghc884";
+      compiler-nix-name = "ghc8102";
       name = "hlint";
       version = "2.2.11";
-      index-state = "2020-04-15T00:00:00Z";
-      plan-sha256 = "02hasr27a994sml1fzf8swb716lm6lgixxr53y0gxkhw437xkck4";
+      index-state = "2021-01-04T00:00:00Z";
+      plan-sha256 = "04hdgqwpaswmyb0ili7fwi6czzihd6x0jlvivw52d1i7wv4gaqy7";
       materialized = ./hlint.materialized;
     };
-in hlint.components.exes.hlint
+in hlint
 ```
 
 Now we can copy the Nix files needed and build with:
 
 ```
-$ cp -r /nix/store/8z6p4237rin3c6c1lmjwshmj8rdqrhw2-hlint-plan-to-nix-pkgs hlint.materialized
-$ nix-build hlint.nix
-/nix/store/rnfz66v7k8i38c8rsmchzsyqjrmrbdpk-hlint-2.2.11-exe-hlint
+$ nix-build hlint.nix 2>&1 | grep -om1 '/nix/store/.*-updateMaterialized' | bash
+$ nix-build hlint.nix -A components.exes.hlint
+building '/nix/store/wpxsgzl1z4jnhfqzmzg3xxv3ljpmzr5h-hlint-plan-to-nix-pkgs.drv'...
+/nix/store/2ybrfmcp79gg75ad4pr1cbxjak70yg8b-hlint-exe-hlint-2.2.11
 ```
-
-We may want to run `chmod -R +w hlint.materialized` as the files copied from the
-store will be read only.
 
 ## How can we check `sha256` and `materialized` are up to date?
 
@@ -164,32 +164,29 @@ If we choose to add the `checkMaterialization` flag you would have:
 let inherit (import ./. {}) sources nixpkgsArgs;
     pkgs = import sources.nixpkgs nixpkgsArgs;
     hlint = pkgs.haskell-nix.hackage-package {
-      compiler-nix-name = "ghc884";
+      compiler-nix-name = "ghc8102";
       name = "hlint";
       version = "2.2.10";
-      index-state = "2020-04-15T00:00:00Z";
-      plan-sha256 = "02hasr27a994sml1fzf8swb716lm6lgixxr53y0gxkhw437xkck4";
+      index-state = "2021-01-04T00:00:00Z";
+      plan-sha256 = "04hdgqwpaswmyb0ili7fwi6czzihd6x0jlvivw52d1i7wv4gaqy7";
       materialized = ./hlint.materialized;
       checkMaterialization = true;
     };
-in hlint.components.exes.hlint
+in hlint
 ```
 
 This will fail and report the details of what is wrong and how to fix it:
 
 ```
-$ nix-build hlint.nix
+$ nix-build hlint.nix -A components.exes.hlint
 
 ...
 
-Calculated hash for hlint-plan-to-nix-pkgs was not 02hasr27a994sml1fzf8swb716lm6lgixxr53y0gxkhw437xkck4. New hash is :
-    plan-sha256 = "0zsi3wv92qax33ic4n5dfsqd1r9qam1k75za3c5jqgdxl3hy8vph";
-Materialized nix used for hlint-plan-to-nix-pkgs incorrect. To fix run :
-    rm -rf /Users/hamish/iohk/haskell.nix/hlint.materialized
-    cp -r /nix/store/ywdhbx9rzzkfc60c5vzk7cins2hnvkgx-hlint-plan-to-nix-pkgs /Users/hamish/iohk/haskell.nix/hlint.materialized
-    chmod -R +w /Users/hamish/iohk/haskell.nix/hlint.materialized
-builder for '/nix/store/a5zmgfjfxahapw0q8hd2da5bg7knqvbx-hlint-plan-to-nix-pkgs.drv' failed with exit code 1
-error: build of '/nix/store/a5zmgfjfxahapw0q8hd2da5bg7knqvbx-hlint-plan-to-nix-pkgs.drv' failed
+Calculated hash for hlint-plan-to-nix-pkgs was not 04hdgqwpaswmyb0ili7fwi6czzihd6x0jlvivw52d1i7wv4gaqy7. New hash is :
+    plan-sha256 = "0jsgdmii0a6b35sd42cpbc83s4sp4fbx8slphzvamq8n9x49i5b6";
+Materialized nix used for hlint-plan-to-nix-pkgs incorrect. To fix run: /nix/store/6wp0zzal40ls874f5ddpaac7qmii9y4z-updateMaterialized
+builder for '/nix/store/61a0vginv76w4p9ycyd628pjanav06pl-hlint-plan-to-nix-pkgs.drv' failed with exit code 1
+error: build of '/nix/store/61a0vginv76w4p9ycyd628pjanav06pl-hlint-plan-to-nix-pkgs.drv' failed
 (use '--show-trace' to show detailed location information)
 ```
 
@@ -200,33 +197,17 @@ removing `materialized` and `plan-sha256`.
 
 ## How can we update the Nix files with a script?
 
-There are versions of the functions (`project'`, `cabalProject'`,
-`stackProject'` and `hackage-project`) that also return the nix as
-`plan-nix` or `stack-nix`.  By calling one of these functions without
-the hash and materialized nix we can find out what nix files should be.
-For instance:
+We can simply put the commands we used earlier in a script:
 
 ```nix
-let inherit (import ./. {}) sources nixpkgsArgs;
-    pkgs = import sources.nixpkgs nixpkgsArgs;
-    hlint = pkgs.haskell-nix.hackage-project {
-      compiler-nix-name = "ghc884";
-      name = "hlint";
-      version = "2.2.10";
-      index-state = "2020-04-15T00:00:00Z";
-    };
-in hlint
-```
+#!/bin/sh
 
-```
-$ nix-build hlint.nix -A plan-nix
-trace: Using index-state: 2020-04-15T00:00:00Z for hlint
-trace: Get `plan-sha256` with `nix-hash --base32 --type sha256 /nix/store/ywdhbx9rzzkfc60c5vzk7cins2hnvkgx-hlint-plan-to-nix-pkgs/`
-/nix/store/ywdhbx9rzzkfc60c5vzk7cins2hnvkgx-hlint-plan-to-nix-pkgs
-```
+# Output new plan-sha256
+nix-build hlint.nix -A project.plan-nix.passthru.calculateMaterializedSha | bash
 
-We can have the script copy `$(nix-build hlint.nix -A plan-nix --no-out-link)`
-and use `nix-hash` to calculate the new value for `plan-sha256`.
+# Update materialized Nix expressions
+nix-build hlint.nix 2>&1 | grep -om1 '/nix/store/.*-updateMaterialized' | bash
+```
 
 ## Can we skip making a copy and use `materialized = /nix/store/...`?
 
@@ -247,30 +228,29 @@ a non-existing path is now an error:
 ```nix
 let inherit (import ./. {}) sources nixpkgsArgs;
     pkgs = import sources.nixpkgs nixpkgsArgs;
-    hlintPlan = /nix/store/kk047cqsjvbj4w8psv4l05abdcnyrqdc-hlint-plan-to-nix-pkgs;
+    hlintPlan = /nix/store/63k3f8bvsnag7v36vb3149208jyx61rk-hlint-plan-to-nix-pkgs;
     hlint = pkgs.haskell-nix.hackage-package {
-      compiler-nix-name = "ghc884";
+      compiler-nix-name = "ghc8102";
       name = "hlint";
       version = "2.2.11";
-      index-state = "2020-04-15T00:00:00Z";
-      plan-sha256 = "02hasr27a994sml1fzf8swb716lm6lgixxr53y0gxkhw437xkck4";
+      index-state = "2021-01-04T00:00:00Z";
+      plan-sha256 = "04hdgqwpaswmyb0ili7fwi6czzihd6x0jlvivw52d1i7wv4gaqy7";
       materialized = if __pathExists hlintPlan then hlintPlan else null;
     };
-in hlint.components.exes.hlint
+in hlint
 ```
 
 Running when no building is needed is still slow in restricted evaluation mode.
 
 ```
-$ time nix-build --option restrict-eval true -I . --option allowed-uris "https://github.com/NixOS https://github.com/input-output-hk" hlint.nix --show-trace
-trace: Using index-state: 2020-04-15T00:00:00Z for hlint
-/nix/store/rnfz66v7k8i38c8rsmchzsyqjrmrbdpk-hlint-2.2.11-exe-hlint
+$ time nix-build --option restrict-eval true -I . --option allowed-uris "https://github.com/NixOS https://github.com/input-output-hk" hlint.nix -A components.exes.hlint --show-trace
+/nix/store/2ybrfmcp79gg75ad4pr1cbxjak70yg8b-hlint-exe-hlint-2.2.11
 
 real	0m4.463s
 user	0m4.440s
 sys	0m0.461s
-$ time nix-build hlint.nix
-/nix/store/rnfz66v7k8i38c8rsmchzsyqjrmrbdpk-hlint-2.2.11-exe-hlint
+$ time nix-build hlint.nix -A components.exes.hlint
+/nix/store/2ybrfmcp79gg75ad4pr1cbxjak70yg8b-hlint-exe-hlint-2.2.11
 
 real	0m2.206s
 user	0m1.665s

--- a/docs/tutorials/materialization.md
+++ b/docs/tutorials/materialization.md
@@ -2,7 +2,7 @@
 
 ## What is materialization?
 
-Capturing and storing the nix files for a project so that they do
+Capturing and storing the Nix files for a project so that they do
 not need to be built (or checked).  This allows us to cache the input
 of an IFD (import from derivation).
 
@@ -16,26 +16,28 @@ dependencies of nix-tools for instance).
   is not unusual for it to take 5 seconds per project).
 
 * They can be slow to build (or download) on machines that do not
-  yet have them in the nix store.
+  yet have them in the Nix store.
 
-* Hydra does not show progress because it does not provide feedback
-  until it has a list of jobs and the list of jobs cannot depends
-  on the nix being present (although this is often blamed on IFD
-  it would be the same if it wrote out JSON files and read them in)
+* Hydra does not show progress because it does not provide feedback until it
+  has a list of jobs and the list of jobs cannot depend on the Nix expressions
+  being present (although this is often blamed on IFD it would be the same if
+  it wrote out JSON files and read them in)
 
-## When is it ok to materialize?
+## When is it OK to materialize?
 
-* The nix is unlikely to change frequently (and when it does you
+* The Nix expressions are unlikely to change frequently (and when it does you
   are happy to manually update it).
 
-* You are happy to script something to update the materialized
-  nix files automatically.
-* You are certain that the IFD you materialize is not `system`-dependent. If it was you'd
-   obtain different nix expressions depending on which `system` the IFD was evaluated.
+* You are happy to script something to update the materialized Nix files
+  automatically.
 
-## How can we materialize the nix files?
+* You are certain that the IFD you materialize is not `system`-dependent. If it
+  was you'd obtain different Nix expressions depending on which `system` the
+  IFD was evaluated.
 
-Lets say we want to build `hlint`.  We might start with an `hlint`
+## How can we materialize the Nix files?
+
+Lets say we want to build `hlint`.  We might start with an `hlint.nix`
 file that looks like this:
 
 ```nix
@@ -105,13 +107,13 @@ let inherit (import ./. {}) sources nixpkgsArgs;
 in hlint.components.exes.hlint
 ```
 
-Just adding the hash might help reuse of the cached nix, but nix will
-still calculate all the dependencies (which can add seconds to
-`nix-build` and `nix-shell` commands when no other work is needed)
-and users who do not yet have the dependencies in their store will have
-to wait while they are built or downloaded.
+Just adding the hash might help reuse of the cached Nix expressions, but Nix
+will still calculate all the dependencies (which can add seconds to `nix-build`
+and `nix-shell` commands when no other work is needed) and users who do not yet
+have the dependencies in their store will have to wait while they are built or
+downloaded.
 
-Running nix build again gives us a hint on what we can do next:
+Running `nix-build` again gives us a hint on what we can do next:
 
 ```
 $ nix-build hlint.nix
@@ -120,7 +122,7 @@ trace: To materialize, point `materialized` to a copy of /nix/store/kk047cqsjvbj
 /nix/store/rnfz66v7k8i38c8rsmchzsyqjrmrbdpk-hlint-2.2.11-exe-hlint
 ```
 
-To capture the nix we can do something like:
+To capture the Nix expressions we can do something like:
 
 ```nix
 let inherit (import ./. {}) sources nixpkgsArgs;
@@ -136,7 +138,7 @@ let inherit (import ./. {}) sources nixpkgsArgs;
 in hlint.components.exes.hlint
 ```
 
-Now we can copy the nix files needed and build with:
+Now we can copy the Nix files needed and build with:
 
 ```
 $ cp -r /nix/store/8z6p4237rin3c6c1lmjwshmj8rdqrhw2-hlint-plan-to-nix-pkgs hlint.materialized
@@ -153,6 +155,7 @@ Let's pretend we had to go back to `hlint` version `2.2.10`.
 We can tell haskell.nix to check the materialization either by:
 
 * Removing the materialization files with `rm -rf hlint.materialized`
+
 * Temporarily adding `checkMaterialization = true;`
 
 If we choose to add the `checkMaterialization` flag you would have:
@@ -190,11 +193,12 @@ error: build of '/nix/store/a5zmgfjfxahapw0q8hd2da5bg7knqvbx-hlint-plan-to-nix-p
 (use '--show-trace' to show detailed location information)
 ```
 
-Checking the materialization requires nix to do all the work that materialization
-avoids.  So while it might be tempting to leave `checkMaterialization = true` all
-the time, we would be better off just removing `materialized` and `plan-sha256`.
+Checking the materialization requires Nix to do all the work that
+materialization avoids.  So while it might be tempting to leave
+`checkMaterialization = true` all the time, we would be better off just
+removing `materialized` and `plan-sha256`.
 
-## How can we update the nix files with a script?
+## How can we update the Nix files with a script?
 
 There are versions of the functions (`project'`, `cabalProject'`,
 `stackProject'` and `hackage-project`) that also return the nix as
@@ -231,7 +235,7 @@ Yes and it gives us the same speed improvement, however:
 * It does not help at all in `restricted-eval` mode (Hydra).
 
 * Users will still wind up building or downloading the dependencies
-  needed to build the nix files (if they do not have them).
+  needed to build the Nix files (if they do not have them).
 
 For those reasons it might be best to make a copy instead
 of using the `/nix/store/...` path directly.


### PR DESCRIPTION
The examples had aged to the point where they could no longer
be followed.

I've tried to make them as easy as possible to follow. Simply copying and pasting the commands should work (modulo changing things like plan-nix to stack-nix and the component name).

I used piping to bash because the Fish shell is fairly popular and doesn't allow command substitutions (and the syntax would differ even if it did).
I'm all ears for neater alternatives : )