### PR TITLE
Non deterministic failures should not be deferred

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -528,6 +528,12 @@ let
     # move pkgs.nix to default.nix ensure we can just nix `import` the result.
     mv $out${subDir'}/pkgs.nix $out${subDir'}/default.nix
     else
+      # Check that this was a solver failure that (not some other
+      # possibly non deterministic failure).
+      # TODO replace grep once https://github.com/haskell/cabal/issues/5191
+      # is fixed.
+      grep "cabal: Could not resolve dependencies" cabal-configure.out
+
       # When cabal configure fails copy the output that we captured above and
       # use `failed-cabal-configure.nix` to make a suitable derviation with.
       cp cabal-configure.out $out


### PR DESCRIPTION
It looks like `callCabalProjectToNix` can fail in its `cabal` call with the following error:

```
open: permission denied (Permission denied)
```

Then running the same derivation locally works.  If the error is deferred there is no easy way on hydra to retry.

This change makes it so only solvers errors (which should hopefully be deterministic) are deferred.  All other errors will go back to being eval time errors meaning they should be automatically retried at the next hydra eval.