### PR TITLE
Include FSF-libre when determining free-ness

### DIFF
--- a/lib/spdx/licenses.nix
+++ b/lib/spdx/licenses.nix
@@ -11,7 +11,7 @@ with builtins; let
               shortName = licenseId;
               fullName  = name;
               url       = dropFour detailsUrl + "html";
-              free      = isFsfLibre || isOsiApproved;
+              free      = isOsiApproved || lic.isFsfLibre or false;
             };
   toNamedValue = lic: { name = lic.spdxId; value = lic; };
 in


### PR DESCRIPTION
In Nixpkgs any license considered free or open source by both the FSF and the OSI is considered free. When implementing the SPDX parsing I must've missed the `isFsfLibre` property. This is now fixed.