### PR TITLE
Simplify the way evalPackages works

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,10 +27,7 @@
       overlaysOverrideable = import ./overlays;
     };
 
-    # Using the eval-on-build version here as the plan is that
-    # `builtins.currentSystem` will not be supported in flakes.
-    # https://github.com/NixOS/rfcs/pull/49/files#diff-a5a138ca225433534de8d260f225fe31R429
-    overlay = self.overlays.combined-eval-on-build;
+    overlay = self.overlays.combined;
     overlays = self.internal.overlaysOverrideable { sourcesOverride = self.internal.sources; };
 
     legacyPackages = let

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -19,8 +19,7 @@ let
     nix-prefetch-git-minimal = import ./nix-prefetch-git-minimal.nix;
     gobject-introspection = import ./gobject-introspection.nix;
     hix = import ./hix.nix;
-    eval-on-current = import ./eval-on-current.nix;
-    eval-on-build = import ./eval-on-build.nix;
+    eval-packages = import ./eval-packages.nix;
     ghcjs = import ./ghcjs.nix;
   };
 
@@ -54,11 +53,9 @@ let
     ghcjs
     gobject-introspection
     hix
+    eval-packages
     # Restore nixpkgs haskell and haskellPackages
     (_: prev: { inherit (prev.haskell-nix-prev) haskell haskellPackages; })
   ];
-  combined = builtins.foldl' composeExtensions (_: _: { })
-    (ordered ++ [overlays.eval-on-current]);
-  combined-eval-on-build = builtins.foldl' composeExtensions (_: _: { })
-    (ordered ++ [overlays.eval-on-build]);
-in overlays // { inherit combined combined-eval-on-build; }
+  combined = builtins.foldl' composeExtensions (_: _: { }) ordered;
+in overlays // { inherit combined; }

--- a/overlays/eval-on-build.nix
+++ b/overlays/eval-on-build.nix
@@ -1,6 +1,0 @@
-final: prev: {
-  # This overlay sets `evalPackages` as just `buildPackages`
-  # See `eval-on-current.nix` for alternative that uses
-  # `builtins.currentSystem`.
-  evalPackages = final.buildPackages;
-}

--- a/overlays/eval-on-current.nix
+++ b/overlays/eval-on-current.nix
@@ -1,8 +1,0 @@
-final: prev: {
-  # This overlay makes `evalPackages` is like `buildPackages`, but on
-  # `builtins.currentSystem`.
-  # See `eval-on-build.nix` for alternative that just uses `buildPackages`.
-  evalPackages = (import final.path {
-    inherit (final.haskell-nix) overlays;
-  }).buildPackages;
-}

--- a/overlays/eval-packages.nix
+++ b/overlays/eval-packages.nix
@@ -1,7 +1,13 @@
 final: prev: {
   # This overlay makes `evalPackages` is like `buildPackages`, but on
-  # `builtins.currentSystem`.
+  # `builtins.currentSystem` (when not building a nix flake).
+  # We do not pass the `config` or `overlays` (not in `final.haskell-nix.overlays`).
+  # This could cause flake and non flake builds to diverge, although only the
+  # derivations that use `evalPackages` (these should be eval time only derviations
+  # used to build nix inputs for IFD, the generated nix should match and so derivations
+  # that depend on the IFD should match).
   evalPackages =
+    # If we are building a flake there will be no currentSystem attribute
     if builtins ? currentSystem
       then (import final.path {
           inherit (final.haskell-nix) overlays;

--- a/overlays/eval-packages.nix
+++ b/overlays/eval-packages.nix
@@ -1,0 +1,10 @@
+final: prev: {
+  # This overlay makes `evalPackages` is like `buildPackages`, but on
+  # `builtins.currentSystem`.
+  evalPackages =
+    if builtins ? currentSystem
+      then (import final.path {
+          inherit (final.haskell-nix) overlays;
+        }).buildPackages
+      else final.buildPackages;
+}


### PR DESCRIPTION
This change uses the same overlay for both flakes and non flake projects.  It chooses where evalPackages should run based on `builtins ? currentSystem` (`currentSystem` will not exist when building flake).

This will be needed to make sure the `evalPackages` still works correctly in #1151 (otherwise the use of `flake-compat` will cause eval-on-build to be used).