### PR TITLE
Fix nixpkgs version

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -49,7 +49,7 @@ Add `default.nix`:
 # haskell.nix provides access to the nixpkgs pins which are used by our CI,
 # hence you will be more likely to get cache hits when using these.
 # But you can also just use your own, e.g. '<nixpkgs>'.
-, nixpkgsSrc ? haskellNix.sources.nixpkgs-2003
+, nixpkgsSrc ? haskellNix.sources.nixpkgs-2009
 
 # haskell.nix provides some arguments to be passed to nixpkgs, including some
 # patches and also the haskell.nix functionality itself as an overlay.


### PR DESCRIPTION
Following the getting started guide would rebuild ghc because of the old nixpkgs version.