### PR TITLE
Rename executable-profiling flag as suggested by Cabal

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -60,7 +60,7 @@ let self =
 
 # Profiling
 , enableLibraryProfiling ? component.enableLibraryProfiling
-, enableExecutableProfiling ? component.enableExecutableProfiling
+, enableProfiling ? component.enableProfiling
 , profilingDetail ? component.profilingDetail
 
 # Coverage
@@ -128,7 +128,7 @@ let
 
   fullName = "${nameOnly}-${package.identifier.version}";
 
-  needsProfiling = enableExecutableProfiling || enableLibraryProfiling;
+  needsProfiling = enableProfiling || enableLibraryProfiling;
 
   configFiles = makeConfigFiles {
     component = componentForSetup;
@@ -184,7 +184,7 @@ let
       (disableFeature dontStrip "executable-stripping")
       (disableFeature dontStrip "library-stripping")
       (enableFeature enableLibraryProfiling "library-profiling")
-      (enableFeature enableExecutableProfiling "executable-profiling")
+      (enableFeature enableProfiling "profiling")
       (enableFeature enableStatic "static")
       (enableFeature enableShared "shared")
       (enableFeature doCoverage "coverage")
@@ -198,7 +198,7 @@ let
       "--ghc-option=-optl=-pthread"
       "--ghc-option=-optl=-static"
     ] ++ lib.optional enableSeparateDataOutput "--datadir=$data/share/${ghc.name}"
-      ++ lib.optional (enableLibraryProfiling || enableExecutableProfiling) "--profiling-detail=${profilingDetail}"
+      ++ lib.optional (enableLibraryProfiling || enableProfiling) "--profiling-detail=${profilingDetail}"
       ++ lib.optional stdenv.hostPlatform.isLinux (enableFeature enableDeadCodeElimination "split-sections")
       ++ lib.optionals haskellLib.isCrossHost (
         map (arg: "--hsc2hs-option=" + arg) (["--cross-compile"] ++ lib.optionals (stdenv.hostPlatform.isWindows) ["--via-asm"])

--- a/modules/plan.nix
+++ b/modules/plan.nix
@@ -158,9 +158,9 @@ let
       default = (def.enableSeparateDataOutput or false);
     };
 
-    enableExecutableProfiling = mkOption {
+    enableProfiling = mkOption {
       type = bool;
-      default = (def.enableExecutableProfiling or false);
+      default = (def.enableProfiling or false);
     };
 
     profilingDetail = mkOption {

--- a/overlays/mingw_w64.nix
+++ b/overlays/mingw_w64.nix
@@ -46,7 +46,7 @@ let
     unset configureFlags
     PORT=$((5000 + $RANDOM % 5000))
     (>&2 echo "---> Starting remote-iserv on port $PORT")
-    WINEDLLOVERRIDES="winemac.drv=d" WINEDEBUG=warn-all,fixme-all,-menubuilder,-mscoree,-ole,-secur32,-winediag WINEPREFIX=$TMP ${wine}/bin/wine64 ${remote-iserv.override { enableExecutableProfiling = true; }}/bin/remote-iserv.exe tmp $PORT &
+    WINEDLLOVERRIDES="winemac.drv=d" WINEDEBUG=warn-all,fixme-all,-menubuilder,-mscoree,-ole,-secur32,-winediag WINEPREFIX=$TMP ${wine}/bin/wine64 ${remote-iserv.override { enableProfiling = true; }}/bin/remote-iserv.exe tmp $PORT &
     (>&2 echo "---| remote-iserv should have started on $PORT")
     RISERV_PID="$!"
     ${iserv-proxy}/bin/iserv-proxy $@ 127.0.0.1 "$PORT"

--- a/test/cabal-simple-prof/default.nix
+++ b/test/cabal-simple-prof/default.nix
@@ -9,7 +9,7 @@ let
       # Package has no exposed modules which causes
       #   haddock: No input file(s)
       packages.cabal-simple.doHaddock = false;
-      packages.cabal-simple.enableExecutableProfiling = true;
+      packages.cabal-simple.enableProfiling = true;
       enableLibraryProfiling = true;
       # executableProfiling = false;
     }


### PR DESCRIPTION
Cabal changed the syntax from `--(enable|disable)-executable-profiling` to `--(enable|disable)-profiling` as shown in `cabal configure --help`:
```
    --enable-profiling                                   Enable Executable and library
                                                         profiling
    --disable-profiling                                  Disable Executable and
                                                         library profiling
    --enable-executable-profiling                        Enable Executable profiling
                                                         (DEPRECATED)
    --disable-executable-profiling                       Disable Executable profiling
                                                         (DEPRECATED)
```