### PR TITLE
Fix getting-started.md for MacOS

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -87,7 +87,7 @@ let
     # haskell.nix provides access to the nixpkgs pins which are used by our CI,
     # hence you will be more likely to get cache hits when using these.
     # But you can also just use your own, e.g. '<nixpkgs>'.
-    haskellNix.sources.nixpkgs-2009
+    haskellNix.sources.nixpkgs-unstable
     # These arguments passed to nixpkgs, include some patches and also
     # the haskell.nix functionality itself as an overlay.
     haskellNix.nixpkgsArgs;


### PR DESCRIPTION
Getting started tutorial doesn't work out of the box on MacOS Big Sur and Monterey

Log output fails at:

```
$ nix-shell

...
building
Preprocessing library for appar-0.1.8..
Building library for appar-0.1.8..

on the commandline: warning:
    -Wnoncanonical-monadfail-instances is deprecated: fail is no longer a method of Monad
[1 of 5] Compiling Text.Appar.Input ( Text/Appar/Input.hs, dist/build/Text/Appar/Input.o, dist/build/Text/Appar/Input.dyn_o )
[2 of 5] Compiling Text.Appar.Parser ( Text/Appar/Parser.hs, dist/build/Text/Appar/Parser.o, dist/build/Text/Appar/Parser.dyn_o )

Text/Appar/Parser.hs:59:1: warning: [-Wunused-imports]
    The import of ‘Control.Monad.Fail’ is redundant
      except perhaps to import instances from ‘Control.Monad.Fail’
    To import instances alone, use: import Control.Monad.Fail()
   |
59 | import Control.Monad.Fail as Fail
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[3 of 5] Compiling Text.Appar.LazyByteString ( Text/Appar/LazyByteString.hs, dist/build/Text/Appar/LazyByteString.o, dist/build/Text/Appar/LazyByteString.dyn_o )
[4 of 5] Compiling Text.Appar.ByteString ( Text/Appar/ByteString.hs, dist/build/Text/Appar/ByteString.o, dist/build/Text/Appar/ByteString.dyn_o )
[5 of 5] Compiling Text.Appar.String ( Text/Appar/String.hs, dist/build/Text/Appar/String.o, dist/build/Text/Appar/String.dyn_o )
ld: warning: /nix/store/d56zjpdw2hj5hzbyxsbjczk73vg401cn-libiconv-osx-10.12.6/lib/libiconv.dylib, ignoring unexpected dylib file
ld: file not found: /usr/lib/system/libcache.dylib for architecture x86_64
clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
`cc' failed in phase `Linker'. (Exit code: 1)
```

I spent several hours and finally found the solution here:

`https://github.com/jonascarpay/template-haskell/commit/d244783c816db99221931d37e89b79d7b968cb10`

I propose to just fix the docs to save time for others. 
Maybe there is a better solution, I'm a Nix newbie.
