### PR TITLE
Ignore .gitignore when making minimal git repo

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -195,7 +195,7 @@ let
             cd $out
             chmod -R +w .
             git init -b minimal
-            git add .
+            git add --force .
             GIT_COMMITTER_NAME='No One' GIT_COMMITTER_EMAIL= git commit -m "Minimal Repo For Haskell.Nix" --author 'No One <>'
           '';
           inherit (repoData) subdirs;


### PR DESCRIPTION
Files in the git repo may also be in `.gitignore`.  We still need these files in our minimal version of the repo.

This fixes #1195