### PR TITLE
Bump nix-tools to PR input-output-hk/nix-tools#98 branch

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -78,16 +78,16 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix-tools": {
-        "branch": "master",
+        "branch": "rvl/stack2nix-fix-cache-errors",
         "builtin": false,
         "description": "Translate Cabals Generic Package Description to a Nix expression",
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "nix-tools",
-        "rev": "c8c5e6a6fbb12a73598d1a434984a36e880ce3cf",
-        "sha256": "1g1g2kd6cgv9pn5s9xn0x4f1gh450qbkg561x6lcdxzncd19sfyn",
+        "rev": "28a201ab7080dc47510fb85b6fdc7b9138f041ef",
+        "sha256": "13pjhhr5gh69pxfksjf6bwgibhf1gcy81mww0rbcsqba4azypwhp",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/nix-tools/archive/c8c5e6a6fbb12a73598d1a434984a36e880ce3cf.tar.gz",
+        "url": "https://github.com/input-output-hk/nix-tools/archive/28a201ab7080dc47510fb85b6fdc7b9138f041ef.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -78,16 +78,16 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix-tools": {
-        "branch": "rvl/stack2nix-fix-cache-errors",
+        "branch": "master",
         "builtin": false,
         "description": "Translate Cabals Generic Package Description to a Nix expression",
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "nix-tools",
-        "rev": "28a201ab7080dc47510fb85b6fdc7b9138f041ef",
-        "sha256": "13pjhhr5gh69pxfksjf6bwgibhf1gcy81mww0rbcsqba4azypwhp",
+        "rev": "15d2e4b61cb63ff351f3c490c12c4d89eafd31a1",
+        "sha256": "15p38dhbhk2c0bq8g9jr0gy01livigz0ca34c2mrwipbd4mipqgm",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/nix-tools/archive/28a201ab7080dc47510fb85b6fdc7b9138f041ef.tar.gz",
+        "url": "https://github.com/input-output-hk/nix-tools/archive/15d2e4b61cb63ff351f3c490c12c4d89eafd31a1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 3
+, ifdLevel ? 2
 , checkMaterialization ? false }:
 
 let


### PR DESCRIPTION
Adds a fix for this error when regenerating files with `stack-to-nix`:
```
stack-to-nix: .stack-to-nix.cache: openFile: resource busy (file is locked)
```
