### PR TITLE
Revert "Use builtins.fetchGit{allRefs=true;} if no ref provided."

### DIFF
--- a/lib/stack-cache-generator.nix
+++ b/lib/stack-cache-generator.nix
@@ -103,11 +103,7 @@ concatMap (dep:
                 }
                 else builtins.fetchGit ({
                   inherit (dep) url rev;
-                } // (if branch != null
-                  then { ref = branch; }
-                  # Don't fail if rev not in default branch:
-                  else { allRefs = true; })
-                );
+                } // pkgs.lib.optionalAttrs (branch != null) { ref = branch; });
         in map (subdir: {
                 name = cabalName "${pkgsrc}/${subdir}";
                 inherit (dep) url rev;

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -308,10 +308,7 @@ final: prev: {
                 assert isNull sha256;
                 builtins.fetchGit
                   ({ inherit url rev; } //
-                    (if ref != null
-                    then { inherit ref; }
-                    # Don't fail if rev not in default branch:
-                    else { allRefs = true; })
+                      final.buildPackages.lib.optionalAttrs (ref != null) { inherit ref; }
                   )
               else
                 # Non-private repos must have sha256 set.
@@ -405,10 +402,7 @@ final: prev: {
                         then
                           builtins.fetchGit
                             ({ inherit url rev; } //
-                              (if ref != null
-                              then { inherit ref; }
-                              # don't fail if rev not in default branch:
-                              else { allRefs = true; })
+                              final.buildPackages.lib.optionalAttrs (ref != null) { inherit ref; }
                             )
                         else
                           final.evalPackages.fetchgit { inherit url rev sha256; };


### PR DESCRIPTION
This reverts commit 9ccc486b9ff51e7f69c6420ded742a597be041fb.

Unfortunately our hydra is built against an old version of nix
which does not support this attribute.