### PR TITLE
Fix configured-src for ghcjs

### DIFF
--- a/compiler/ghcjs/ghcjs.nix
+++ b/compiler/ghcjs/ghcjs.nix
@@ -55,7 +55,7 @@ let
        ++ pkgs.lib.optional isGhcjs88 pkgs.buildPackages.procps;
       passthru = {
         inherit all-ghcjs bundled-ghcjs project;
-        inherit (project) configured-src;
+        configured-src = project.configured-src + "/ghc";
         # Used to detect non haskell-nix compilers (accidental use of nixpkgs compilers can lead to unexpected errors)
         isHaskellNixCompiler = true;
       } // ghcjs.components.exes;


### PR DESCRIPTION
It should point to the `ghc` sub directory not the `ghcjs` one.