### PR TITLE
Disable benchmarks and tests for tools

### DIFF
--- a/overlays/hackage-quirks.nix
+++ b/overlays/hackage-quirks.nix
@@ -71,7 +71,6 @@ in { haskell-nix = prev.haskell-nix // {
         allow-newer: haskell-language-server:ghcide
         constraints: ghcide <0.7.4
       '';
-      configureArgs = "--disable-benchmarks --disable-tests";
     };
 
   }."${name}" or {};

--- a/overlays/tools.nix
+++ b/overlays/tools.nix
@@ -62,7 +62,10 @@ in { haskell-nix = prev.haskell-nix // {
       args = { caller = "hackage-tool"; } // args';
     in
       (final.haskell-nix.hackage-package
-        (args // { name = final.haskell-nix.toolPackageName.${name} or name; }))
+        ( # Disable benchmarks and tests by default (since we only want the exe component)
+          { configureArgs = "--disable-benchmarks --disable-tests"; }
+          // args
+          // { name = final.haskell-nix.toolPackageName.${name} or name; }))
           .components.exes."${final.haskell-nix.packageToolName.${name} or name}";
 
   tool = compiler-nix-name: name: versionOrArgs:


### PR DESCRIPTION
By default haskell.nix cabalProject functions run cabal
configure with --enable-tests and --enable-benchmarks.
This is good when you are working on a project as
it means your tests and benchmarks are in the
package `components`.

The `tools` functions (and `shellFor` `tools` arg)
return `components.exes.${toolName}` and while
it is possible to access the other components
via the `project` and `package` properties of
tool component.

In some cases the benchmarks and tests can
have problematic constraints that cause
problems building other components.

Disabling the tests and benchmarks by default
when building `tools` should reduce the these
issues.