### PR TITLE
Add patches for non-moving gc fixes in 8.10

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -183,6 +183,9 @@ in {
                   (fromUntil "8.10.5" "8.10.6" ./patches/ghc/ghc-8.10.5-darwin-allocateExec.patch)
                 ++ until              "8.10.6" ./patches/ghc/Sphinx_Unicode_Error.patch
                 ++ from      "9.2.1"           ./patches/ghc/ghc-9.2.1-xattr-fix.patch
+                ++ fromUntil "8.10"   "9.2.2"  ./patches/ghc/MR6654-nonmoving-maxmem.patch  # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6654
+                ++ fromUntil "8.10"   "8.10.8" ./patches/ghc/MR6617-nonmoving-mvar.patch    # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6617
+                ++ fromUntil "8.10"   "8.10.8" ./patches/ghc/MR6595-nonmoving-mutvar.patch  # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6595
                 ;
         in ({
             ghc844 = final.callPackage ../compiler/ghc {

--- a/overlays/patches/ghc/MR6595-nonmoving-mutvar.patch
+++ b/overlays/patches/ghc/MR6595-nonmoving-mutvar.patch
@@ -1,0 +1,521 @@
+From 51698e1b0c762caa284a3daa2ab131f9464b1008 Mon Sep 17 00:00:00 2001
+From: Ben Gamari <ben@smart-cactus.org>
+Date: Mon, 20 Sep 2021 22:51:01 -0400
+Subject: [PATCH 1/4] nonmoving: Fix and factor out mark_trec_chunk
+
+We need to ensure that the TRecChunk itself is marked, in addition to
+the TRecs it contains.
+
+(cherry picked from commit 8d6de5416406be7b1c90f8e0c9a80f5bea1befff)
+---
+ rts/sm/NonMovingMark.c | 39 +++++++++++++++++----------------------
+ 1 file changed, 17 insertions(+), 22 deletions(-)
+
+diff --git a/rts/sm/NonMovingMark.c b/rts/sm/NonMovingMark.c
+index 16085cb27a..c1e41219f8 100644
+--- a/rts/sm/NonMovingMark.c
++++ b/rts/sm/NonMovingMark.c
+@@ -790,8 +790,8 @@ void markQueuePushThunkSrt (MarkQueue *q, const StgInfoTable *info)
+ }
+ 
+ void markQueuePushArray (MarkQueue *q,
+-                            const StgMutArrPtrs *array,
+-                            StgWord start_index)
++                         const StgMutArrPtrs *array,
++                         StgWord start_index)
+ {
+     push_array(q, array, start_index);
+ }
+@@ -940,20 +940,26 @@ markQueueLength (MarkQueue *q)
+  * barrier. Consequently it's quite important that we deeply mark
+  * any outstanding transactions.
+  */
++static void
++mark_trec_chunk (MarkQueue *queue, StgTRecChunk *chunk)
++{
++    markQueuePushClosure_(queue, (StgClosure *) chunk);
++    for (StgWord i=0; i < chunk->next_entry_idx; i++) {
++        TRecEntry *ent = &chunk->entries[i];
++        markQueuePushClosure_(queue, (StgClosure *) ent->tvar);
++        markQueuePushClosure_(queue, ent->expected_value);
++        markQueuePushClosure_(queue, ent->new_value);
++    }
++}
++
+ static void
+ mark_trec_header (MarkQueue *queue, StgTRecHeader *trec)
+ {
+     while (trec != NO_TREC) {
+         StgTRecChunk *chunk = trec->current_chunk;
+         markQueuePushClosure_(queue, (StgClosure *) trec);
+-        markQueuePushClosure_(queue, (StgClosure *) chunk);
+         while (chunk != END_STM_CHUNK_LIST) {
+-            for (StgWord i=0; i < chunk->next_entry_idx; i++) {
+-                TRecEntry *ent = &chunk->entries[i];
+-                markQueuePushClosure_(queue, (StgClosure *) ent->tvar);
+-                markQueuePushClosure_(queue, ent->expected_value);
+-                markQueuePushClosure_(queue, ent->new_value);
+-            }
++            mark_trec_chunk(queue, chunk);
+             chunk = chunk->prev_chunk;
+         }
+         trec = trec->enclosing_trec;
+@@ -1552,7 +1558,6 @@ mark_closure (MarkQueue *queue, const StgClosure *p0, StgClosure **origin)
+     case MUT_ARR_PTRS_DIRTY:
+     case MUT_ARR_PTRS_FROZEN_CLEAN:
+     case MUT_ARR_PTRS_FROZEN_DIRTY:
+-        // TODO: Check this against Scav.c
+         markQueuePushArray(queue, (StgMutArrPtrs *) p, 0);
+         break;
+ 
+@@ -1602,19 +1607,9 @@ mark_closure (MarkQueue *queue, const StgClosure *p0, StgClosure **origin)
+         break;
+     }
+ 
+-    case TREC_CHUNK: {
+-        // TODO: Should we abort here? This should have already been marked
+-        // when we dirtied the TSO
+-        StgTRecChunk *tc = ((StgTRecChunk *) p);
+-        PUSH_FIELD(tc, prev_chunk);
+-        TRecEntry *end = &tc->entries[tc->next_entry_idx];
+-        for (TRecEntry *e = &tc->entries[0]; e < end; e++) {
+-            markQueuePushClosure_(queue, (StgClosure *) e->tvar);
+-            markQueuePushClosure_(queue, (StgClosure *) e->expected_value);
+-            markQueuePushClosure_(queue, (StgClosure *) e->new_value);
+-        }
++    case TREC_CHUNK:
++        // N.B. chunk contents are deeply marked by mark_trec_header
+         break;
+-    }
+ 
+     case WHITEHOLE:
+         while (*(StgInfoTable* volatile*) &p->header.info == &stg_WHITEHOLE_info);
+-- 
+2.33.1
+
+
+From 8c3bf8af42a3891e28a8edde20f31655cc2a4654 Mon Sep 17 00:00:00 2001
+From: Ben Gamari <ben@smart-cactus.org>
+Date: Thu, 23 Sep 2021 14:47:55 -0400
+Subject: [PATCH 2/4] rts/nonmoving: Rename mark_* to trace_*
+
+These functions really do no marking; they merely trace pointers.
+
+(cherry picked from commit aa520ba158d9f73a3e59af4fbce3b9d294254965)
+---
+ rts/sm/NonMovingMark.c | 84 +++++++++++++++++++++---------------------
+ 1 file changed, 42 insertions(+), 42 deletions(-)
+
+diff --git a/rts/sm/NonMovingMark.c b/rts/sm/NonMovingMark.c
+index c1e41219f8..ee9b3d89eb 100644
+--- a/rts/sm/NonMovingMark.c
++++ b/rts/sm/NonMovingMark.c
+@@ -29,12 +29,12 @@
+ 
+ static bool check_in_nonmoving_heap(StgClosure *p);
+ static void mark_closure (MarkQueue *queue, const StgClosure *p, StgClosure **origin);
+-static void mark_tso (MarkQueue *queue, StgTSO *tso);
+-static void mark_stack (MarkQueue *queue, StgStack *stack);
+-static void mark_PAP_payload (MarkQueue *queue,
+-                              StgClosure *fun,
+-                              StgClosure **payload,
+-                              StgWord size);
++static void trace_tso (MarkQueue *queue, StgTSO *tso);
++static void trace_stack (MarkQueue *queue, StgStack *stack);
++static void trace_PAP_payload (MarkQueue *queue,
++                               StgClosure *fun,
++                               StgClosure **payload,
++                               StgWord size);
+ 
+ // How many Array# entries to add to the mark queue at once?
+ #define MARK_ARRAY_CHUNK_LENGTH 128
+@@ -629,7 +629,7 @@ void updateRemembSetPushThunkEager(Capability *cap,
+         if (check_in_nonmoving_heap(ap->fun)) {
+             push_closure(queue, ap->fun, NULL);
+         }
+-        mark_PAP_payload(queue, ap->fun, ap->payload, ap->n_args);
++        trace_PAP_payload(queue, ap->fun, ap->payload, ap->n_args);
+         break;
+     }
+     case THUNK_SELECTOR:
+@@ -715,7 +715,7 @@ void updateRemembSetPushTSO(Capability *cap, StgTSO *tso)
+ {
+     if (needs_upd_rem_set_mark((StgClosure *) tso)) {
+         debugTrace(DEBUG_nonmoving_gc, "upd_rem_set: TSO %p", tso);
+-        mark_tso(&cap->upd_rem_set.queue, tso);
++        trace_tso(&cap->upd_rem_set.queue, tso);
+         finish_upd_rem_set_mark((StgClosure *) tso);
+     }
+ }
+@@ -730,7 +730,7 @@ void updateRemembSetPushStack(Capability *cap, StgStack *stack)
+               != nonmovingMarkEpoch) {
+             // We have claimed the right to mark the stack.
+             debugTrace(DEBUG_nonmoving_gc, "upd_rem_set: STACK %p", stack->sp);
+-            mark_stack(&cap->upd_rem_set.queue, stack);
++            trace_stack(&cap->upd_rem_set.queue, stack);
+             finish_upd_rem_set_mark((StgClosure *) stack);
+             return;
+         } else {
+@@ -941,7 +941,7 @@ markQueueLength (MarkQueue *q)
+  * any outstanding transactions.
+  */
+ static void
+-mark_trec_chunk (MarkQueue *queue, StgTRecChunk *chunk)
++trace_trec_chunk (MarkQueue *queue, StgTRecChunk *chunk)
+ {
+     markQueuePushClosure_(queue, (StgClosure *) chunk);
+     for (StgWord i=0; i < chunk->next_entry_idx; i++) {
+@@ -953,13 +953,13 @@ mark_trec_chunk (MarkQueue *queue, StgTRecChunk *chunk)
+ }
+ 
+ static void
+-mark_trec_header (MarkQueue *queue, StgTRecHeader *trec)
++trace_trec_header (MarkQueue *queue, StgTRecHeader *trec)
+ {
+     while (trec != NO_TREC) {
+         StgTRecChunk *chunk = trec->current_chunk;
+         markQueuePushClosure_(queue, (StgClosure *) trec);
+         while (chunk != END_STM_CHUNK_LIST) {
+-            mark_trec_chunk(queue, chunk);
++            trace_trec_chunk(queue, chunk);
+             chunk = chunk->prev_chunk;
+         }
+         trec = trec->enclosing_trec;
+@@ -967,7 +967,7 @@ mark_trec_header (MarkQueue *queue, StgTRecHeader *trec)
+ }
+ 
+ static void
+-mark_tso (MarkQueue *queue, StgTSO *tso)
++trace_tso (MarkQueue *queue, StgTSO *tso)
+ {
+     // TODO: Clear dirty if contains only old gen objects
+ 
+@@ -977,7 +977,7 @@ mark_tso (MarkQueue *queue, StgTSO *tso)
+ 
+     markQueuePushClosure_(queue, (StgClosure *) tso->blocked_exceptions);
+     markQueuePushClosure_(queue, (StgClosure *) tso->bq);
+-    mark_trec_header(queue, tso->trec);
++    trace_trec_header(queue, tso->trec);
+     markQueuePushClosure_(queue, (StgClosure *) tso->stackobj);
+     markQueuePushClosure_(queue, (StgClosure *) tso->_link);
+     if (   tso->why_blocked == BlockedOnMVar
+@@ -999,16 +999,16 @@ do_push_closure (StgClosure **p, void *user)
+ }
+ 
+ static void
+-mark_large_bitmap (MarkQueue *queue,
+-                   StgClosure **p,
+-                   StgLargeBitmap *large_bitmap,
+-                   StgWord size)
++trace_large_bitmap (MarkQueue *queue,
++                    StgClosure **p,
++                    StgLargeBitmap *large_bitmap,
++                    StgWord size)
+ {
+     walk_large_bitmap(do_push_closure, p, large_bitmap, size, queue);
+ }
+ 
+ static void
+-mark_small_bitmap (MarkQueue *queue, StgClosure **p, StgWord size, StgWord bitmap)
++trace_small_bitmap (MarkQueue *queue, StgClosure **p, StgWord size, StgWord bitmap)
+ {
+     while (size > 0) {
+         if ((bitmap & 1) == 0) {
+@@ -1022,10 +1022,10 @@ mark_small_bitmap (MarkQueue *queue, StgClosure **p, StgWord size, StgWord bitma
+ }
+ 
+ static GNUC_ATTR_HOT
+-void mark_PAP_payload (MarkQueue *queue,
+-                       StgClosure *fun,
+-                       StgClosure **payload,
+-                       StgWord size)
++void trace_PAP_payload (MarkQueue *queue,
++                        StgClosure *fun,
++                        StgClosure **payload,
++                        StgWord size)
+ {
+     const StgFunInfoTable *fun_info = get_fun_itbl(UNTAG_CONST_CLOSURE(fun));
+     ASSERT(fun_info->i.type != PAP);
+@@ -1037,20 +1037,20 @@ void mark_PAP_payload (MarkQueue *queue,
+         bitmap = BITMAP_BITS(fun_info->f.b.bitmap);
+         goto small_bitmap;
+     case ARG_GEN_BIG:
+-        mark_large_bitmap(queue, payload, GET_FUN_LARGE_BITMAP(fun_info), size);
++        trace_large_bitmap(queue, payload, GET_FUN_LARGE_BITMAP(fun_info), size);
+         break;
+     case ARG_BCO:
+-        mark_large_bitmap(queue, payload, BCO_BITMAP(fun), size);
++        trace_large_bitmap(queue, payload, BCO_BITMAP(fun), size);
+         break;
+     default:
+         bitmap = BITMAP_BITS(stg_arg_bitmaps[fun_info->f.fun_type]);
+     small_bitmap:
+-        mark_small_bitmap(queue, (StgClosure **) p, size, bitmap);
++        trace_small_bitmap(queue, (StgClosure **) p, size, bitmap);
+         break;
+     }
+ }
+ 
+-/* Helper for mark_stack; returns next stack frame. */
++/* Helper for trace_stack; returns next stack frame. */
+ static StgPtr
+ mark_arg_block (MarkQueue *queue, const StgFunInfoTable *fun_info, StgClosure **args)
+ {
+@@ -1064,14 +1064,14 @@ mark_arg_block (MarkQueue *queue, const StgFunInfoTable *fun_info, StgClosure **
+         goto small_bitmap;
+     case ARG_GEN_BIG:
+         size = GET_FUN_LARGE_BITMAP(fun_info)->size;
+-        mark_large_bitmap(queue, (StgClosure**)p, GET_FUN_LARGE_BITMAP(fun_info), size);
++        trace_large_bitmap(queue, (StgClosure**)p, GET_FUN_LARGE_BITMAP(fun_info), size);
+         p += size;
+         break;
+     default:
+         bitmap = BITMAP_BITS(stg_arg_bitmaps[fun_info->f.fun_type]);
+         size = BITMAP_SIZE(stg_arg_bitmaps[fun_info->f.fun_type]);
+     small_bitmap:
+-        mark_small_bitmap(queue, (StgClosure**)p, size, bitmap);
++        trace_small_bitmap(queue, (StgClosure**)p, size, bitmap);
+         p += size;
+         break;
+     }
+@@ -1079,7 +1079,7 @@ mark_arg_block (MarkQueue *queue, const StgFunInfoTable *fun_info, StgClosure **
+ }
+ 
+ static GNUC_ATTR_HOT void
+-mark_stack_ (MarkQueue *queue, StgPtr sp, StgPtr spBottom)
++trace_stack_ (MarkQueue *queue, StgPtr sp, StgPtr spBottom)
+ {
+     ASSERT(sp <= spBottom);
+ 
+@@ -1109,7 +1109,7 @@ mark_stack_ (MarkQueue *queue, StgPtr sp, StgPtr spBottom)
+             // NOTE: the payload starts immediately after the info-ptr, we
+             // don't have an StgHeader in the same sense as a heap closure.
+             sp++;
+-            mark_small_bitmap(queue, (StgClosure **) sp, size, bitmap);
++            trace_small_bitmap(queue, (StgClosure **) sp, size, bitmap);
+             sp += size;
+         }
+         follow_srt:
+@@ -1124,7 +1124,7 @@ mark_stack_ (MarkQueue *queue, StgPtr sp, StgPtr spBottom)
+             StgBCO *bco = (StgBCO *)*sp;
+             sp++;
+             StgWord size = BCO_BITMAP_SIZE(bco);
+-            mark_large_bitmap(queue, (StgClosure **) sp, BCO_BITMAP(bco), size);
++            trace_large_bitmap(queue, (StgClosure **) sp, BCO_BITMAP(bco), size);
+             sp += size;
+             continue;
+         }
+@@ -1136,7 +1136,7 @@ mark_stack_ (MarkQueue *queue, StgPtr sp, StgPtr spBottom)
+ 
+             size = GET_LARGE_BITMAP(&info->i)->size;
+             sp++;
+-            mark_large_bitmap(queue, (StgClosure **) sp, GET_LARGE_BITMAP(&info->i), size);
++            trace_large_bitmap(queue, (StgClosure **) sp, GET_LARGE_BITMAP(&info->i), size);
+             sp += size;
+             // and don't forget to follow the SRT
+             goto follow_srt;
+@@ -1154,17 +1154,17 @@ mark_stack_ (MarkQueue *queue, StgPtr sp, StgPtr spBottom)
+         }
+ 
+         default:
+-            barf("mark_stack: weird activation record found on stack: %d", (int)(info->i.type));
++            barf("trace_stack: weird activation record found on stack: %d", (int)(info->i.type));
+         }
+     }
+ }
+ 
+ static GNUC_ATTR_HOT void
+-mark_stack (MarkQueue *queue, StgStack *stack)
++trace_stack (MarkQueue *queue, StgStack *stack)
+ {
+     // TODO: Clear dirty if contains only old gen objects
+ 
+-    mark_stack_(queue, stack->sp, stack->stack + stack->stack_size);
++    trace_stack_(queue, stack->sp, stack->stack + stack->stack_size);
+ }
+ 
+ /* See Note [Static objects under the nonmoving collector].
+@@ -1532,21 +1532,21 @@ mark_closure (MarkQueue *queue, const StgClosure *p0, StgClosure **origin)
+     case AP_STACK: {
+         StgAP_STACK *ap = (StgAP_STACK *)p;
+         PUSH_FIELD(ap, fun);
+-        mark_stack_(queue, (StgPtr) ap->payload, (StgPtr) ap->payload + ap->size);
++        trace_stack_(queue, (StgPtr) ap->payload, (StgPtr) ap->payload + ap->size);
+         break;
+     }
+ 
+     case PAP: {
+         StgPAP *pap = (StgPAP *) p;
+         PUSH_FIELD(pap, fun);
+-        mark_PAP_payload(queue, pap->fun, pap->payload, pap->n_args);
++        trace_PAP_payload(queue, pap->fun, pap->payload, pap->n_args);
+         break;
+     }
+ 
+     case AP: {
+         StgAP *ap = (StgAP *) p;
+         PUSH_FIELD(ap, fun);
+-        mark_PAP_payload(queue, ap->fun, ap->payload, ap->n_args);
++        trace_PAP_payload(queue, ap->fun, ap->payload, ap->n_args);
+         break;
+     }
+ 
+@@ -1574,7 +1574,7 @@ mark_closure (MarkQueue *queue, const StgClosure *p0, StgClosure **origin)
+     }
+ 
+     case TSO:
+-        mark_tso(queue, (StgTSO *) p);
++        trace_tso(queue, (StgTSO *) p);
+         break;
+ 
+     case STACK: {
+@@ -1587,7 +1587,7 @@ mark_closure (MarkQueue *queue, const StgClosure *p0, StgClosure **origin)
+         if (cas_word8(&stack->marking, marking, nonmovingMarkEpoch)
+               != nonmovingMarkEpoch) {
+             // We have claimed the right to mark the stack.
+-            mark_stack(queue, stack);
++            trace_stack(queue, stack);
+         } else {
+             // A mutator has already started marking the stack; we just let it
+             // do its thing and move on. There's no reason to wait; we know that
+@@ -1608,7 +1608,7 @@ mark_closure (MarkQueue *queue, const StgClosure *p0, StgClosure **origin)
+     }
+ 
+     case TREC_CHUNK:
+-        // N.B. chunk contents are deeply marked by mark_trec_header
++        // N.B. chunk contents are deeply marked by trace_trec_header
+         break;
+ 
+     case WHITEHOLE:
+-- 
+2.33.1
+
+
+From 452b4f555a69a51e7d28f2c45c217c083cc3ec25 Mon Sep 17 00:00:00 2001
+From: Ben Gamari <ben@smart-cactus.org>
+Date: Fri, 24 Sep 2021 08:40:40 -0400
+Subject: [PATCH 3/4] rts/primops: Fix write barrier in
+ stg_atomicModifyMutVarzuzh
+
+Previously the call to dirty_MUT_VAR in stg_atomicModifyMutVarzuzh was
+missing its final argument.
+
+Fixes #20414.
+
+(cherry picked from commit 2c02ea8dc33fe008675b1c0629c0ffb0e8ca4482)
+---
+ rts/PrimOps.cmm | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/rts/PrimOps.cmm b/rts/PrimOps.cmm
+index 1bf5b4adae..e97187fe29 100644
+--- a/rts/PrimOps.cmm
++++ b/rts/PrimOps.cmm
+@@ -625,7 +625,7 @@ stg_casMutVarzh ( gcptr mv, gcptr old, gcptr new )
+         return (1,h);
+     } else {
+         if (GET_INFO(mv) == stg_MUT_VAR_CLEAN_info) {
+-            ccall dirty_MUT_VAR(BaseReg "ptr", mv "ptr", old);
++            ccall dirty_MUT_VAR(BaseReg "ptr", mv "ptr", old "ptr");
+         }
+         return (0,new);
+     }
+@@ -638,7 +638,7 @@ stg_casMutVarzh ( gcptr mv, gcptr old, gcptr new )
+     } else {
+         StgMutVar_var(mv) = new;
+         if (GET_INFO(mv) == stg_MUT_VAR_CLEAN_info) {
+-            ccall dirty_MUT_VAR(BaseReg "ptr", mv "ptr", old);
++            ccall dirty_MUT_VAR(BaseReg "ptr", mv "ptr", old "ptr");
+         }
+         return (0,new);
+     }
+@@ -710,7 +710,7 @@ stg_atomicModifyMutVar2zh ( gcptr mv, gcptr f )
+ #endif
+ 
+     if (GET_INFO(mv) == stg_MUT_VAR_CLEAN_info) {
+-        ccall dirty_MUT_VAR(BaseReg "ptr", mv "ptr", h);
++        ccall dirty_MUT_VAR(BaseReg "ptr", mv "ptr", h "ptr");
+     }
+ 
+     return (x,z);
+@@ -762,7 +762,7 @@ stg_atomicModifyMutVarzuzh ( gcptr mv, gcptr f )
+ #endif
+ 
+     if (GET_INFO(mv) == stg_MUT_VAR_CLEAN_info) {
+-        ccall dirty_MUT_VAR(BaseReg "ptr", mv "ptr");
++        ccall dirty_MUT_VAR(BaseReg "ptr", mv "ptr", x "ptr");
+     }
+ 
+     return (x,z);
+-- 
+2.33.1
+
+
+From a3db355edd2fe7e44e66624bab22551e901128d6 Mon Sep 17 00:00:00 2001
+From: Ben Gamari <ben@smart-cactus.org>
+Date: Fri, 24 Sep 2021 16:46:56 -0400
+Subject: [PATCH 4/4] rts/nonmoving: Enable selector optimisation by default
+
+(cherry picked from commit 2e0c13ab50b28d3e2ad5bfeed2b6651096921c9d)
+---
+ includes/rts/Flags.h   | 2 --
+ rts/RtsFlags.c         | 5 -----
+ rts/sm/NonMovingMark.c | 6 +-----
+ 3 files changed, 1 insertion(+), 12 deletions(-)
+
+diff --git a/includes/rts/Flags.h b/includes/rts/Flags.h
+index 37f1253501..76a3c512d2 100644
+--- a/includes/rts/Flags.h
++++ b/includes/rts/Flags.h
+@@ -53,8 +53,6 @@ typedef struct _GC_FLAGS {
+     double  pcFreeHeap;
+ 
+     bool         useNonmoving; // default = false
+-    bool         nonmovingSelectorOpt; // Do selector optimization in the
+-                                       // non-moving heap, default = false
+     uint32_t     generations;
+     bool squeezeUpdFrames;
+ 
+diff --git a/rts/RtsFlags.c b/rts/RtsFlags.c
+index 4361de8641..e56640f714 100644
+--- a/rts/RtsFlags.c
++++ b/rts/RtsFlags.c
+@@ -157,7 +157,6 @@ void initRtsFlagsDefaults(void)
+     RtsFlags.GcFlags.pcFreeHeap         = 3;    /* 3% */
+     RtsFlags.GcFlags.oldGenFactor       = 2;
+     RtsFlags.GcFlags.useNonmoving       = false;
+-    RtsFlags.GcFlags.nonmovingSelectorOpt = false;
+     RtsFlags.GcFlags.generations        = 2;
+     RtsFlags.GcFlags.squeezeUpdFrames   = true;
+     RtsFlags.GcFlags.compact            = false;
+@@ -1587,10 +1586,6 @@ error = true;
+                     OPTION_SAFE;
+                     RtsFlags.GcFlags.useNonmoving = true;
+                     unchecked_arg_start++;
+-                    if (rts_argv[arg][3] == 's') {
+-                        RtsFlags.GcFlags.nonmovingSelectorOpt = true;
+-                        unchecked_arg_start++;
+-                    }
+                     break;
+ 
+                 case 'c': /* Debugging tool: show current cost centre on
+diff --git a/rts/sm/NonMovingMark.c b/rts/sm/NonMovingMark.c
+index ee9b3d89eb..7ef4d0c0e5 100644
+--- a/rts/sm/NonMovingMark.c
++++ b/rts/sm/NonMovingMark.c
+@@ -1522,11 +1522,7 @@ mark_closure (MarkQueue *queue, const StgClosure *p0, StgClosure **origin)
+     }
+ 
+     case THUNK_SELECTOR:
+-        if (RtsFlags.GcFlags.nonmovingSelectorOpt) {
+-            nonmoving_eval_thunk_selector(queue, (StgSelector*)p, origin);
+-        } else {
+-            PUSH_FIELD((StgSelector *) p, selectee);
+-        }
++        nonmoving_eval_thunk_selector(queue, (StgSelector*)p, origin);
+         break;
+ 
+     case AP_STACK: {
+-- 
+2.33.1
+

--- a/overlays/patches/ghc/MR6617-nonmoving-mvar.patch
+++ b/overlays/patches/ghc/MR6617-nonmoving-mvar.patch
@@ -1,0 +1,174 @@
+From 2bcb79d44adbc07095f5e1506b7f918dc348ef40 Mon Sep 17 00:00:00 2001
+From: Ben Gamari <ben@smart-cactus.org>
+Date: Thu, 30 Sep 2021 15:52:59 +0000
+Subject: [PATCH 1/2] rts: Unify stack dirtiness check
+
+This fixes an inconsistency where one dirtiness check would not mask out
+the STACK_DIRTY flag, meaning it may also be affected by the STACK_SANE
+flag.
+
+(cherry picked from commit 23f11efb9a59f99a1d4c7e4cd1955259fcaeb549)
+---
+ includes/Cmm.h  |   6 +-
+ rts/PrimOps.cmm | 247 ++++++++++++++++++++++++++++++++++++++++++++++--
+ 2 files changed, 242 insertions(+), 11 deletions(-)
+
+diff --git a/includes/Cmm.h b/includes/Cmm.h
+index e53ed4b227..789461a9f4 100644
+--- a/includes/Cmm.h
++++ b/includes/Cmm.h
+@@ -633,6 +633,9 @@
+ #define OVERWRITING_CLOSURE_OFS(c,n) /* nothing */
+ #endif
+ 
++#define IS_STACK_CLEAN(stack) \
++    ((TO_W_(StgStack_dirty(stack)) & STACK_DIRTY) == 0)
++
+ // Memory barriers.
+ // For discussion of how these are used to fence heap object
+ // accesses see Note [Heap memory barriers] in SMP.h.
+@@ -773,9 +776,6 @@
+       __gen = TO_W_(bdescr_gen_no(__bd));                       \
+       if (__gen > 0) { recordMutableCap(__p, __gen); }
+ 
+-/* -----------------------------------------------------------------------------
+-   Update remembered set write barrier
+-   -------------------------------------------------------------------------- */
+ 
+ /* -----------------------------------------------------------------------------
+    Arrays
+diff --git a/rts/PrimOps.cmm b/rts/PrimOps.cmm
+index e97187fe29..3c948f94a7 100644
+--- a/rts/PrimOps.cmm
++++ b/rts/PrimOps.cmm
+@@ -1852,15 +1852,14 @@ loop:
+     // actually perform the takeMVar
+     W_ stack;
+     stack = StgTSO_stackobj(tso);
++    if (IS_STACK_CLEAN(stack)) {
++        ccall dirty_STACK(MyCapability() "ptr", stack "ptr");
++    }
+     PerformTake(stack, val);
+ 
+     // indicate that the MVar operation has now completed.
+     StgTSO__link(tso) = stg_END_TSO_QUEUE_closure;
+ 
+-    if ((TO_W_(StgStack_dirty(stack)) & STACK_DIRTY) == 0) {
+-        ccall dirty_STACK(MyCapability() "ptr", stack "ptr");
+-    }
+-
+     ccall tryWakeupThread(MyCapability() "ptr", tso);
+ 
+     // If it was a readMVar, then we can still do work,
+@@ -1943,15 +1942,14 @@ loop:
+     // actually perform the takeMVar
+     W_ stack;
+     stack = StgTSO_stackobj(tso);
++    if (IS_STACK_CLEAN(stack)) {
++        ccall dirty_STACK(MyCapability() "ptr", stack "ptr");
++    }
+     PerformTake(stack, val);
+ 
+     // indicate that the MVar operation has now completed.
+     StgTSO__link(tso) = stg_END_TSO_QUEUE_closure;
+ 
+-    if ((TO_W_(StgStack_dirty(stack)) & STACK_DIRTY) == 0) {
+-        ccall dirty_STACK(MyCapability() "ptr", stack "ptr");
+-    }
+-
+     ccall tryWakeupThread(MyCapability() "ptr", tso);
+ 
+     // If it was a readMVar, then we can still do work,
+-- 
+2.33.1
+
+
+From a3a5b05ef182f8b641e82c190445ae893e1d7384 Mon Sep 17 00:00:00 2001
+From: Ben Gamari <ben@well-typed.com>
+Date: Tue, 28 Sep 2021 20:53:26 +0000
+Subject: [PATCH 2/2] rts: Add missing write barriers in MVar wake-up paths
+
+Previously PerformPut failed to respect the non-moving collector's
+snapshot invariant, hiding references to an MVar and its new value by
+overwriting a stack frame without dirtying the stack. Fix this.
+
+PerformTake exhibited a similar bug, failing to dirty (and therefore
+mark) the blocked stack before mutating it.
+
+Closes #20399.
+
+(cherry picked from commit 801978bdfbe635a76e474ea32fd3da83b59325d1)
+---
+ rts/PrimOps.cmm    | 24 ++++++++++++++++++++++++
+ rts/sm/NonMoving.c |  4 ++++
+ 2 files changed, 28 insertions(+)
+
+diff --git a/rts/PrimOps.cmm b/rts/PrimOps.cmm
+index 3c948f94a7..116d6d0520 100644
+--- a/rts/PrimOps.cmm
++++ b/rts/PrimOps.cmm
+@@ -1545,6 +1545,23 @@ stg_writeTVarzh (P_ tvar,     /* :: TVar a */
+  * exception and never perform its take or put, and we'd end up with a
+  * deadlock.
+  *
++ * Note [Nonmoving write barrier in Perform{Take,Put}]
++ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++ * As noted in Note [Non-moving garbage collector] in NonMoving.c, the
++ * non-moving GC requires that all overwritten pointers be pushed to the update
++ * remembered set. In the case of stack mutation this typically happens by
++ * "dirtying" the stack, which eagerly traces the entire stack chunk.
++ *
++ * An exception to this rule is PerformPut, which mutates the stack of a
++ * blocked thread (overwriting an stg_block_putmvar frame). To ensure that the
++ * collector sees the MVar and value reachable from the overwritten frame, we
++ * must push them to the update remembered set. Failing to do so was the cause
++ * of #20399.
++ *
++ * Note that unlike PerformPut, the callers of PerformTake first dirty the
++ * stack prior mutating it (since they introduce a *new*, potentially
++ * inter-generational reference to the stack) and therefore the barrier
++ * described above is unnecessary in this case.
+  * -------------------------------------------------------------------------- */
+ 
+ stg_isEmptyMVarzh ( P_ mvar /* :: MVar a */ )
+@@ -1573,15 +1590,22 @@ stg_newMVarzh ()
+ }
+ 
+ 
++// See Note [Nonmoving write barrier in Perform{Put,Take}].
++// Precondition: the stack must be dirtied.
+ #define PerformTake(stack, value)               \
+     W_ sp;                                      \
+     sp = StgStack_sp(stack);                    \
+     W_[sp + WDS(1)] = value;                    \
+     W_[sp + WDS(0)] = stg_ret_p_info;
+ 
++// See Note [Nonmoving write barrier in Perform{Put,Take}].
+ #define PerformPut(stack,lval)                  \
+     W_ sp;                                      \
+     sp = StgStack_sp(stack) + WDS(3);           \
++    IF_NONMOVING_WRITE_BARRIER_ENABLED {        \
++      ccall updateRemembSetPushClosure_(BaseReg "ptr", W_[sp - WDS(1)] "ptr"); \
++      ccall updateRemembSetPushClosure_(BaseReg "ptr", W_[sp - WDS(2)] "ptr"); \
++    }                                           \
+     StgStack_sp(stack) = sp;                    \
+     lval = W_[sp - WDS(1)];
+ 
+diff --git a/rts/sm/NonMoving.c b/rts/sm/NonMoving.c
+index 99fd9c1ece..5971cbac20 100644
+--- a/rts/sm/NonMoving.c
++++ b/rts/sm/NonMoving.c
+@@ -229,6 +229,10 @@ Mutex concurrent_coll_finished_lock;
+  *  - Note [StgStack dirtiness flags and concurrent marking] (TSO.h) describes
+  *    the protocol for concurrent marking of stacks.
+  *
++ *  - Note [Nonmoving write barrier in Perform{Take,Put}] (PrimOps.cmm) describes
++ *    a tricky barrier necessary when resuming threads blocked on MVar
++ *    operations.
++ *
+  *  - Note [Static objects under the nonmoving collector] (Storage.c) describes
+  *    treatment of static objects.
+  *
+-- 
+2.33.1
+

--- a/overlays/patches/ghc/MR6654-nonmoving-maxmem.patch
+++ b/overlays/patches/ghc/MR6654-nonmoving-maxmem.patch
@@ -1,0 +1,31 @@
+From 878e265680651be374effe4adcd5753f92eb2704 Mon Sep 17 00:00:00 2001
+From: Teo Camarasu <teofilcamarasu@gmail.com>
+Date: Mon, 4 Oct 2021 11:40:51 +0100
+Subject: [PATCH] fix non-moving gc heap space requirements estimate
+
+The space requirements of the non-moving gc are comparable to the
+compacting gc, not the copying gc.
+
+The copying gc requires a much larger overhead.
+
+Fixes #20475
+---
+ rts/sm/GC.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rts/sm/GC.c b/rts/sm/GC.c
+index 90a5164414..1799cf98c4 100644
+--- a/rts/sm/GC.c
++++ b/rts/sm/GC.c
+@@ -1963,7 +1963,7 @@ resizeGenerations (void)
+             heapOverflow();
+         }
+ 
+-        if (oldest_gen->compact) {
++        if (oldest_gen->compact || RtsFlags.GcFlags.useNonmoving) {
+             if ( (size + (size - 1) * (gens - 2) * 2) + min_alloc > max ) {
+                 size = (max - min_alloc) / ((gens - 1) * 2 - 1);
+             }
+-- 
+2.33.1
+


### PR DESCRIPTION
This adds some fixes for the non-moving gc that have been backported to the 8.10 branch. One of them avoids seg-faults when using the non-moving garbage collector with MVars.

I've tested that ghc-8.10.7 builds and works with this patch applied, but haven't tested any of the other releases in the 8.10 line