### PR TITLE
fix #1173: have CI build/cache GHC 8.10.4

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -32,6 +32,7 @@
     } // nixpkgs.lib.optionalAttrs (nixpkgsName == "unstable") {
       ghc865 = false;
       ghc884 = false; # Native version is used to boot 9.0.1
+      ghc8104 = false;
       ghc8105 = true;
       ghc901 = true;
       ghc810420210212 = false;

--- a/docs/reference/supported-ghc-versions.md
+++ b/docs/reference/supported-ghc-versions.md
@@ -1,28 +1,49 @@
 # Supported GHC Versions
 
-
-The following GHC versions are defined in `haskell.nix` (i.e. there is a derivation for them even if it isn't necessarily cached):
+The following GHC versions are defined in `haskell.nix` (there is a derivation
+for each, though not all are cached or tested by CI):
 - 8.4.4
 - 8.6.{1,2,3,4,5}
 - 8.8.{1,2,3,4}
-- 8.10.{1,2,3,4}
+- 8.10.{1,2,3,4,5}
+- 9.0.1
 
-The following table shows the nixpkgs/GHC versions which are built by CI, and which of those are tested.
-If you use a combination of nixpkgs version and GHC version which is in this table, you should get cache hits from our cache.
-The "nixpkgs versions" refer to the versions that `haskell.nix` provides; if you use your own version of nixpkgs you will likely not get cache hit.
+The following table shows the Nixpkgs/GHC versions which are built/cached, and
+which of those are further tested.  If you use a combination of Nixpkgs version
+and GHC version which is in this table, you should hit our cache, saving
+considering time by not building GHC and a few additional tools.
 
-| Nixpkgs version  | GHC version | Tested? |
-|------------------|-------------|---------|
-| 20.03            | 8.6.5       | Y       |
-| 20.09            | 8.6.5       | Y       |
-| 20.09            | 8.8.4       | Y       |
-| 20.09            | 8.10.4      | Y       |
-| nixpkgs-unstable | 8.6.5       | Y       |
-| nixpkgs-unstable | 8.8.4       | Y       |
-| nixpkgs-unstable | 8.10.4      | Y       |
+Note that if you try to use `haskell.nix` as an overlay over Nixpkgs from a
+standard Nixpkgs channel you will likely get a cache miss.  To hit our cache you
+really should use an instance of Nixpkgs provided by `haskell.nix` itself.
 
-See [ci.nix](https://github.com/input-output-hk/haskell.nix/blob/master/ci.nix) for the source of truth about what is built and tested.
+| Nixpkgs version  | Nixpkgs pinning    | GHC version | `compiler-nix-name`   | Tested in CI? |
+|------------------|--------------------|-------------|-----------------------|---------------|
+| 20.09            | `nixpkgs-2009`     | 8.6.5       | `ghc865`              | No            |
+| 20.09            | `nixpkgs-2009`     | 8.10.5      | `ghc8105`             | No            |
+| 21.05            | `nixpkgs-2105`     | 8.6.5       | `ghc865`              | No            |
+| 21.05            | `nixpkgs-2105`     | 8.10.5      | `ghc8105`             | Yes           |
+| unstable         | `nixpkgs-unstable` | 8.6.5       | `ghc865`              | No            |
+| unstable         | `nixpkgs-unstable` | 8.8.4       | `ghc884`              | No            |
+| unstable         | `nixpkgs-unstable` | 8.10.4      | `ghc8104`             | No            |
+| unstable         | `nixpkgs-unstable` | 8.10.5      | `ghc8105`             | Yes           |
+| unstable         | `nixpkgs-unstable` | 9.0.1       | `ghc901`              | Yes           |
 
-See [overlays/bootstrap.nix](https://github.com/input-output-hk/haskell.nix/blob/master/overlays/bootstrap.nix) for a list of all the valid `compiler-nix-names`.
+See [ci.nix](https://github.com/input-output-hk/haskell.nix/blob/master/ci.nix)
+for the source of truth about what is built and tested (in the off chance this
+document is out-of-sync with your checkout).
 
-See also: [Instructions on adding new GHC versions](../dev/adding-new-ghc.md).
+See the [getting started guide](../tutorials/getting-started.md) for
+instructions on how to set up Nix to take advantage of our cache when building.
+This guide also covers where to use the Nixpkgs pinning and `compiler-nix-name`
+settings from the table above.  For further information, see the [instructions
+for how to pin Nixpkgs](../dev/nixpkgs-pin.md).
+
+See
+[overlays/bootstrap.nix](https://github.com/input-output-hk/haskell.nix/blob/master/overlays/bootstrap.nix)
+for a full list of all the valid `compiler-nix-name`s beyond what's
+cached/tested in CI.  You're free to use these, but be ready for longer build
+times.
+
+Lastly, see [instructions on adding new GHC versions](../dev/adding-new-ghc.md)
+in the event that what's in `haskell.nix` doesn't suit your needs.


### PR DESCRIPTION
The idea is to keep 8.10.4 in CI while 8.10.5 is still neither in
- a (non-nightly) Stackage LTS resolver
- upstream Nixpkgs-unstable

Hopefully it isn't long before 8.10.5 is more standard and we can remove
8.10.4 from the IOHK build.

This commit also updates documentation (which seems to have fallen out
of date), with some changes and additions to hopefully make things
easier on first-time readers.