### PR TITLE
Fix haskell-language-server and ghc 8.10.5

### DIFF
--- a/overlays/hackage-quirks.nix
+++ b/overlays/hackage-quirks.nix
@@ -37,6 +37,17 @@ in { haskell-nix = prev.haskell-nix // {
       ];
     };
 
+    haskell-language-server = {
+      cabalProject = ''
+        packages: .
+        source-repository-package
+          type: git
+          location: https://github.com/hsyl20/ghc-api-compat
+          tag: 8fee87eac97a538dbe81ff1ab18cff10f2f9fa15
+          --sha256: sha256-byehvdxQxhNk5ZQUXeFHjAZpAze4Ct9261ro4c5acZk=
+      '';
+    };
+
     hpack = {
       modules = [ { reinstallableLibGhc = true; } ];
     };


### PR DESCRIPTION
Needs:

https://github.com/hsyl20/ghc-api-compat/commit/8fee87eac97a538dbe81ff1ab18cff10f2f9fa15

Which cannot be uploaded to hackage yet because of:

https://gitlab.haskell.org/haskell/ghc-api-compat/-/issues/1