### PR TITLE
Add hackage and stackage as flake inputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,9 +7,13 @@
     nixpkgs-2009.url = github:NixOS/nixpkgs/46d1c3f28ca991601a53e9a14fdd53fcd3dd8416;
     nixpkgs-2105.url = github:NixOS/nixpkgs/3c6f3f84af60a8ed5b8a79cf3026b7630fcdefb8;
     nixpkgs-unstable.url = github:NixOS/nixpkgs/0747387223edf1aa5beaedf48983471315d95e16;
+    hackage.url = github:input-output-hk/hackage.nix;
+    hackage.flake = false;
+    stackage.url = github:input-output-hk/stackage.nix;
+    stackage.flake = false;
   };
 
-  outputs = { self, nixpkgs, ... }:
+  outputs = { self, nixpkgs, hackage, stackage, ... }:
   {
 
     internal = rec {
@@ -17,6 +21,8 @@
       # Use a shim for pkgs that does not depend on `builtins.currentSystem`.
       sources = import ./nix/sources.nix {
         pkgs = { fetchzip = builtins.fetchTarball; };
+      } // {
+        inherit hackage stackage;
       };
 
       nixpkgsArgs = {


### PR DESCRIPTION
This will mean that the pinned commits in `hackage-src.json` and `stackage-src.json` will not be used for flakes.  Instead the nix flake system will be free to choose the most recent commit.

One possible drawback of this system is that if we wanted to roll back to an old commit of `haskell.nix` and also pin `hackage` and `stackage` to whatever was current at the time we would have to look up the commit manually (it will not be possible to use `follows` to get the appropriate commits).

If we create a new `flake.lock` for a project using the latest haskell.nix though it get pins for `hackage` and `stackage` at the time it is created.  So if we keep the `flake.lock` in the projects repo we can easily roll back to it.

Fixes #1132