### PR TITLE
Update the project modules and fix missing args param

### DIFF
--- a/docs/tutorials/getting-started-flakes.md
+++ b/docs/tutorials/getting-started-flakes.md
@@ -50,24 +50,26 @@ Add `flake.nix`:
             final.haskell-nix.project' {
               src = ./.;
               compiler-nix-name = "ghc8104";
+              # This is used by `nix develop .` to open a shell for use with
+              # `cabal`, `hlint` and `haskell-language-server`
+              shell.tools = {
+                cabal = {};
+                hlint = {};
+                haskell-language-server = {};
+              };
+              # This adds `js-unknown-ghcjs-cabal` to the shell.
+              shell.crossPlatform = p: [p.ghcjs];
             };
         })
       ];
       pkgs = import nixpkgs { inherit system overlays; };
-      flake = pkgs.helloProject.flake {};
+      flake = pkgs.helloProject.flake {
+        # This adds support for `nix build .#js-unknown-ghcjs-cabal:hello:exe:hello`
+        crossPlatforms = p: [p.ghcjs];
+      };
     in flake // {
       # Built by `nix build .`
       defaultPackage = flake.packages."hello:exe:hello";
-      
-      # This is used by `nix develop .` to open a shell for use with
-      # `cabal`, `hlint` and `haskell-language-server`
-      devShell = pkgs.helloProject.shellFor {
-        tools = {
-          cabal = "latest";
-          hlint = "latest";
-          haskell-language-server = "latest";
-        };
-      };
     });
 }
 ```

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -339,8 +339,9 @@ in {
   # The resulting config is then passed to the project function's implementation.
   evalProjectModule = projectType: m: f: f
       (lib.evalModules {
-        modules = [m] ++ [
+        modules = (if builtins.isList m then m else [m]) ++ [
           # Include ../modules/cabal-project.nix or ../modules/stack-project.nix
+          (import ../modules/project-common.nix)
           (import projectType)
           # Pass the pkgs to the modules
           ({ config, lib, ... }: {

--- a/modules/cabal-project.nix
+++ b/modules/cabal-project.nix
@@ -11,14 +11,6 @@ in {
   _file = "haskell.nix/modules/cabal-project.nix";
   options = {
     # Used by callCabalProjectToNix
-    name = mkOption {
-      type = nullOr str;
-      default = config.src.name or null;
-      description = "Optional name for better error messages";
-    };
-    src = mkOption {
-      type = either path package;
-    };
     compiler-nix-name = mkOption {
       type = str;
       description = "The name of the ghc compiler to use eg. \"ghc884\"";
@@ -136,18 +128,6 @@ in {
     extra-hackages = mkOption {
       type = nullOr (listOf unspecified);
       default = [];
-    };
-
-    # Default shell arguments
-    shell = mkOption {
-      # TODO make this a submodule
-      type = unspecified;
-      default = {};
-      description = ''
-        Arguments to use for the default shell `p.shell` (these are passed to p.shellFor).
-        For instance to include `cabal` and `ghcjs` support use
-          shell = { tools.cabal = {}; crossPlatforms = p: [ p.ghcjs ]; }
-      '';
     };
   };
 }

--- a/modules/project-common.nix
+++ b/modules/project-common.nix
@@ -1,0 +1,28 @@
+{ lib, ... }:
+with lib;
+with lib.types;
+{
+  _file = "haskell.nix/modules/project-common.nix";
+  options = {
+    # Used by callCabalProjectToNix and callStackToNix
+    name = mkOption {
+      type = nullOr str;
+      default = "haskell-project"; # TODO figure out why `config.src.name or null` breaks hix;
+      description = "Optional name for better error messages";
+    };
+    src = mkOption {
+      type = either path package;
+    };
+    # Default shell arguments
+    shell = mkOption {
+      # TODO make this a submodule
+      type = unspecified;
+      default = {};
+      description = ''
+        Arguments to use for the default shell `p.shell` (these are passed to p.shellFor).
+        For instance to include `cabal` and `ghcjs` support use
+          shell = { tools.cabal = {}; crossPlatforms = p: [ p.ghcjs ]; }
+      '';
+    };
+  };
+}

--- a/modules/project.nix
+++ b/modules/project.nix
@@ -1,0 +1,9 @@
+{ lib, ... }: {
+  _file = "haskell.nix/modules/project.nix";
+  options = {
+    projectFileName = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+    };
+  };
+}

--- a/modules/stack-project.nix
+++ b/modules/stack-project.nix
@@ -5,14 +5,6 @@ with types;
   _file = "haskell.nix/modules/stack-project.nix";
   options = {
     # Used by callStackToNix
-    name = mkOption {
-      type = nullOr str;
-      default = config.src.name or null;
-      description = "Optional name for better error messages";
-    };
-    src = mkOption {
-      type = either path package;
-    };
     stackYaml = mkOption {
       type = str;
       default = "stack.yaml";
@@ -108,18 +100,6 @@ with types;
       type = nullOr package;
       default = null;
       description = "Deprecated in favour of `compiler-nix-name`";
-    };
-
-    # Default shell arguments
-    shell = mkOption {
-      # TODO make this a submodule
-      type = unspecified;
-      default = {};
-      description = ''
-        Arguments to use for the default shell `p.shell` (these are passed to p.shellFor).
-        For instance to include `cabal` and `ghcjs` support use
-          shell = { tools.cabal = {}; crossPlatforms = p: [ p.ghcjs ]; }
-      '';
     };
   };
 }

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -531,7 +531,7 @@ final: prev: {
                   tools = final.buildPackages.haskell-nix.tools pkg-set.config.compiler.nix-name;
                   roots = final.haskell-nix.roots pkg-set.config.compiler.nix-name;
                   projectFunction = haskell-nix: haskell-nix.cabalProject';
-                  inherit projectModule;
+                  inherit projectModule args;
                 };
             in project);
 
@@ -793,7 +793,7 @@ final: prev: {
                   tools = final.buildPackages.haskell-nix.tools pkg-set.config.compiler.nix-name;
                   roots = final.haskell-nix.roots pkg-set.config.compiler.nix-name;
                   projectFunction = haskell-nix: haskell-nix.stackProject';
-                  inherit projectModule;
+                  inherit projectModule args;
                 };
             in project);
 
@@ -809,9 +809,17 @@ final: prev: {
         # selected file ends in a `.yaml` it is assumed to be for `stackProject`.
         # If neither `stack.yaml` nor `cabal.project` exist `cabalProject` is
         # used (as it will use a default `cabal.project`).
-        project' = { src, projectFileName ? null, ... }@args':
+        project' = projectModule:
           let
-            args = { caller = "project'"; } // final.lib.filterAttrs (n: _: n != "projectFileName") args';
+            projectModule' = if builtins.isList projectModule then projectModule else [projectModule];
+            inherit ((final.lib.evalModules {
+              modules = [
+                (import ../modules/project-common.nix)
+                (import ../modules/stack-project.nix)
+                (import ../modules/cabal-project.nix)
+                (import ../modules/project.nix)
+              ] ++ projectModule';
+            }).config) src projectFileName;
             dir = __readDir (src.origSrcSubDir or src);
             exists = fileName: builtins.elem (dir.${fileName} or "") ["regular" "symlink"];
             stackYamlExists    = exists "stack.yaml";
@@ -829,15 +837,33 @@ final: prev: {
                         else "cabal.project";  # the cabal.project file is optional
           in
             if final.lib.hasSuffix ".yaml" selectedFileName
-              then stackProject' (args // { stackYaml            = selectedFileName; })
-              else cabalProject' (args // { cabalProjectFileName = selectedFileName; });
+              then stackProject' ([
+                {
+                  options = {
+                    projectFileName = final.lib.mkOption {
+                      type = final.lib.types.nullOr final.lib.types.string;
+                      default = null;
+                    };
+                  };
+                }
+                    { caller = "project'"; stackYaml = selectedFileName; }
+                  ] ++ projectModule'
+                )
+              else cabalProject' ([
+                {
+                  options = {
+                    projectFileName = final.lib.mkOption {
+                      type = final.lib.types.nullOr final.lib.types.string;
+                      default = null;
+                    };
+                  };
+                }
+                    { caller = "project'"; cabalProjectFileName = selectedFileName; }
+                  ] ++ projectModule');
 
         # This is the same as the `cabalPackage` and `stackPackage` wrappers
         # for `cabalPackage` and `stackPackage`.
-        project = args':
-          let
-            args = { caller = "project"; } // args';
-            p = project' args;
+        project = args: let p = project' args;
           in p.hsPkgs // p;
 
         # Like `cabalProject'`, but for building the GHCJS compiler.

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -838,26 +838,12 @@ final: prev: {
           in
             if final.lib.hasSuffix ".yaml" selectedFileName
               then stackProject' ([
-                {
-                  options = {
-                    projectFileName = final.lib.mkOption {
-                      type = final.lib.types.nullOr final.lib.types.string;
-                      default = null;
-                    };
-                  };
-                }
+                    (import ../modules/project.nix)
                     { caller = "project'"; stackYaml = selectedFileName; }
                   ] ++ projectModule'
                 )
               else cabalProject' ([
-                {
-                  options = {
-                    projectFileName = final.lib.mkOption {
-                      type = final.lib.types.nullOr final.lib.types.string;
-                      default = null;
-                    };
-                  };
-                }
+                    (import ../modules/project.nix)
                     { caller = "project'"; cabalProjectFileName = selectedFileName; }
                   ] ++ projectModule');
 


### PR DESCRIPTION
There are now 4 project modules used to check the arguments passed to the various project functions:

* `project-common.nix` - Arguments used by all the project functions
* `stack-project.nix` - Used by the `stackProject` and `stackProject'` functions
* `cabal-project.nix` - Used by the `cabalProject` and `cabalProject'` functions
* `project.nix` - Just the `projectFileName` argument that is used by `project` and `project'` functions to determine whether to call `stackProject` or `cabalProject` function.

This also includes the `rawProject.args` that was mistakenly left out of #1141 causing #1142 and improvements for the docs for the use of the `shell` argument in `flake.nix` files.