### PR TITLE
Fix filtering package in root of project

### DIFF
--- a/lib/clean-cabal-component.nix
+++ b/lib/clean-cabal-component.nix
@@ -37,9 +37,16 @@ let
       then "/"
       else ""
     ) + normalizeRelativePath path;
-  combinePaths = a: b: if isAbsolutePath b
-    then b
-    else normalizePath (a + "/" + b);
+  combinePaths = a: b:
+    if isAbsolutePath b
+      then b
+    else normalizePath (
+      if a == ""
+        then b
+      else if b == ""
+        then a
+      else a + "/" + b
+    );
   # Like normalizePath but with a trailing / when needed
   normalizeDir = dir:
     let p = normalizePath dir;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -315,16 +315,16 @@ in {
     subDir = src.origSubDir or "";
     root =
       if subDir == ""
-        then src
+        then src # if there was no subdir use the original src
         else
           # Use `cleanSourceWith` to make sure the `filter` is still used
-          if src ? origSrc && src ? filter && subDir != ""
+          if src ? origSrc && src ? filter
             then haskellLib.cleanSourceWith {
               name = src.name or "source" + "-root";
               src = src.origSrc;
               # Not passing src.origSubDir so that the result points `origSrc`
               inherit (src) filter;
             }
-            else src.origSrc or src;
+            else src.origSrc or src;  # If there is a subDir and origSrc (but no filter) use origSrc
   };
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -314,14 +314,17 @@ in {
   rootAndSubDir = src: rec {
     subDir = src.origSubDir or "";
     root =
-      # Use `cleanSourceWith` to make sure the `filter` is still used
-      if src ? origSrc && src ? filter && subDir != ""
-        then haskellLib.cleanSourceWith {
-          name = src.name or "source" + "-root";
-          src = src.origSrc;
-          # Not passing src.origSubDir so that the result points `origSrc`
-          inherit (src) filter;
-        }
-        else src.origSrc or src;
+      if subDir == ""
+        then src
+        else
+          # Use `cleanSourceWith` to make sure the `filter` is still used
+          if src ? origSrc && src ? filter && subDir != ""
+            then haskellLib.cleanSourceWith {
+              name = src.name or "source" + "-root";
+              src = src.origSrc;
+              # Not passing src.origSubDir so that the result points `origSrc`
+              inherit (src) filter;
+            }
+            else src.origSrc or src;
   };
 }


### PR DESCRIPTION
When a package is not in a subdirectory, but instead
in the root of the project the cleaning of the package
source was broken.

This might explain why some `cabal.project` file
based projects might also see be affected by #1013.