### PR TITLE
Fix typo in eval-time repo fetching

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -203,8 +203,8 @@ let
       #   on the target system would use, so that the derivation is unaffected
       #   and, say, a linux release build job can identify the derivation
       #   as built by a darwin builder, and fetch it from a cache
-      sourceReposBuild = builtins.map (fetchRepo pkgs.evalPackages.fetchgit) sourceRepoData ;
-      sourceReposEval = builtins.map (fetchRepo pkgs.fetchgit) sourceRepoData;
+      sourceReposEval = builtins.map (fetchRepo pkgs.evalPackages.fetchgit) sourceRepoData ;
+      sourceReposBuild = builtins.map (fetchRepo pkgs.fetchgit) sourceRepoData;
     in {
       sourceRepos = sourceReposBuild;
       makeFixedProjectFile = ''


### PR DESCRIPTION
This was backwards.

(Lo: the PR that introduced this was merged by me no less :facepalm: )