### PR TITLE
Add crossPlatforms arg to shellFor

### DIFF
--- a/docs/reference/library.md
+++ b/docs/reference/library.md
@@ -435,6 +435,7 @@ shellFor =
 | `exactDeps`    | Boolean  | Prevents the Cabal solver from choosing any package dependency other than what are in the package set. |
 | `tools`        | Function | AttrSet of tools to make available e.g. `{ cabal = "3.2.0.0"; }` or `{ cabal = { version = "3.2.0.0"; }; }`. If an AttrSet is provided for a tool, the additional arguments will be passed to the function creating the derivation for that tool. So you can provide an `index-state` or a `materialized` argument like that `{ cabal = { version = "3.2.0.0"; index-state = "2020-10-30T00:00:00Z"; materialized = ./cabal.materialized; }; }` for example. You can specify and materialize the version of hoogle used to construct the hoogle index by including something like `{ hoogle = { version = "5.0.17.15"; index-state = "2020-05-31T00:00:00Z"; materialized = ./hoogle.materialized; }`. Uses a default version of hoogle if omitted. |
 | `inputsFrom`   | List     | List of other shells to include in this one.  The `buildInputs` and `nativeBuildInputs` of each will be included using [mkShell](https://nixos.org/manual/nixpkgs/stable/#sec-pkgs-mkShell).
+| `crossPlatforms` | Function | Platform selection function for cross compilation targets to support eg. `ps: with ps; [ghcjs mingwW64]`. |
 | `{ ... }`      | Attrset  | All the other arguments are passed to [`mkDerivation`](https://nixos.org/nixpkgs/manual/#sec-using-stdenv). |
 
 **Return value**: a derivation

--- a/docs/reference/library.md
+++ b/docs/reference/library.md
@@ -165,7 +165,7 @@ Then feeding its result into [mkCabalProjectPkgSet](#mkcabalprojectpkgset) passi
 | `shellFor`        | Function                                         | [`shellFor`](#shellfor)                                                     |
 | `ghcWithHoogle`   | Function                                         | [`ghcWithHoogle`](#ghcwithhoogle)                                           | 
 | `ghcWithPackages` | Function                                         | [`ghcWithPackages`](#ghcwithpackages)                                       |
-| `projectCross`    | Attrset                                          | Like `pkgs.pkgsCross.X` from nixpkgs `p.projectCross.X` returns the project results for cross compilation to X.  So `p.projectCross.ghcjs.hsPkgs` is the same as `hsPkgs` but compiled with ghcjs |
+| `projectCross`    | Attrset                                          | Like `pkgs.pkgsCross.<system>` from nixpkgs `p.projectCross.<system>` returns the project results for cross compilation (where system is a member of nixpkgs lib.systems.examples).  So `p.projectCross.ghcjs.hsPkgs` is the same as `hsPkgs` but compiled with ghcjs |
 
 ## project, cabalProject and stackProject
 
@@ -435,7 +435,7 @@ shellFor =
 | `exactDeps`    | Boolean  | Prevents the Cabal solver from choosing any package dependency other than what are in the package set. |
 | `tools`        | Function | AttrSet of tools to make available e.g. `{ cabal = "3.2.0.0"; }` or `{ cabal = { version = "3.2.0.0"; }; }`. If an AttrSet is provided for a tool, the additional arguments will be passed to the function creating the derivation for that tool. So you can provide an `index-state` or a `materialized` argument like that `{ cabal = { version = "3.2.0.0"; index-state = "2020-10-30T00:00:00Z"; materialized = ./cabal.materialized; }; }` for example. You can specify and materialize the version of hoogle used to construct the hoogle index by including something like `{ hoogle = { version = "5.0.17.15"; index-state = "2020-05-31T00:00:00Z"; materialized = ./hoogle.materialized; }`. Uses a default version of hoogle if omitted. |
 | `inputsFrom`   | List     | List of other shells to include in this one.  The `buildInputs` and `nativeBuildInputs` of each will be included using [mkShell](https://nixos.org/manual/nixpkgs/stable/#sec-pkgs-mkShell).
-| `crossPlatforms` | Function | Platform selection function for cross compilation targets to support eg. `ps: with ps; [ghcjs mingwW64]`. |
+| `crossPlatforms` | Function | Platform selection function for cross compilation targets to support eg. `ps: with ps; [ghcjs mingwW64]` (see nixpkgs lib.systems.examples for list of platform names). |
 | `{ ... }`      | Attrset  | All the other arguments are passed to [`mkDerivation`](https://nixos.org/nixpkgs/manual/#sec-using-stdenv). |
 
 **Return value**: a derivation

--- a/docs/tutorials/development.md
+++ b/docs/tutorials/development.md
@@ -62,6 +62,12 @@ in
     # Some you may need to get some other way.
     buildInputs = [ (import <nixpkgs> {}).git ];
 
+    # Sellect cross compilers to include.
+    crossPlatforms = ps: with ps; [
+      ghcjs      # Adds support for `js-unknown-ghcjs-cabal build` in the shell
+      # mingwW64 # Adds support for `x86_64-W64-mingw32-cabal build` in the shell
+    ];
+
     # Prevents cabal from choosing alternate plans, so that
     # *all* dependencies are provided by Nix.
     exactDeps = true;

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -582,32 +582,68 @@ final: prev: {
 
             projectCoverageReport = haskellLib.projectCoverageReport project (map (pkg: pkg.coverageReport) (final.lib.attrValues (haskellLib.selectProjectPackages hsPkgs)));
 
+            # `projectCross` is like `pkgsCross`, but for haskell.nix projects.
+            # See https://nixos.wiki/wiki/Cross_Compiling
             projectCross = (final.lib.mapAttrs (_: pkgs:
                 rawProject.projectFunction pkgs.haskell-nix rawProject.projectModule
               ) final.pkgsCross) // { recurseForDerivations = false; };
 
             # Add support for passing in `crossPlatforms` argument.
             # crossPlatforms is an easy way to include the inputs for a basic
-            # cross platform shell in a native shell.  For instance
-            #   .shellFor { crossPlatforms = p: [ p.ghcjs ]; tools.cabal = {}; }
-            # adds support for compiling with ghcjs.  To build use the cabal wrapper:
+            # cross platform shell in a native shell.
+            #
+            # For instance if `default.nix` is a project, then `shell.nix` can be:
+            #   (import ./. {}).shellFor {
+            #     tools.cabal = {};
+            #     crossPlatforms = p: [ p.ghcjs ];
+            #   }
+            #
+            # This adds support for compiling with ghcjs.  To build use the cabal wrapper:
             #   js-unknown-ghcjs-cabal build all
+            #
+            # ## How it Works
+            #
+            # The cross compilation shells are made using the `projectCross` attribute
+            # to get the selected cross compilation projects (e.g. project.projectCross.ghcjs).
+            #
+            # The `shellFor` function for those projects is called with arguments based on the
+            # ones used for the main shell (the `withHoogle` argument is set to `false`).
+            #
+            # These shells are added to the main shell using the `inputsFrom` argument.
+            #
+            # Without `crossPlatforms` the above example would be:
+            #   let project = import ./. {};
+            #   in project.shellFor {
+            #     tools.cabal = {};
+            #     inputsFrom = [
+            #       (project.platformCross.ghcjs.shellFor { withHoogle = false; })
+            #     ];
+            #   }
+            #
             shellFor = shellArgs:
               let
+                # These are the args we will pass to the main shell.
                 args' = builtins.removeAttrs shellArgs [ "crossPlatforms" ];
+                # These are the args we will pass to the shells for the corss compiler
+                argsCross =
+                  # These things should match main shell
+                  final.lib.filterAttrs (n: _: builtins.elem n [
+                    "packages" "components" "additional" "exactDeps" "packageSetupDeps"
+                  ]) shellArgs // {
+                    # The main shell's hoogle will probably be faster to build.
+                    withHoogle = false;
+                  };
+                # These are the cross compilation versions of the project we will include.
+                selectedCrossProjects =
+                  if shellArgs ? crossPlatforms
+                    then shellArgs.crossPlatforms projectCross
+                    else [];
+                # Shells for cross compilation
+                crossShells = builtins.map (project: project.shellFor argsCross)
+                  selectedCrossProjects;
               in rawProject.hsPkgs.shellFor (args' // {
                   # Add inputs from the cross compilation shells
-                  inputsFrom = args'.inputsFrom or []
-                    ++ builtins.map (project:
-                      project.shellFor (
-                        # These things should match native shell
-                        final.lib.filterAttrs (n: _: builtins.elem n [
-                          "packages" "components" "additional" "exactDeps" "packageSetupDeps"
-                        ]) args' // {
-                          # The native shell's hoogle will probably be faster to build.
-                          withHoogle = false;
-                      }))
-                      ((shellArgs.crossPlatforms or (_: [])) projectCross);
+                  inputsFrom = args'.inputsFrom or [] ++ crossShells;
                 });
 
             # Like `.hsPkgs.${packageName}` but when compined with `getComponent` any

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -583,6 +583,8 @@ final: prev: {
             projectCoverageReport = haskellLib.projectCoverageReport project (map (pkg: pkg.coverageReport) (final.lib.attrValues (haskellLib.selectProjectPackages hsPkgs)));
 
             # `projectCross` is like `pkgsCross`, but for haskell.nix projects.
+            # To get a cross platform version of the project use
+            # `projectCross.<system>` where system is a member of nixpkgs lib.systems.examples.
             # See https://nixos.wiki/wiki/Cross_Compiling
             projectCross = (final.lib.mapAttrs (_: pkgs:
                 rawProject.projectFunction pkgs.haskell-nix rawProject.projectModule


### PR DESCRIPTION
This makes it easier to get cross compilers for a project in a nix shell.