### PR TITLE
flakes tutorial: add `shell.buildInputs` example

### DIFF
--- a/docs/tutorials/getting-started-flakes.md
+++ b/docs/tutorials/getting-started-flakes.md
@@ -57,6 +57,10 @@ Add `flake.nix`:
                 hlint = {};
                 haskell-language-server = {};
               };
+              # Non-Haskell shell tools go here
+              shell.buildInputs = with pkgs; [
+                nixpkgs-fmt
+              ];
               # This adds `js-unknown-ghcjs-cabal` to the shell.
               shell.crossPlatform = p: [p.ghcjs];
             };


### PR DESCRIPTION
Often I want to have non-haskell tools, like nixpkgs-fmt (used to format .nix files in IDE context), installed in the nix shell.

In vanilla nixpkgs, one would use `addBuildTools`. With haskell.nix+flakes, I learned that it would be `shell.buildInputs`.