### PR TITLE
Remove workaround for hls

### DIFF
--- a/overlays/hackage-quirks.nix
+++ b/overlays/hackage-quirks.nix
@@ -26,19 +26,6 @@ in { haskell-nix = prev.haskell-nix // {
       ];
     };
 
-    haskell-language-server = {
-      # Fixes for:
-      #   * ghc-api-compat
-      cabalProject = ''
-        packages: .
-        source-repository-package
-          type: git
-          location: https://github.com/hsyl20/ghc-api-compat
-          tag: 8fee87eac97a538dbe81ff1ab18cff10f2f9fa15
-          --sha256: sha256-byehvdxQxhNk5ZQUXeFHjAZpAze4Ct9261ro4c5acZk=
-      '';
-    };
-
     hpack = {
       modules = [ { reinstallableLibGhc = true; } ];
     };


### PR DESCRIPTION
Not needed now ghc-api-compat has been updated in hackage