### PR TITLE
Fix for postgresql-libpg and musl (fixes #948)

### DIFF
--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -115,6 +115,7 @@ pkgs:
     "png"                                = [ pkgs."libpng" ];
     "poppler-glib"                       = [ pkgs."poppler" ];
     "pq"                                 = [ pkgs."postgresql" ];
+    "libpq"                              = [ pkgs."postgresql" ];
     "pthread"                            = [];
     "pulse"                              = [ pkgs."libpulseaudio" ];
     "pulse-simple"                       = [ pkgs."libpulseaudio" ];

--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -21,7 +21,6 @@ pkgs:
     "cairo-ps"                           = [ pkgs."cairo" ];
     "cairo-svg"                          = [ pkgs."cairo" ];
     "crypt"                              = []; # provided by glibc
-    "crypto"                             = [ pkgs."openssl" ];
     "curses"                             = [ pkgs."ncurses" ];
     "dbusmenu-glib-0.4"                  = [ pkgs."libdbusmenu" ];
     "dbusmenu-gtk3-0.4"                  = [ pkgs."libdbusmenu-gtk3" ]; # do we also need pkgs."gtk3"
@@ -80,6 +79,7 @@ pkgs:
     "lber"                               = [ pkgs."openldap" ];
     "ldap"                               = [ pkgs."openldap" ];
     "libavutil"                          = [ pkgs."ffmpeg" ];
+    "libcrypto"                          = [ pkgs."openssl".dev ];
     "libgsasl"                           = [ pkgs."gsasl" ];
     "libpcre"                            = [ pkgs."pcre" ];
     "libqrencode"                        = [ pkgs."qrencode" ];
@@ -88,6 +88,7 @@ pkgs:
     "libsecp256k1"                       = [ pkgs."secp256k1" ];
     "libsoup-2.4"                        = [ pkgs."libsoup" ];
     "libsoup-gnome-2.4"                  = [ pkgs."libsoup" ];
+    "libssl"                             = [ pkgs."openssl".dev ];
     "libsystemd"                         = [ pkgs."systemd" ];
     "libudev"                            = [ pkgs."systemd" ];
     "libusb-1.0"                         = [ pkgs."libusb1" ];
@@ -137,7 +138,6 @@ pkgs:
     "sodium"                             = [ pkgs."libsodium" ];
     "sqlite3"                            = [ pkgs."sqlite" ];
     "ssh2"                               = [ pkgs."libssh2" ];
-    "ssl"                                = [ pkgs."openssl" ];
     "statgrab"                           = [ pkgs."libstatgrab" ];
     "stdc++"                             = []; # What is that?
     "stdc++.dll"                         = []; # What is that?

--- a/overlays/hackage-quirks.nix
+++ b/overlays/hackage-quirks.nix
@@ -82,6 +82,7 @@ in { haskell-nix = prev.haskell-nix // {
       '';
       modules = [(
        {pkgs, ...}: final.lib.mkIf pkgs.stdenv.hostPlatform.isMusl {
+         # The order of -lssl and -lcrypto is important here
          packages.postgrest.configureFlags = [
            "--ghc-option=-optl=-lssl"
            "--ghc-option=-optl=-lcrypto"

--- a/overlays/hackage-quirks.nix
+++ b/overlays/hackage-quirks.nix
@@ -80,6 +80,14 @@ in { haskell-nix = prev.haskell-nix // {
         package postgresql-libpq
           flags: +use-pkg-config
       '';
+      modules = [(
+       {pkgs, ...}: final.lib.mkIf pkgs.stdenv.hostPlatform.isMusl {
+         packages.postgrest.configureFlags = [
+           "--ghc-option=-optl=-lssl"
+           "--ghc-option=-optl=-lcrypto"
+           "--ghc-option=-optl=-L${pkgs.openssl.out}/lib"
+         ];
+      })];
     };
 
   }."${name}" or {};

--- a/overlays/hackage-quirks.nix
+++ b/overlays/hackage-quirks.nix
@@ -73,6 +73,15 @@ in { haskell-nix = prev.haskell-nix // {
       '';
     };
 
+    # See https://github.com/input-output-hk/haskell.nix/issues/948
+    postgrest = {
+      cabalProject = ''
+        packages: .
+        package postgresql-libpq
+          flags: +use-pkg-config
+      '';
+    };
+
   }."${name}" or {};
 
 }; }

--- a/overlays/musl.nix
+++ b/overlays/musl.nix
@@ -16,7 +16,9 @@ final: prev: prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl ({
   numactl = prev.numactl.overrideAttrs (_: { configureFlags = "--enable-static"; });
 
   # See https://github.com/input-output-hk/haskell.nix/issues/948
-  postgresql = prev.postgresql.override { enableSystemd = false; };
+  postgresql = (prev.postgresql.overrideAttrs (old: { dontDisableStatic = true; }))
+    .override { enableSystemd = false; };
+  openssl = prev.openssl.override { static = true; };
 
   # Fails on cross compile
   nix = prev.nix.overrideAttrs (_: { doInstallCheck = false; });

--- a/overlays/musl.nix
+++ b/overlays/musl.nix
@@ -15,6 +15,9 @@ final: prev: prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl ({
 
   numactl = prev.numactl.overrideAttrs (_: { configureFlags = "--enable-static"; });
 
+  # See https://github.com/input-output-hk/haskell.nix/issues/948
+  postgresql = prev.postgresql.override { enableSystemd = false; };
+
   # Fails on cross compile
   nix = prev.nix.overrideAttrs (_: { doInstallCheck = false; });
 } // prev.lib.optionalAttrs (prev.lib.versionAtLeast prev.lib.trivial.release "20.03") {


### PR DESCRIPTION
This combined with setting the `use-pkg-config` flag on `postgresql-libpq` should get it compiling.  There is still a problem with `openssl` that requires a `module` to fix the linking of executables.

Add the following to the `cabal.project` file or to `cabalProjectLocal`:

```
package postgresql-libpq
  flags: +use-pkg-config
```

Include a module like this one to include `openssl` in the linker arguments:

```nix
{
  modules = [(
   {pkgs, ...}: final.lib.mkIf pkgs.stdenv.hostPlatform.isMusl {
     # The order of -lssl and -lcrypto is important here
     packages.postgrest.configureFlags = [
       "--ghc-option=-optl=-lssl"
       "--ghc-option=-optl=-lcrypto"
       "--ghc-option=-optl=-L${pkgs.openssl.out}/lib"
     ];
  })];
}
```

This PR also adds a "hackage quirk" for `postgrest`  to that makes these changes for `postgrest` automatically when built it as a `tool` or with `hackage-package`.

Unfortunately we do not have a good way to avoid the need make these changes.