### PR TITLE
Fix windows cross compile issues with C++ code

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -157,6 +157,7 @@ in {
                 ++ final.lib.optional (versionAtLeast "8.6.4") ./patches/ghc/Cabal-3886.patch
 
                 ++ fromUntil "8.10.3" "8.10.5" ./patches/ghc/ghc-8.10.3-rts-make-markLiveObject-thread-safe.patch
+                ++ final.lib.optional (versionAtLeast "8.10.4" && final.targetPlatform.isWindows) ./patches/ghc/ghc-8.10-z-drive-fix.patch
                 ;
         in ({
             ghc844 = final.callPackage ../compiler/ghc {

--- a/overlays/patches/ghc/ghc-8.10-z-drive-fix.patch
+++ b/overlays/patches/ghc/ghc-8.10-z-drive-fix.patch
@@ -1,0 +1,14 @@
+diff --git a/libraries/libiserv/src/Remote/Slave.hs b/libraries/libiserv/src/Remote/Slave.hs
+index 577161f35f..3a4dbbf842 100644
+--- a/libraries/libiserv/src/Remote/Slave.hs
++++ b/libraries/libiserv/src/Remote/Slave.hs
+@@ -128,6 +128,8 @@ hook verbose base_path pipe m = case m of
+   -- system libraries.
+   Msg (LoadDLL path@('C':':':_)) -> do
+     return m
++  Msg (LoadDLL path@('Z':':':_)) -> do
++    return m
+   Msg (LoadDLL path) | isAbsolute path -> do
+     when verbose $ trace ("Need DLL: " ++ (base_path <//> path))
+     handleLoad pipe path (base_path <//> path)
+

--- a/overlays/windows.nix
+++ b/overlays/windows.nix
@@ -73,11 +73,17 @@ final: prev:
           # dependencies) and then placing them somewhere where wine+remote-iserv
           # will find them.
           remote-iserv.postInstall = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isWindows (
-            let extra-libs = [ pkgs.openssl.bin pkgs.libffi pkgs.gmp pkgs.libsodium ]; in ''
+            let extra-libs = [ pkgs.openssl.bin pkgs.libffi pkgs.gmp pkgs.libsodium pkgs.windows.mcfgthreads pkgs.buildPackages.gcc.cc ]; in ''
             for p in ${lib.concatStringsSep " "extra-libs}; do
               find "$p" -iname '*.dll' -exec cp {} $out/bin/ \;
               find "$p" -iname '*.dll.a' -exec cp {} $out/bin/ \;
             done
+            (
+            cd $out/bin
+            for l in lib*.dll; do
+              ln -s "$l" "''${l#lib}"
+            done
+            )
           '');
 
           # Apply https://github.com/haskell/cabal/pull/6055


### PR DESCRIPTION
This fixes issues when using packages like `double-conversion` in TH code.