### PR TITLE
Fix aarch64 bootstrapping GHC selection.

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -34,7 +34,7 @@ let
     '';
     # For each architecture, what GHC version we should use for bootstrapping.
     buildBootstrapper =
-        if final.targetPlatform.isAarch64 && final.buildPlatform.isAarch64
+        if final.targetPlatform.isAarch64 || final.buildPlatform.isAarch64
         then {
             compilerNixName = "ghc882";
         }


### PR DESCRIPTION
We need to use the 8.8.x branch if aarch64 is the target (since any previous branch will yield broken code) or the build platform (because previous branches are broken, the compiler itself can segfault on aarch64).