### PR TITLE
Fix wrong default.nix if following instructions blindly

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -174,7 +174,7 @@ Straightforward way of doing this is to change the branch name to a revision.
 
 ```nix
 let sources = {
-    haskellNix = import (builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/f1a94a4c82a2ab999a67c3b84269da78d89f0075.tar.gz") {};
+    haskellNix = builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/f1a94a4c82a2ab999a67c3b84269da78d89f0075.tar.gz";
   };
 ```
 


### PR DESCRIPTION
When copy-pasting the modified lines to the `default.nix` file, it will produce the following error:
`error: cannot coerce a set to a string, at [...]/default.nix`

Making the changes makes it work. Actually, the lines above (untouched in this PR) `fetchTarball "[...]/master.tar.gz"` were correct alread.