### PR TITLE
Build 8.10.7 rather than 8.10.5 on 20.09

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -26,7 +26,7 @@
     # Update supported-ghc-versions.md to reflect any changes made here.
     nixpkgs.lib.optionalAttrs (nixpkgsName == "R2009") {
       ghc865 = false;
-      ghc8105 = false;
+      ghc8107 = false;
     } // nixpkgs.lib.optionalAttrs (nixpkgsName == "R2105") {
       ghc865 = false;
       ghc8107 = true;


### PR DESCRIPTION
I think this is what it was meant to be (and what the support table says
it is).