### PR TITLE
Improve shellFor `selectComponents` performance

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -132,14 +132,7 @@ in {
   ## flatLibDepends :: Component -> [Package]
   flatLibDepends = component:
     let
-      # this is a minor improvement over the "cannot coerce set to string"
-      # error.  It will now say:
-      #
-      # > The option `packages.Win32.package.identifier.name' is used but not defined.
-      #
-      # which indicates that the package.Win32 is missing and not defined.
-      getKey = x: if x ? "outPath" then "${x}" else (throw x.identifier.name);
-      makePairs = map (p: rec { key=getKey val; val=(p.components.library or p); });
+      makePairs = map (p: rec { key=val.name; val=(p.components.library or p); });
       closure = builtins.genericClosure {
         startSet = makePairs component.depends;
         operator = {val,...}: makePairs val.config.depends;


### PR DESCRIPTION
Improves performance of  #1145 by only traversing local packages in search of components to add to
`selectComponents`.

Let me know if you have any suggestions