### PR TITLE
Remove remaining hls hackage workaround

### DIFF
--- a/overlays/hackage-quirks.nix
+++ b/overlays/hackage-quirks.nix
@@ -68,15 +68,6 @@ in { haskell-nix = prev.haskell-nix // {
       ];
     };
 
-    haskell-language-server = {
-      # This is still needed for HLS 0.9.0.0 because ghcide 0.7.3 has no upper
-      # bound for haddock-library. 
-      cabalProject = ''
-        packages: .
-        constraints: haddock-library <1.10
-      '';
-    };
-
     # See https://github.com/input-output-hk/haskell.nix/issues/948
     postgrest = {
       cabalProject = ''


### PR DESCRIPTION
This is now fixed in hackage (see https://github.com/haskell/haskell-language-server/issues/1525)