### PR TITLE
Use nix module system to check project arguments

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 This file contains a summary of changes to Haskell.nix and `nix-tools`
 that will impact users.
 
+## Apr 8, 2021
+* Project arguments are now validated with the Nix module system.
+  If unexpected argments are passed to a project function this may now
+  result in an error.
+
 ## Feb 22, 2021
 * Add `.dwarf` to build any component with DWARF dubug info on linux
   (ghc >=8.10.2).

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -21,8 +21,6 @@ in
 , caller               ? "callCabalProjectToNix" # Name of the calling function for better warning messages
 , ghc           ? null # Deprecated in favour of `compiler-nix-name`
 , ghcOverride   ? null # Used when we need to set ghc explicitly during bootstrapping
-, nix-tools     ? evalPackages.haskell-nix.nix-tools-unchecked.${compiler-nix-name}     # When building cabal projects we use the nix-tools
-, cabal-install ? evalPackages.haskell-nix.cabal-install-unchecked.${compiler-nix-name} # and cabal-install compiled with matching ghc version
 , configureArgs ? "" # Extra arguments to pass to `cabal v2-configure`.
                      # `--enable-tests --enable-benchmarks` are included by default.
                      # If the tests and benchmarks are not needed and they
@@ -43,6 +41,14 @@ in
 }@args:
 
 let
+  # These defaults are hear rather than in modules/cabal-project.nix to make them
+  # lazy enough to avoid infinite recursion issues.
+  nix-tools = if args.nix-tools or null != null
+    then args.nix-tools
+    else evalPackages.haskell-nix.nix-tools-unchecked.${compiler-nix-name};
+  cabal-install = if args.cabal-install or null != null
+    then args.cabal-install
+    else evalPackages.haskell-nix.cabal-install-unchecked.${compiler-nix-name};
   forName = pkgs.lib.optionalString (name != null) (" for " + name);
   nameAndSuffix = suffix: if name == null then suffix else name + "-" + suffix;
 

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -43,6 +43,8 @@ in
 let
   # These defaults are hear rather than in modules/cabal-project.nix to make them
   # lazy enough to avoid infinite recursion issues.
+  # Using null as the default also improves performance as they are not forced by the
+  # nix module system for `nix-tools-unchecked` and `cabal-install-unchecked`.
   nix-tools = if args.nix-tools or null != null
     then args.nix-tools
     else evalPackages.haskell-nix.nix-tools-unchecked.${compiler-nix-name};

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -333,4 +333,16 @@ in {
             }
             else src.origSrc or src;  # If there is a subDir and origSrc (but no filter) use origSrc
   };
+
+  evalProjectModule = projectType: m: f: f
+      (lib.evalModules {
+        modules = [m] ++ [
+          (import projectType)
+          ({ config, lib, ... }: {
+            _module.args = {
+              inherit pkgs;
+            };
+          })
+        ];
+      }).config;
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -334,10 +334,15 @@ in {
             else src.origSrc or src;  # If there is a subDir and origSrc (but no filter) use origSrc
   };
 
+  # Run evalModules passing the project function argument (m) as a module along with
+  # the the a projectType module (../modules/cabal-project.nix or ../modules/stack-project.nix).
+  # The resulting config is then passed to the project function's implementation.
   evalProjectModule = projectType: m: f: f
       (lib.evalModules {
         modules = [m] ++ [
+          # Include ../modules/cabal-project.nix or ../modules/stack-project.nix
           (import projectType)
+          # Pass the pkgs to the modules
           ({ config, lib, ... }: {
             _module.args = {
               inherit pkgs;

--- a/modules/cabal-project.nix
+++ b/modules/cabal-project.nix
@@ -1,0 +1,140 @@
+{ lib, config, pkgs, haskellLib, ... }:
+with lib;
+with types;
+let readIfExists = src: fileName:
+      let origSrcDir = src.origSrcSubDir or src;
+      in
+        if builtins.elem ((__readDir origSrcDir)."${fileName}" or "") ["regular" "symlink"]
+          then __readFile (origSrcDir + "/${fileName}")
+          else null;
+in {
+  options = {
+    # Used by callCabalProjectToNix
+    name = mkOption {
+      type = nullOr str;
+      default = config.src.name or null;
+      description = "Optional name for better error messages";
+    };
+    src = mkOption {
+      type = either path package;
+    };
+    compiler-nix-name = mkOption {
+      type = str;
+      description = "The name of the ghc compiler to use eg. \"ghc884\"";
+    };
+    index-state = mkOption {
+      type = nullOr str;
+      default = null;
+      description = "Hackage index-state, eg. \"2019-10-10T00:00:00Z\"";
+    };
+    index-sha256 = mkOption {
+      type = nullOr str;
+      default = null;
+      description = "The hash of the truncated hackage index-state";
+    };
+    plan-sha256 = mkOption {
+      type = nullOr str;
+      default = null;
+      description = "The hash of the plan-to-nix output (makes the plan-to-nix step a fixed output derivation)";
+    };
+    materialized = mkOption {
+      type = nullOr (either path package);
+      default = null;
+      description = "Location of a materialized copy of the nix files";
+    };
+    checkMaterialization = mkOption {
+      type = nullOr bool;
+      default = null;
+      description = "If true the nix files will be generated used to check plan-sha256 and material";
+    };
+    cabalProjectFileName = mkOption {
+      type = str;
+      default = "cabal.project";
+    };
+    cabalProject = mkOption {
+      type = nullOr str;
+      default = readIfExists config.src config.cabalProjectFileName;
+    };
+    cabalProjectLocal = mkOption {
+      type = nullOr str;
+      default = readIfExists config.src "${config.cabalProjectFileName}.local";
+    };
+    cabalProjectFreeze = mkOption {
+      type = nullOr str;
+      default = readIfExists config.src "${config.cabalProjectFileName}.freeze";
+    };
+    caller = mkOption {
+      type = str;
+      default = "callCabalProjectToNix";
+      description = "Name of the calling function for better warning messages";
+    };
+    ghc = mkOption {
+      type = nullOr package;
+      default = null;
+      description = "Deprecated in favour of `compiler-nix-name`";
+    };
+    ghcOverride = mkOption {
+      type = nullOr package;
+      default = null;
+      description = "Used when we need to set ghc explicitly during bootstrapping";
+    };
+    # The defaults for `nix-tools` and `cabal-install` are in `call-cabal-project-to-nix.nix`
+    # to make sure it is not evaluated too strictly (which would lead to infinite recursion).
+    nix-tools = mkOption {
+      type = nullOr package;
+      default = null;
+      description = "nix-tools to use when converting the `plan.json` to nix";
+    };
+    cabal-install = mkOption {
+      type = nullOr package;
+      default = null;
+      description = "cabal-install to use when running `cabal configure`";
+    };
+    configureArgs = mkOption {
+      type = nullOr str;
+      default = "";
+      description = ''
+        Extra arguments to pass to `cabal v2-configure`.
+        `--enable-tests --enable-benchmarks` are included by default.
+        If the tests and benchmarks are not needed and they
+        cause the wrong plan to be chosen, then we can use
+        `configureArgs = "--disable-tests --disable-benchmarks";`
+      '';
+    };
+    sha256map = mkOption {
+      type = nullOr unspecified;
+      default = null;
+      description = ''
+        An alternative to adding `--sha256` comments into the
+        cabal.project file:
+          sha256map =
+            { "https://github.com/jgm/pandoc-citeproc"."0.17"
+              = "0dxx8cp2xndpw3jwiawch2dkrkp15mil7pyx7dvd810pwc22pm2q"; };
+      '';
+    };
+    lookupSha256 = mkOption {
+      type = nullOr unspecified;
+      default = if config.sha256map != null
+        then { location, tag, ...}: config.sha256map.${location}.${tag}
+        else _: null;
+    };
+    extra-hackage-tarballs = mkOption {
+      type = nullOr (listOf unspecified);
+      default = [];
+    };
+
+    # Used by mkCabalProjectPkgSet
+    pkg-def-extras = mkOption {
+      type = nullOr (listOf unspecified);
+      default = [];
+    };
+    modules = mkOption {
+      type = nullOr (listOf unspecified);
+      default = [];
+    };
+    extra-hackages = mkOption {
+      type = nullOr (listOf unspecified);
+      default = [];
+    };
+  };
+}

--- a/modules/stack-project.nix
+++ b/modules/stack-project.nix
@@ -1,0 +1,112 @@
+{ lib, config, pkgs, haskellLib, ... }:
+with lib;
+with types;
+{
+  options = {
+    # Used by callStackToNix
+    name = mkOption {
+      type = nullOr str;
+      default = config.src.name or null;
+      description = "Optional name for better error messages";
+    };
+    src = mkOption {
+      type = either path package;
+    };
+    stackYaml = mkOption {
+      type = str;
+      default = "stack.yaml";
+    };
+    ignorePackageYaml = mkOption {
+      type = bool;
+      default = false;
+    };
+    cache = mkOption {
+      type = nullOr unspecified;
+      default = null;
+    };
+    stack-sha256 = mkOption {
+      type = nullOr str;
+      default = null;
+    };
+    resolverSha256 = mkOption {
+      type = nullOr str;
+      default = null;
+    };
+    materialized = mkOption {
+      type = nullOr (either path package);
+      default = null;
+      description = "Location of a materialized copy of the nix files";
+    };
+    checkMaterialization = mkOption {
+      type = nullOr bool;
+      default = null;
+      description = "If true the nix files will be generated used to check plan-sha256 and material";
+    };
+    caller = mkOption {
+      type = str;
+      default = "callCabalProjectToNix";
+      description = "Name of the calling function for better warning messages";
+    };
+    nix-tools = mkOption {
+      type = nullOr package;
+      default = pkgs.haskell-nix.internal-nix-tools;
+      description = "nix-tools to use when converting the `plan.json` to nix";
+    };
+
+    # Used by mkStackPkgSet
+    pkg-def-extras = mkOption {
+      type = nullOr (listOf unspecified);
+      default = [];
+    };
+    modules = mkOption {
+      type = nullOr (listOf unspecified);
+      default = [];
+    };
+    extra-hackages = mkOption {
+      type = nullOr (listOf unspecified);
+      default = [];
+    };
+
+    # Used in stack-cache-generator.nix
+    sha256map = mkOption {
+      type = nullOr unspecified;
+      default = null;
+      description = ''
+        An alternative to adding `# nix-sha256:` comments into the
+        stack.yaml file:
+          sha256map =
+            { "https://github.com/jgm/pandoc-citeproc"."0.17"
+              = "0dxx8cp2xndpw3jwiawch2dkrkp15mil7pyx7dvd810pwc22pm2q"; };
+      '';
+    };
+    lookupSha256 = mkOption {
+      type = nullOr unspecified;
+      default = if config.sha256map != null
+        then { location, tag, ...}: config.sha256map.${location}.${tag}
+        else _: null;
+    };
+    branchMap = mkOption {
+      type = nullOr unspecified;
+      default = null;
+      description = "A way to specify in which branch a git commit can be found";
+    };
+    lookupBranch = mkOption {
+      type = nullOr unspecified;
+      default = if config.branchMap != null
+        then { location, tag, ...}: config.branchMap.${location}.${tag} or null
+        else _: null;
+    };
+
+    # Used by stackProject itself
+    compiler-nix-name = mkOption {
+      type = nullOr str;
+      description = "The name of the ghc compiler to use eg. \"ghc884\"";
+      default = null;
+    };
+    ghc = mkOption {
+      type = nullOr package;
+      default = null;
+      description = "Deprecated in favour of `compiler-nix-name`";
+    };
+  };
+}

--- a/modules/stack-project.nix
+++ b/modules/stack-project.nix
@@ -49,7 +49,7 @@ with types;
     };
     nix-tools = mkOption {
       type = nullOr package;
-      default = pkgs.haskell-nix.internal-nix-tools;
+      default = pkgs.evalPackages.haskell-nix.internal-nix-tools;
       description = "nix-tools to use when converting the `plan.json` to nix";
     };
 

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -632,10 +632,6 @@ in {
         name = "cabal-install";
         version = "3.4.0.0";
         index-state = final.haskell-nix.internalHackageIndexState;
-        # When building cabal-install (only happens when checking materialization)
-        # disable checking of the tools used to avoid infinite recursion.
-        cabal-install = final.evalPackages.haskell-nix.cabal-install-unchecked.${compiler-nix-name};
-        nix-tools = final.evalPackages.haskell-nix.nix-tools-unchecked.${compiler-nix-name};
         materialized = ../materialized + "/${compiler-nix-name}/cabal-install";
       } // args)).getComponent "exe:cabal";
     nix-tools-set = { compiler-nix-name, ... }@args:
@@ -648,6 +644,7 @@ in {
             else args.compiler-nix-name;
         project =
           final.haskell-nix.cabalProject ({
+            caller = "nix-tools-set";
             name = "nix-tools";
             src = final.haskell-nix.sources.nix-tools;
             # This is a handy way to use a local git clone of nix-tools when developing
@@ -657,10 +654,6 @@ in {
               allow-newer: Cabal:base, cryptohash-sha512:base, haskeline:base
               index-state: ${final.haskell-nix.internalHackageIndexState}
             '';
-            # When building cabal-install (only happens when checking materialization)
-            # disable checking of the tools used to avoid infinite recursion.
-            cabal-install = final.evalPackages.haskell-nix.cabal-install-unchecked.${compiler-nix-name};
-            nix-tools = final.evalPackages.haskell-nix.nix-tools-unchecked.${compiler-nix-name};
             materialized = ../materialized + "/${compiler-nix-name}/nix-tools";
             modules = [{
               packages.transformers-compat.components.library.doExactConfig = true;

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -690,7 +690,8 @@ final: prev: {
         stackProject' =
           projectModule: haskellLib.evalProjectModule ../modules/stack-project.nix projectModule (
             { src, ... }@args:
-            let callProjectResults = callStackToNix ({ inherit cache; } // args);
+            let callProjectResults = callStackToNix (args
+                  // final.lib.optionalAttrs (args.cache == null) { inherit cache; });
                 generatedCache = genStackCache args;
                 cache = if args.cache != null then args.cache else generatedCache;
             in let pkg-set = mkStackPkgSet


### PR DESCRIPTION
This change uses the nix module system for the arguments to:

* `cabalProject'`
* `cabalProject`
* `stackProject'`
* `stackProject`

This will:

* Give an error when the name or type of an argument is incorrect
  (currently misnamed args are quietly ignored).

* Fixes a problem with `projectCross` not having a way to pass different args to `cabalProject`
  for different platforms. We can now use:
    `({pkgs, ...}: { cabalProjectLocal = if pkgs.stdenv.hostPlatform.isX then ... })`