### PR TITLE
Add Hix wrappers for Nix tools

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -26,4 +26,5 @@
   nixpkgsArgs = { inherit config overlays system; };
   pkgs = import sources.nixpkgs nixpkgsArgs;
   pkgs-unstable = import sources.nixpkgs-unstable nixpkgsArgs;
+  hix = import ./hix/default.nix;
 }

--- a/docs/dev/hix.md
+++ b/docs/dev/hix.md
@@ -1,0 +1,27 @@
+# Making changes to Hix
+
+When making changes to the way Hix works it is often useful to be able to
+test the changes locally before uploading them to github.
+
+## Hix Command Wrappers
+
+Install the hix command wrappers after making changes to a local clone of haskell.nix:
+
+```
+nix-env -iA hix -f /path/to/local/haskell.nix
+hix-shell
+```
+
+Or override the version of haskell.nix used by the commands with the `HIX_ROOT` environment variable:
+
+```
+HIX_ROOT=/path/to/local/haskell.nix hix-shell
+```
+
+## Flakes
+
+For flakes use `--override-input` to point to the modified haskell.nix:
+
+```
+nix develop --override-input haskellNix /path/to/local/haskell.nix
+```

--- a/docs/tutorials/getting-started-hix.md
+++ b/docs/tutorials/getting-started-hix.md
@@ -1,0 +1,210 @@
+# Getting started with Hix
+
+The `hix` tools are wrappers for the various `nix` tools that
+use `haskell.nix` without the need to add any `.nix` files.
+
+This is useful for:
+
+* A quick way to try out haskell.nix for new users.
+
+* Using haskell.nix to work on projects that do not have
+  `.nix` files.
+
+* Testing to see if `haskell.nix` can build a project.
+
+* Making `flake` and `non flake` configurations to check `haskell.nix`
+  treats them the same.
+
+## Installing Nix
+
+To use Hix you will need to install [Nix](https://nixos.org/download.html).
+
+## Setting up the binary cache
+
+IMPORTANT: you *must* do this or you *will* build several copies of GHC!
+
+You can configure Nix to use our binary cache, which is pushed to by CI, so should contain the artifacts that you need.
+
+You need to add the following sections to `/etc/nix/nix.conf` or, if you are a trusted user, `~/.config/nix/nix.conf` (if you don't know what a "trusted user" is, you probably want to do the former).
+
+```
+trusted-public-keys = [...] hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= [...]
+substituters = [...] https://hydra.iohk.io [...]
+```
+
+This can be tricky to get setup properly. If you're still having trouble getting cache hits, consult the corresponding [troubleshooting section](../reference/troubleshooting#why-am-i-building-ghc).
+
+## Installing Hix
+
+
+Until [this](https://github.com/input-output-hk/haskell.nix/pull/1053) is merged use:
+```
+nix-env -iA hix -f https://github.com/input-output-hk/haskell.nix/tarball/hkm/hix
+```
+
+TODO once merged replace the above with:
+```
+nix-env -iA hix -f https://github.com/input-output-hk/haskell.nix/tarball/master
+```
+
+## Updating Hix (also updates hackage)
+
+```
+hix update
+```
+
+This is also necessary to make the latest nightly snapshot of hackage
+avaiable to nix.
+
+## Building with Hix
+
+To run `cabal build` in a nix-shell with all the dependencies required:
+
+```
+cabal unpack hello
+cd hello-1.0.0.2
+hix-shell --run 'cabal build'
+```
+
+Build with nix:
+
+```
+hix-build -A hsPkgs.hello.components.exes.hello
+```
+
+Cross compile to JavaScript:
+
+```
+hix-build -A projectCross.ghcjs.hsPkgs.hello.components.exes.hello
+```
+
+## Configuring Hix
+
+The configuration arguments for `Hix` can be (from highest precedence to lowest):
+
+* Passed on the command line with `--arg` (or `--argstr` for string args).
+
+* Placed in `nix/hix.nix` file in the project dir.
+
+* Placed in `~/.config/hix/hix.conf`
+
+For example to build with GHC 8.10.5:
+
+```
+hix-shell --argstr compiler-nix-name ghc8105 --run 'cabal build'
+```
+
+or add a `nix/hix.nix` or `~/.config/hix/hix.conf` file:
+
+```nix
+{ compiler-nix-name = "ghc8105"; }
+```
+
+Here are just a few of the other configuration arguments you could use
+in the files or on the command line (they are all optional):
+
+```nix
+{ name = "hello";                    # for better error messages and derivation names
+  nixpkgsPin = "nixpkgs-unstable";   # or nixpkgs-2009 or nixpkgs-2003
+  nixpkgs = <nixpkgs>;               # use this instead of nixpkgsPin
+  subDir = "some/sub/dir";           # sub dir containing the haskell project
+  projectFileName = "stack.yaml";    # use this project file
+  tools.haskell-language-server = "latest";
+  tools.hlint = "latest";            # Include the latest hls and hlint in the shell
+  index-state = "2021-02-22T00:00:00Z"; # It is normally best to put this in `cabal.project` (not here)
+
+# PLUS MANY MORE!  Almost any argument you can pass to the project functions
+# or to `shellFor` can be used in as a Hix configuration argument.
+
+}
+```
+
+## Adding Nix Support with Niv
+
+If you have a `nix/hix.nix` file with suitable configuration that
+you want to make available to users with Nix (without having to
+install Hix).
+
+[Niv](https://github.com/nmattia/niv) is a command line tool for keeping tack of Nix project dependencies.
+
+After installing niv you can initialize niv and pin the latest haskell.nix
+commit by running the following in the root directory of the project:
+
+```
+niv init
+niv add input-output-hk/haskell.nix -n haskellNix
+```
+
+Add `default.nix`:
+
+```nix
+(import (import nix/sources.nix).haskellNix {}).hix.project { src = ./.; }
+```
+
+If you want to also pin `nixpkgs` with Niv use:
+
+```nix
+let
+  sources = import nix/sources.nix;
+in
+  (import sources.haskellNix {}).hix.project {
+    inherit (sources) nixpkgs;
+    src = ./.;
+  }
+```
+
+Add `shell.nix`:
+
+```nix
+(import ./.).shell
+```
+
+When you want to update to the latest version of haskell.nix use:
+
+```
+niv update haskellNix
+```
+
+## Adding Nix Flake Support
+
+To add flake support that uses the `nix/hix.nix` configuration in your
+follow the [Getting started with flakes](getting-started.md) guide, but
+use `haskell-nix.hix.project` instead of `haskell-nix.project'`
+
+The `nixpkgs` used will need to be selected as a flake input (any selection
+made in `nix/hix.nix` will be ignored).
+
+Example `flake.nix` file:
+
+```nix
+{
+  description = "A very basic flake";
+  inputs.haskellNix.url = "github:input-output-hk/haskell.nix";
+  inputs.nixpkgs.follows = "haskellNix/nixpkgs-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  outputs = { self, nixpkgs, flake-utils, haskellNix }:
+    flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" ] (system:
+    let
+      overlays = [ haskellNix.overlay
+        (final: prev: {
+          # This overlay adds our project to pkgs
+          helloProject =
+            final.haskell-nix.hix.project {
+              src = ./.;
+              # Other project options can be put in `nix/hix.nix`
+            };
+        })
+      ];
+      pkgs = import nixpkgs { inherit system overlays; };
+      flake = pkgs.helloProject.flake {
+        # This adds support for `nix build .#js-unknown-ghcjs:hello:exe:hello`
+        crossPlatforms = p: [p.ghcjs];
+      };
+    in flake // {
+      # Built by `nix build .`
+      defaultPackage = flake.packages."hello:exe:hello";
+    });
+}
+```
+
+

--- a/docs/tutorials/getting-started-hix.md
+++ b/docs/tutorials/getting-started-hix.md
@@ -36,13 +36,6 @@ This can be tricky to get setup properly. If you're still having trouble getting
 
 ## Installing Hix
 
-
-Until [this](https://github.com/input-output-hk/haskell.nix/pull/1053) is merged use:
-```
-nix-env -iA hix -f https://github.com/input-output-hk/haskell.nix/tarball/hkm/hix
-```
-
-TODO once merged replace the above with:
 ```
 nix-env -iA hix -f https://github.com/input-output-hk/haskell.nix/tarball/master
 ```

--- a/hix/default.nix
+++ b/hix/default.nix
@@ -1,0 +1,44 @@
+let
+  sources = import (../nix/sources.nix) {};
+  nixpkgs = import sources.nixpkgs-2009 {};
+  args = '' --arg userDefaults "$HOME/.config/hix/hix.conf" --arg src ./.'';
+  # Use HIX_ROOT to override the version of hix used when developing new hix features.
+  # See docs/dev/hix.md for details.
+  hixProject = "\${HIX_ROOT:-${./..}}/hix/project.nix";
+in nixpkgs.symlinkJoin {
+  name = "hix";
+  paths = [
+    (nixpkgs.writeScriptBin "hix-shell" ''
+      nix-shell ${hixProject} ${args} -A shell "$@"
+    '')
+    (nixpkgs.writeScriptBin "hix-build" ''
+      nix-build ${hixProject} ${args} "$@"
+    '')
+    (nixpkgs.writeScriptBin "hix-instantiate" ''
+      nix-instantiate ${hixProject} ${args} "$@"
+    '')
+    (nixpkgs.writeScriptBin "hix-env" ''
+      nix-env -f ${hixProject} ${args} "$@"
+    '')
+    (nixpkgs.writeScriptBin "hix" ''
+      cmd=$1
+      shift
+      case $cmd in
+      update)
+        nix-env -iA hix -f https://github.com/input-output-hk/haskell.nix/tarball/master
+        ;;
+      build|dump-path|eval|log|path-info|run|search|show-derivation|sign-paths|verify|why-depends)
+        nix $cmd -f ${hixProject} ${args} "$@"
+        ;;
+      repl)
+        nix $cmd ${hixProject} ${args} "$@"
+        ;;
+      *)
+        nix $cmd "$@"
+        ;;
+      esac
+    '')
+  ];
+} // {
+  project = import ./project.nix; 
+}

--- a/hix/project.nix
+++ b/hix/project.nix
@@ -1,0 +1,77 @@
+{ src
+, userDefaults ? {}
+, nxipkgs ? null
+, nixpkgsPin ? null
+, pkgs ? null
+, checkMaterialization ? null
+, compiler-nix-name ? null
+, shell ? null
+, ...}@commandArgs:
+let
+  inherit ((lib.evalModules {
+    modules = [
+      (import ../modules/project-common.nix)
+      (import ../modules/stack-project.nix)
+      (import ../modules/cabal-project.nix)
+      (import ../modules/project.nix)
+      (import ../modules/hix-project.nix)
+      projectDefaults
+      commandArgs'
+      { _module.args.pkgs = {}; }
+    ];
+  }).config) name;
+  sources = import ../nix/sources.nix {};
+  lib = import (sources.nixpkgs-unstable + "/lib");
+  commandArgs' =
+    builtins.listToAttrs (
+      builtins.concatMap (
+        name:
+          if commandArgs.${name} == null || name == "src" || name == "userDefaults" || name == "inNixShell"
+            then []
+            else [{ inherit name; value = commandArgs.${name}; }]
+    ) (builtins.attrNames commandArgs));
+  defaultArgs = {
+    nixpkgsPin = "nixpkgs-unstable";
+  };
+  importDefaults = src:
+    if src == null || !(__pathExists src)
+      then {}
+      else import src;
+  userDefaults = importDefaults (commandArgs.userDefaults or null);
+  projectDefaults = importDefaults (toString (src.origSrcSubDir or src) + "/nix/hix.nix");
+  inherit ((lib.evalModules {
+    modules = [
+      (import ../modules/project-common.nix)
+      (import ../modules/stack-project.nix)
+      (import ../modules/cabal-project.nix)
+      (import ../modules/project.nix)
+      (import ../modules/hix-project.nix)
+      userDefaults
+      projectDefaults
+      commandArgs'
+      ({config, pkgs, ...}: {
+        haskellNix = import ./.. { inherit checkMaterialization; };
+        nixpkgsPin = "nixpkgs-unstable";
+        nixpkgs = config.haskellNix.sources.${config.nixpkgsPin};
+        nixpkgsArgs = config.haskellNix.nixpkgsArgs // {
+          overlays = config.haskellNix.nixpkgsArgs.overlays ++ config.overlays;
+        };
+        pkgs = import config.nixpkgs config.nixpkgsArgs;
+        project = config.pkgs.haskell-nix.project [
+            (import ../modules/hix-project.nix)
+            userDefaults
+            projectDefaults
+            commandArgs'
+            {
+              src =
+                if __pathExists (toString (src.origSrcSubDir or src) + "/.git")
+                  then config.pkgs.haskell-nix.haskellLib.cleanGit {
+                    inherit src name;
+                  }
+                  else src;
+            }
+          ];
+      })
+    ];
+  }).config) project shell;
+in project

--- a/modules/hix-project.nix
+++ b/modules/hix-project.nix
@@ -1,0 +1,40 @@
+{ lib, ... }: {
+  _file = "haskell.nix/modules/hix-project.nix";
+  options = {
+    # These are options that only the Hix command wrappers use. If you make a flake
+    # with `haskell-nix.hix.project`, then they are ignored.
+    haskellNix = lib.mkOption {
+      type = lib.types.unspecified;
+      default = null;
+    };
+    nixpkgsPin = lib.mkOption {
+      type = lib.types.str;
+      default = "nixpkgs-unstable";
+    };
+    nixpkgs = lib.mkOption {
+      type = lib.types.unspecified;
+      default = null;
+    };
+    nixpkgsArgs = lib.mkOption {
+      type = lib.types.unspecified;
+      default = null;
+    };
+    overlays = lib.mkOption {
+      type = lib.types.unspecified;
+      default = [];
+    };
+    pkgs = lib.mkOption {
+      type = lib.types.unspecified;
+      default = null;
+    };
+    project = lib.mkOption {
+      type = lib.types.unspecified;
+      default = null;
+    };
+  };
+
+  # Default values for other project options (things that do not have defaults for non hix projects)
+  config = {
+    compiler-nix-name = lib.mkDefault "ghc8105";
+  };
+}

--- a/modules/hix-project.nix
+++ b/modules/hix-project.nix
@@ -6,30 +6,37 @@
     haskellNix = lib.mkOption {
       type = lib.types.unspecified;
       default = null;
+      description = "Imported haskell.nix itself (this will be set by `hix`)";
     };
     nixpkgsPin = lib.mkOption {
       type = lib.types.str;
       default = "nixpkgs-unstable";
+      description = "The name of a haskell.nix nixpkgs pin to use (e.g. nixpkgs-unstable or nixpkgs-2009)";
     };
     nixpkgs = lib.mkOption {
-      type = lib.types.unspecified;
+      type = lib.types.nullOr lib.types.path;
       default = null;
+      description = "Path to the nixpkgs files to use (uses nixpkgsPin by default)";
     };
     nixpkgsArgs = lib.mkOption {
       type = lib.types.unspecified;
       default = null;
+      description = "Path to the nixpkgs files to use (this will be set by `hix`)";
     };
     overlays = lib.mkOption {
       type = lib.types.unspecified;
       default = [];
+      description = "Extra overlays to use (in addition to those haskell.nix includes)";
     };
     pkgs = lib.mkOption {
       type = lib.types.unspecified;
       default = null;
+      description = "The pkgs (this will be set by `hix`)";
     };
     project = lib.mkOption {
       type = lib.types.unspecified;
       default = null;
+      description = "The project (this will be set by `hix`)";
     };
   };
 

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -18,6 +18,7 @@ let
     emscripten = import ./emscripten.nix;
     nix-prefetch-git-minimal = import ./nix-prefetch-git-minimal.nix;
     gobject-introspection = import ./gobject-introspection.nix;
+    hix = import ./hix.nix;
     eval-on-current = import ./eval-on-current.nix;
     eval-on-build = import ./eval-on-build.nix;
     ghcjs = import ./ghcjs.nix;
@@ -52,6 +53,7 @@ let
     nix-prefetch-git-minimal
     ghcjs
     gobject-introspection
+    hix
     # Restore nixpkgs haskell and haskellPackages
     (_: prev: { inherit (prev.haskell-nix-prev) haskell haskellPackages; })
   ];

--- a/overlays/hix.nix
+++ b/overlays/hix.nix
@@ -1,0 +1,51 @@
+final: prev: { haskell-nix = prev.haskell-nix // { hix = {
+  project =
+    { src
+    , userDefaults ? {}
+    , subDir ? null
+    , name ? null
+    , compiler-nix-name ? null
+    , shell ? null
+    , ...}@commandArgs:
+    let
+      inherit (final) lib;
+      hixDefaults = { compiler-nix-name = lib.mkDefault "ghc8105"; };
+      inherit ((lib.evalModules {
+        modules = [
+          (import ../modules/project-common.nix)
+          (import ../modules/stack-project.nix)
+          (import ../modules/cabal-project.nix)
+          (import ../modules/project.nix)
+          (import ../modules/hix-project.nix)
+          projectDefaults
+          commandArgs'
+          { _module.args.pkgs = {}; }
+        ];
+      }).config) name;
+      commandArgs' =
+        builtins.listToAttrs (
+          builtins.concatMap (
+            name:
+              if commandArgs.${name} == null || name == "src" || name == "userDefaults"
+                then []
+                else [{ inherit name; value = commandArgs.${name}; }]
+        ) (builtins.attrNames commandArgs));
+      importDefaults = src:
+        if src == null || !(__pathExists src)
+          then {}
+          else import src;
+      projectDefaults = importDefaults (toString (src.origSrcSubDir or src) + "/nix/hix.nix");
+    in final.haskell-nix.project [
+            (import ../modules/hix-project.nix)
+            projectDefaults
+            commandArgs'
+            {
+              src =
+                if __pathExists (toString (src.origSrcSubDir or src) + "/.git")
+                  then final.haskell-nix.haskellLib.cleanGit {
+                    inherit src name;
+                  }
+                  else src;
+            }
+          ];
+}; }; }


### PR DESCRIPTION
The `hix` tools are wrappers for the various `nix` tools that
use `haskell.nix` without the need to add any `.nix` files.

This is useful for:

* A quick way to try out haskell.nix for new users.

* Using haskell.nix to work on projects that do not have
  `.nix` files.

* Testing to see if `haskell.nix` can build a project.

* Making `flake` and `non flake` configurations to check `haskell.nix`
  treats them the same.

The configuration arguments for `Hix` can be (from highest precedence to lowest):

* Passed on the command line with `--arg` (or `--argstr` for string args).

* Placed in `nix/hix.nix` file in the project dir.

* Placed in `~/.config/hix/hix.conf`

Boilerplate `default.nix`, `shell.nix` and `flake.nix` files can be added to a
a project with a `nix/hix.nix` file to make it work with the standard `Nix`
tools.