### PR TITLE
overlays/windows.nix: Workaround for remote-iserv libsodium.dll

### DIFF
--- a/overlays/windows.nix
+++ b/overlays/windows.nix
@@ -73,7 +73,7 @@ final: prev:
           # dependencies) and then placing them somewhere where wine+remote-iserv
           # will find them.
           remote-iserv.postInstall = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isWindows (
-            let extra-libs = [ pkgs.openssl.bin pkgs.libffi pkgs.gmp pkgs.libsodium pkgs.windows.mcfgthreads pkgs.buildPackages.gcc.cc ]; in ''
+            let extra-libs = [ pkgs.openssl.bin pkgs.libffi pkgs.gmp (pkgs.libsodium-vrf or pkgs.libsodium) pkgs.windows.mcfgthreads pkgs.buildPackages.gcc.cc ]; in ''
             for p in ${lib.concatStringsSep " "extra-libs}; do
               find "$p" -iname '*.dll' -exec cp {} $out/bin/ \;
               find "$p" -iname '*.dll.a' -exec cp {} $out/bin/ \;


### PR DESCRIPTION
This will use libsodium-vrf if it exists, otherwise libsodium.

See: https://github.com/input-output-hk/iohk-nix/pull/488

Ideally, we could automatically collect the runtime dependencies necessary for `remote-iserv.exe` - perhaps later though.
