### PR TITLE
Bump internal-* to ghc 8.10.4 (from 8.8.4)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 steps:
-  - label: 'Run tests with ghc884'
-    command: "./test/tests.sh ghc884"
+  - label: 'Run tests with ghc8104'
+    command: "./test/tests.sh ghc8104"
     agents:
       system: x86_64-linux
 
@@ -14,9 +14,9 @@ steps:
     agents:
       system: x86_64-linux
 
-  - label: 'Check closure size with ghc884'
+  - label: 'Check closure size with ghc8104'
     command:
-      - nix-build build.nix -A maintainer-scripts.check-closure-size --argstr compiler-nix-name ghc884 -o check-closure-size.sh
+      - nix-build build.nix -A maintainer-scripts.check-closure-size --argstr compiler-nix-name ghc8104 -o check-closure-size.sh
       - echo "+++ Closure size (MB)"
       - ./check-closure-size.sh
     agents:

--- a/ci.nix
+++ b/ci.nix
@@ -25,7 +25,7 @@
     # Update supported-ghc-versions.md to reflect any changes made here.
     {
       ghc865 = true;
-      ghc884 = false; # Just included because the native version is needed at eval time
+      ghc8104 = false; # Just included because the native version is needed at eval time
     } // nixpkgs.lib.optionalAttrs (nixpkgsName == "R2009") {
       ghc884 = true;
       ghc8104 = true;
@@ -52,10 +52,10 @@
     # Windows cross compilation is currently broken on macOS
     inherit (lib.systems.examples) mingwW64;
   } // lib.optionalAttrs (system == "x86_64-linux"
-      && !(nixpkgsName == "R2003" && compiler-nix-name == "ghc884")) {
+      && !(nixpkgsName == "R2003" && compiler-nix-name == "ghc8104")) {
     # Musl cross only works on linux
     # aarch64 cross only works on linux
-    # We also skip these for the R2003 was build of ghc884 (we only need the
+    # We also skip these for the R2003 was build of ghc8104 (we only need the
     # native so ifdLevel 1 includes compiler needed in ifdLevel2 eval)
     inherit (lib.systems.examples) musl64 aarch64-multiplatform;
   };

--- a/ci.nix
+++ b/ci.nix
@@ -32,7 +32,6 @@
       ghc8104 = true;
     } // nixpkgs.lib.optionalAttrs (nixpkgsName == "unstable") {
       ghc865 = false;
-      ghc884 = false;
       ghc8104 = true;
       ghc901 = true;
       ghc810420210212 = false;

--- a/ci.nix
+++ b/ci.nix
@@ -27,9 +27,11 @@
       ghc865 = true;
       ghc8104 = false; # Just included because the native version is needed at eval time
     } // nixpkgs.lib.optionalAttrs (nixpkgsName == "R2009") {
+      ghc865 = false;
       ghc884 = true;
       ghc8104 = true;
     } // nixpkgs.lib.optionalAttrs (nixpkgsName == "unstable") {
+      ghc865 = false;
       ghc884 = false;
       ghc8104 = true;
       ghc901 = true;

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -756,8 +756,8 @@ in {
     # there should be no difference in the behaviour of these tools.
     # (stack projects on macOS may see a significant change in the
     # closure size of their build dependencies due to dynamic linking).
-    internal-cabal-install = final.haskell-nix.cabal-install.ghc884;
-    internal-nix-tools = final.haskell-nix.nix-tools.ghc884;
+    internal-cabal-install = final.haskell-nix.cabal-install.ghc8104;
+    internal-nix-tools = final.haskell-nix.nix-tools.ghc8104;
 
     # WARN: The `import ../. {}` will prevent
     #       any cross to work, as we will loose

--- a/test/call-stack-to-nix/stack.yaml
+++ b/test/call-stack-to-nix/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-13.19
+resolver: lts-14.13
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
Anyone using `hpack` and/or `stack` will have a dependency on `internal-nix-tools` (built with a fixed version of ghc).  This is fine if your `nixpkgs` is one of the ones we cache, but if not we may have to wait for an extra ghc to build.  When this happens it would be nice if it is at least building a more recent version (rather than an older one).