### PR TITLE
Postgresql static compile set gssSupport false

### DIFF
--- a/overlays/musl.nix
+++ b/overlays/musl.nix
@@ -18,7 +18,7 @@ final: prev: prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl ({
 
   # See https://github.com/input-output-hk/haskell.nix/issues/948
   postgresql = (prev.postgresql.overrideAttrs (old: { dontDisableStatic = true; }))
-    .override { enableSystemd = false; };
+    .override { enableSystemd = false; gssSupport = false; };
   openssl = prev.openssl.override { static = true; };
 
   # Fails on cross compile


### PR DESCRIPTION
when i compile with musl and postgresql with the follow error

```
fe-connect.c:445:0: error:
     error: undefined reference to 'gss_delete_sec_context'

fe-connect.c:447:0: error:
     error: undefined reference to 'gss_release_name'

fe-auth.c:76:0: error:
     error: undefined reference to 'gss_display_status'

fe-auth.c:79:0: error:
     error: undefined reference to 'gss_release_buffer'

fe-auth.c:142:0: error:
     error: undefined reference to 'gss_init_sec_context'

fe-auth.c:173:0: error:
     error: undefined reference to 'gss_release_buffer'

fe-auth.c:169:0: error:
     error: undefined reference to 'gss_release_buffer'

fe-auth.c:187:0: error:
     error: undefined reference to 'gss_release_name'

fe-auth.c:180:0: error:
     error: undefined reference to 'gss_release_name'

fe-auth.c:182:0: error:
     error: undefined reference to 'gss_delete_sec_context'

fe-auth.c:234:0: error:
     error: undefined reference to 'GSS_C_NT_HOSTBASED_SERVICE'

fe-auth.c:234:0: error:
     error: undefined reference to 'GSS_C_NT_HOSTBASED_SERVICE'

fe-auth.c:234:0: error:
     error: undefined reference to 'gss_import_name'
```