### PR TITLE
shellFor: Add withHaddocks and fix ghc-pkg reporting no haddocks for dependencies

### DIFF
--- a/builder/shell-for.nix
+++ b/builder/shell-for.nix
@@ -13,6 +13,7 @@
   # Additional packages to be added unconditionally
 , additional ? _: []
 , withHoogle ? true
+, withHaddock ? withHoogle
 , exactDeps ? false
 , tools ? {}
 , packageSetupDeps ? true
@@ -102,6 +103,7 @@ let
     fullName = args.name or name;
     identifier.name = name;
     inherit component;
+    chooseDrv = p: if withHaddock && p ? haddock then p.haddock else p;
   };
   ghcEnv = ghcForComponent {
     inherit configFiles;


### PR DESCRIPTION
Previously, ghc-pkg didn't know where to find the haddock derivations for any dependency. So this fixes that, along with adding a toggle for it that's on by default when hoogle is on.