### PR TITLE
default.nix: Add configOverride argument

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,10 @@
 { checkMaterialization ? false  # Allows us to easily switch on materialization checking
+, configOverride ? {}
 , system ? builtins.currentSystem
 , sourcesOverride ? {}
 , ... }@args: rec {
   sources  = (import ./nix/sources.nix) // sourcesOverride;
-  config   = import ./config.nix;
+  config   = (import ./config.nix) // configOverride;
   overlays = [ allOverlays.combined ] ++ (
     if checkMaterialization == true
       then [(


### PR DESCRIPTION
This should make it easier to provide a custom config argument.
Previously to allow unfree hackage packages you had to do the following:

```
nixpkgs = import haskell-nix.sources.nixpkgs
                 ( haskell-nix.nixpkgsArgs
                   // { config = haskell-nix.nixpkgsArgs.config
                                 // { allowUnfree = true; };
                      }
                 );
```

Now you can simply provide `{ allowUnfree = true; }` as the
`configOverride` argument when importing haskell.nix.

# Motivation

Recently a user came to #haskell.nix asking how to allow unfree packages. While most packages on hackage have a free license, some have no license specified or were migrated from cabal's old license identifiers to "LicenseRef-..." SPDX identifiers. A package that used to have license identifier "LGPL" and has been migrated to the SPDX identifiers automatically without being revised since is deemed unfree by haskell.nix. This is the proper behavior because the meaning of a "LicenseRef-..." identifier is entirely arbitrary and up to the user.

As you can see above the incantation to pass config to the haskell.nix "nixpkgs" isn't very intuitive. This PR is only a suggestion of how to provide a more convenient UX in this. I'm not sure adding an argument that'll get merged in the right places later is very robust but I don't know of a better way so I wanted to start a discussion on how this can be improved.