### PR TITLE
Support for source-repo only cabal.project file

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -458,9 +458,13 @@ let
     # repo yet. We fail early and provide a useful error
     # message to prevent headaches (#290).
     if [ -z "$(ls -A ${maybeCleanedSource})" ]; then
-      echo "cleaned source is empty. Did you forget to 'git add -A'?"; exit 1;
+      echo "cleaned source is empty. Did you forget to 'git add -A'?"
+      ${pkgs.lib.optionalString (__length fixedProject.sourceRepos == 0) ''
+        exit 1
+      ''}
+    else
+      cp -r ${maybeCleanedSource}/* .
     fi
-    cp -r ${maybeCleanedSource}/* .
     chmod +w -R .
     # Decide what to do for each `package.yaml` file.
     for hpackFile in $(find . -name package.yaml); do (


### PR DESCRIPTION
It is handy to be able to make a `cabal.project` file with only a `source-repository-package` inside it.  Currently we assume if there are no local `.cabal` files it is an error.  This change allows it, but only if we have found a `source-repository-package` in the `cabal.project`.