### PR TITLE
Add cross compilation and devShell to project.flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,8 @@
   inputs = {
     # Note: keep this in sync with sources.json!
     nixpkgs.url = github:NixOS/nixpkgs/f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693;
-    nixpkgs-2003.url = github:NixOS/nixpkgs/7f73e46625f508a793700f5110b86f1a53341d6e;
     nixpkgs-2009.url = github:NixOS/nixpkgs/f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693;
-    nixpkgs-unstable.url = github:NixOS/nixpkgs/410bbd828cdc6156aecd5bc91772ad3a6b1099c7;
+    nixpkgs-unstable.url = github:NixOS/nixpkgs/d8eb97e3801bde96491535f40483d550b57605b9;
   };
 
   outputs = { self, nixpkgs, ... }:
@@ -14,14 +13,10 @@
 
     internal = rec {
       config = import ./config.nix;
-      # We can't import ./nix/sources.nix directly, because that uses nixpkgs to fetch by default,
-      # and importing nixpkgs without specifying localSystem doesn't work on flakes.
-      sources = let
-        sourcesInfo =
-          builtins.fromJSON (builtins.readFile ./nix/sources.json);
-          fetch = sourceInfo:
-          builtins.fetchTarball { inherit (sourceInfo) url sha256; };
-      in builtins.mapAttrs (_: fetch) sourcesInfo;
+      # Use a shim for pkgs that does not depend on `builtins.currentSystem`.
+      sources = import ./nix/sources.nix {
+        pkgs = { fetchzip = builtins.fetchTarball; };
+      };
 
       nixpkgsArgs = {
         inherit config;

--- a/modules/cabal-project.nix
+++ b/modules/cabal-project.nix
@@ -143,6 +143,11 @@ in {
       # TODO make this a submodule
       type = unspecified;
       default = {};
+      description = ''
+        Arguments to use for the default shell `p.shell` (these are passed to p.shellFor).
+        For instance to include `cabal` and `ghcjs` support use
+          shell = { tools.cabal = {}; crossPlatforms = p: [ p.ghcjs ]; }
+      '';
     };
   };
 }

--- a/modules/cabal-project.nix
+++ b/modules/cabal-project.nix
@@ -8,6 +8,7 @@ let readIfExists = src: fileName:
           then __readFile (origSrcDir + "/${fileName}")
           else null;
 in {
+  _file = "haskell.nix/modules/cabal-project.nix";
   options = {
     # Used by callCabalProjectToNix
     name = mkOption {
@@ -135,6 +136,13 @@ in {
     extra-hackages = mkOption {
       type = nullOr (listOf unspecified);
       default = [];
+    };
+
+    # Default shell arguments
+    shell = mkOption {
+      # TODO make this a submodule
+      type = unspecified;
+      default = {};
     };
   };
 }

--- a/modules/stack-project.nix
+++ b/modules/stack-project.nix
@@ -115,6 +115,11 @@ with types;
       # TODO make this a submodule
       type = unspecified;
       default = {};
+      description = ''
+        Arguments to use for the default shell `p.shell` (these are passed to p.shellFor).
+        For instance to include `cabal` and `ghcjs` support use
+          shell = { tools.cabal = {}; crossPlatforms = p: [ p.ghcjs ]; }
+      '';
     };
   };
 }

--- a/modules/stack-project.nix
+++ b/modules/stack-project.nix
@@ -2,6 +2,7 @@
 with lib;
 with types;
 {
+  _file = "haskell.nix/modules/stack-project.nix";
   options = {
     # Used by callStackToNix
     name = mkOption {
@@ -107,6 +108,13 @@ with types;
       type = nullOr package;
       default = null;
       description = "Deprecated in favour of `compiler-nix-name`";
+    };
+
+    # Default shell arguments
+    shell = mkOption {
+      # TODO make this a submodule
+      type = unspecified;
+      default = {};
     };
   };
 }


### PR DESCRIPTION
The default shell `devShell` works by adding a default `shell` to all projects.  You can pass the shell arguments to the project function using the new `shell` argument:

```
let myProject = haskell-nix.project {
  src = ./.;
  shell.tools = { cabal = {}; };
  shell.crossPlatforms = p: [ p.cross ];
};
```

This will include js-unknown-ghcjs-cabal in the `devShell`.

To add cross compiled outputs to the flake pass `crossPlatforms` to the `flake` function.

```
myProject.flake { crossPlatforms = p: [ p.cross ]; }
```

To cross compile a component include the platforms `config` string to the output name like this

```
nix build .#js-unknown-ghcjs:pkg-name:lib:pkg-name
```