### PR TITLE
Add `package.buildable` option

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -73,7 +73,7 @@ in {
       comps = config.components;
       applyLibrary = cname: f { cname = config.package.identifier.name; ctype = "lib"; };
       applySubComp = ctype: cname: f { inherit cname; ctype = componentPrefix.${ctype} or (throw "Missing component mapping for ${ctype}."); };
-      buildableAttrs = lib.filterAttrs (n: comp: comp.buildable or true && comp.planned);
+      buildableAttrs = lib.filterAttrs (n: comp: config.package.buildable or true && comp.buildable or true && comp.planned);
       libComp = if comps.library == null || !(comps.library.buildable or true && comps.library.planned)
         then {}
         else lib.mapAttrs applyLibrary (removeAttrs comps (subComponentTypes ++ [ "setup" ]));

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -74,7 +74,7 @@ in {
       applyLibrary = cname: f { cname = config.package.identifier.name; ctype = "lib"; };
       applySubComp = ctype: cname: f { inherit cname; ctype = componentPrefix.${ctype} or (throw "Missing component mapping for ${ctype}."); };
       buildableAttrs = lib.filterAttrs (n: comp: config.package.buildable or true && comp.buildable or true && comp.planned);
-      libComp = if comps.library == null || !(comps.library.buildable or true && comps.library.planned)
+      libComp = if comps.library == null || !(config.package.buildable or true && comps.library.buildable or true && comps.library.planned)
         then {}
         else lib.mapAttrs applyLibrary (removeAttrs comps (subComponentTypes ++ [ "setup" ]));
       subComps = lib.mapAttrs

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -74,9 +74,9 @@ in {
       applyLibrary = cname: f { cname = config.package.identifier.name; ctype = "lib"; };
       applySubComp = ctype: cname: f { inherit cname; ctype = componentPrefix.${ctype} or (throw "Missing component mapping for ${ctype}."); };
       isBuildable = comp:
-        config.package.buildable or true # Set manually in a module (allows whole packages to be disabled)
-        && comp.buildable or true        # Set based on `buildable` in `.cabal` files
-        && comp.planned;                 # Set if the component was in the `plan.json`
+        config.package.buildable # Set manually in a module (allows whole packages to be disabled)
+        && comp.buildable        # Set based on `buildable` in `.cabal` files
+        && comp.planned;         # Set if the component was in the `plan.json`
       buildableAttrs = lib.filterAttrs (n: isBuildable);
       libComp = if comps.library == null || !(isBuildable comps.library)
         then {}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -74,9 +74,9 @@ in {
       applyLibrary = cname: f { cname = config.package.identifier.name; ctype = "lib"; };
       applySubComp = ctype: cname: f { inherit cname; ctype = componentPrefix.${ctype} or (throw "Missing component mapping for ${ctype}."); };
       isBuildable = comp:
-        config.package.buildable # Set manually in a module (allows whole packages to be disabled)
-        && comp.buildable        # Set based on `buildable` in `.cabal` files
-        && comp.planned;         # Set if the component was in the `plan.json`
+        config.package.buildable or true # Set manually in a module (allows whole packages to be disabled)
+        && comp.buildable or true        # Set based on `buildable` in `.cabal` files
+        && comp.planned;                 # Set if the component was in the `plan.json`
       buildableAttrs = lib.filterAttrs (n: isBuildable);
       libComp = if comps.library == null || !(isBuildable comps.library)
         then {}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -73,8 +73,12 @@ in {
       comps = config.components;
       applyLibrary = cname: f { cname = config.package.identifier.name; ctype = "lib"; };
       applySubComp = ctype: cname: f { inherit cname; ctype = componentPrefix.${ctype} or (throw "Missing component mapping for ${ctype}."); };
-      buildableAttrs = lib.filterAttrs (n: comp: config.package.buildable or true && comp.buildable or true && comp.planned);
-      libComp = if comps.library == null || !(config.package.buildable or true && comps.library.buildable or true && comps.library.planned)
+      isBuildable = comp:
+        config.package.buildable # Set manually in a module (allows whole packages to be disabled)
+        && comp.buildable        # Set based on `buildable` in `.cabal` files
+        && comp.planned;         # Set if the component was in the `plan.json`
+      buildableAttrs = lib.filterAttrs (n: isBuildable);
+      libComp = if comps.library == null || !(isBuildable comps.library)
         then {}
         else lib.mapAttrs applyLibrary (removeAttrs comps (subComponentTypes ++ [ "setup" ]));
       subComps = lib.mapAttrs

--- a/modules/package.nix
+++ b/modules/package.nix
@@ -215,6 +215,11 @@ in {
         type = bool;
         default = false;
       };
+
+      buildable = mkOption {
+        type = bool;
+        default = true;
+      };
     };
 
     components = {

--- a/test/unit.nix
+++ b/test/unit.nix
@@ -6,23 +6,25 @@ let
        benchmarks = { };
        exes = { };
        foreignlibs = { };
-       library = { planned = true; };
+       library = { buildable = true; planned = true; };
        sublibs = { };
        tests = { };
     };
     package.identifier.name = "empty";
+    package.buildable = true;
   };
 
   componentsConfig = {
     components = {
-       benchmarks = { bbb = { planned = true; }; };
-       exes = { eee = { planned = true; }; };
-       foreignlibs = { fff = { planned = true; }; };
-       library = { planned = true; };
+       benchmarks = { bbb = { buildable = true; planned = true; }; };
+       exes = { eee = { buildable = true; planned = true; }; };
+       foreignlibs = { fff = { buildable = true; planned = true; }; };
+       library = { buildable = true; planned = true; };
        sublibs = { };
-       tests = { ttt = { planned = true; }; };
+       tests = { ttt = { buildable = true; planned = true; }; };
     };
     package.identifier.name = "nnn";
+    package.buildable = true;
   };
 
   testRepoData = {


### PR DESCRIPTION
Turning off building for a whole package requires setting `buildable = lib.mkForce false` on each of the components of the package.  This change adds support for `package.buildable = false` to make it easier.

So:

```
packages.marlowe-actus.components.library.buildable = lib.mkForce false;
packages.marlowe-actus.components.exes.marlowe-actus-test-kit.buildable = lib.mkForce false;
packages.marlowe-actus.components.tests.marlowe-actus-test.buildable = lib.mkForce false;
```

Can be replaced with:

```
packages.marlowe-actus.package.buildable = false;
```