### PR TITLE
Patched GHCJS 8.10

### DIFF
--- a/compiler/ghcjs/ghcjs.nix
+++ b/compiler/ghcjs/ghcjs.nix
@@ -7,6 +7,7 @@
   then "ghc884"
   else "ghc865"
 , ghc ? pkgs.buildPackages.ghc
+, overrideBootPackages ? [] # adds if not present, overrides if present.
 }:
 let
     isGhcjs88 = builtins.compareVersions ghcjsVersion "8.8.0.0" >= 0;
@@ -14,8 +15,14 @@ let
 
     project = pkgs.buildPackages.haskell-nix.ghcjsProject {
         src = ghcjsSrc;
-        inherit ghcjsVersion compiler-nix-name;
+        inherit ghcjsVersion compiler-nix-name overrideBootPackages;
         index-state = "2020-04-25T00:00:00Z";
+        patches = if isGhcjs810 
+          then [
+            ./patches/810/fast-weak.patch 
+            ./patches/810/boot-optimization-flags.patch
+            ] 
+          else [];
 #        plan-sha256 = "1wy2lr08maxyi7r8jiwf2gj6pdayk5vxxwh42bj4s2gg4035z0yc";
 #        materialized = ../../materialized/ghcjs;
     };

--- a/compiler/ghcjs/ghcjs810-patched-boot-packages/aeson.patch
+++ b/compiler/ghcjs/ghcjs810-patched-boot-packages/aeson.patch
@@ -1,0 +1,13 @@
+diff --git a/aeson.cabal b/aeson.cabal
+index a0ebd59..552f160 100755
+--- a/aeson.cabal
++++ b/aeson.cabal
+@@ -150,7 +150,7 @@ library
+     dlist                >= 0.8.0.4  && < 0.9,
+     hashable             >= 1.2.7.0  && < 1.4,
+     scientific           >= 0.3.6.2  && < 0.4,
+-    th-abstraction       >= 0.2.8.0  && < 0.4,
++    th-abstraction       >= 0.2.8.0  && < 0.5,
+     uuid-types           >= 1.0.3    && < 1.1,
+     vector               >= 0.12.0.1 && < 0.13
+ 

--- a/compiler/ghcjs/ghcjs810-patched-boot-packages/default.nix
+++ b/compiler/ghcjs/ghcjs810-patched-boot-packages/default.nix
@@ -1,0 +1,176 @@
+{ pkgs
+, ...
+}:
+let
+  patch = p: path: pkgs.runCommand "patched" { buildInputs = [ pkgs.gnupatch ]; } ''
+    cp -r ${path} $out
+    chmod -R +w $out
+    cd $out
+    patch -p1 <${p}
+  '';
+  getSubdir = d: path: pkgs.runCommand "subdir" { } ''
+    cp -r ${path}/${d} $out
+  '';
+in
+[
+  {
+    name = "primitive";
+    src = pkgs.fetchgit {
+      url = "https://github.com/haskell/primitive.git";
+      rev = "11ff865fd2157a1dfd7dfd525b1cf27e1a300633";
+      sha256 = "1skim1vlmf0v4ixm8h8ja3m1pz0h10xrfdh1rfzawsy8rvrp2cc0";
+    };
+  }
+  {
+    name = "dlist";
+    src = pkgs.fetchgit {
+      url = "https://github.com/spl/dlist.git";
+      rev = "567cfeb2f5da30f2e5faf167895b3ee04c698ca0";
+      sha256 = "0b8ij3ls7bccbp9rlm8dnflnf1wim9xsg42wmirvwxwmh2c0r0hg";
+    };
+  }
+  {
+    name = "vector";
+    src = pkgs.fetchgit {
+      url = "https://github.com/haskell/vector.git";
+      rev = "de10fd281fa5d8beee3623e809a71385a5ef6864";
+      sha256 = "09vhbvrkw90xgqfrybmhy120rwcy4snw2f97004alr3n96lwpg1q";
+    };
+  }
+  {
+    name = "ghcjs-base";
+    src = patch ./ghcjs-base.patch (pkgs.fetchgit {
+      url = "https://github.com/ghcjs/ghcjs-base.git";
+      rev = "85e31beab9beffc3ea91b954b61a5d04e708b8f2";
+      sha256 = "15fdkjv0l7hpbbsn5238xxgzfdg61g666nzbv2sgxkwryn5rycv0";
+    });
+  }
+  {
+    name = "text";
+    src = pkgs.fetchgit {
+      url = "https://github.com/dfordivam/text.git";
+      rev = "126174753ea8e5f45df8fcbba609e3f1c453bf27";
+      sha256 = "0l7nbln2w77s12fm4ybhi0jsfnxkyiwskfx3b682pfisa6n32rgm";
+    };
+  }
+  {
+    name = "hashable";
+    src = patch ./hashable.patch (pkgs.fetchgit {
+      url = "https://github.com/haskell-unordered-containers/hashable.git";
+      rev = "819fdbeaeeb62ed1344fb057de17fa29b10fa3e1";
+      sha256 = "0xnwfwnnh0bxq16wx0qmdakvgvj8i22km3bhvvki15rd9jil04cc";
+    });
+  }
+  {
+    name = "integer-logarithms";
+    src = pkgs.fetchgit {
+      url = "https://github.com/haskellari/integer-logarithms.git";
+      rev = "df09cef2c8eb0d5899e2bcccee2a4fad413bdc11";
+      sha256 = "1k17hjnjmy44dfywx9nr804qiqmjjhkpfpll5bsfvzvpnl5r75nj";
+    };
+  }
+  {
+    name = "scientific";
+    src = pkgs.fetchgit {
+      url = "https://github.com/basvandijk/scientific.git";
+      rev = "1d049cdf04e2d92ab187754044b0df933c5e6b0d";
+      sha256 = "1v4fmfq8hyhdb5ck5r2b45s1izr7hx97v4g7s597ajbv72ldvilq";
+    };
+  }
+  {
+    name = "attoparsec";
+    src = pkgs.fetchgit {
+      url = "https://github.com/dfordivam/attoparsec.git";
+      rev = "cbfb944aeff61144059a28ada93c579e93ccf7d2";
+      sha256 = "0bbr4943439sy3grwpwbna4mk7iv87ijaiv3jjfhxhp7y67z51h8";
+    };
+  }
+  {
+    name = "splitmix";
+    src = pkgs.fetchgit {
+      url = "https://github.com/haskellari/splitmix.git";
+      rev = "d8c1b57bb75178675423f87b1ff58429f37bc9fe";
+      sha256 = "1m8v439vlwqpqw28dbr04n6m0j2cfb169ly285lp0bjmzcwlr289";
+    };
+  }
+  {
+    name = "random";
+    src = pkgs.fetchgit {
+      url = "https://github.com/haskell/random.git";
+      rev = "8c59bd0fda84fa581d53069b45100d810f5a778f";
+      sha256 = "1drdipfbmpg2g2cdrnq1k8yysh86i7ljwm6zkrrs3g8l47n4ha4d";
+    };
+  }
+  {
+    name = "uuid-types";
+    src = getSubdir "uuid-types" (pkgs.fetchgit {
+      url = "https://github.com/haskell-hvr/uuid.git";
+      rev = "e8dc7126582ba4d3abc5e0f26dc1d8477caab01e";
+      sha256 = "037cnfz7rhkw383rn117b994jzs93i3bwdv47x5qiza5h5syd76f";
+    });
+  }
+  {
+    name = "unordered-containers";
+    src = pkgs.fetchgit {
+      url = "https://github.com/haskell-unordered-containers/unordered-containers.git";
+      rev = "db9ddde2b243366976a1bdfbb12a5e257ca762c3";
+      sha256 = "1wd5hxppj1gg9fa1ihcn3s2y0i70ykv2sf8sym6dlf3r4snda9zi";
+    };
+  }
+  {
+    name = "base-orphans";
+    src = pkgs.fetchgit {
+      url = "https://github.com/haskell-compat/base-orphans.git";
+      rev = "1af3a3512efbcc12e0c34637a0e433ab6e195932";
+      sha256 = "14b6qwc3dbnmrhqk66a2cn4pvv3nf6kb3h7ym1hjn5xs7n62zhw1";
+    };
+  }
+  {
+    name = "time-compat";
+    src = pkgs.fetchgit {
+      url = "https://github.com/haskellari/time-compat.git";
+      rev = "67b8b063295601fb1db185baad363a3f33ed63a9";
+      sha256 = "0nbjsn7yrygv4i1fd8x90mnf4janq536ffvkjd5zsnyzm8qk8k3j";
+    };
+  }
+  {
+    name = "th-abstraction";
+    src = pkgs.fetchgit {
+      url = "https://github.com/glguy/th-abstraction.git";
+      rev = "d75761bc5a0f912aeeb508e2c227b9fd830153fd";
+      sha256 = "070ihxncymzsbrgvwmrm717n0qq5bf9nvc2k210nkil1cwrsnhvc";
+    };
+  }
+  {
+    name = "tagged";
+    src = pkgs.fetchgit {
+      url = "https://github.com/ekmett/tagged.git";
+      rev = "15fcfe90c779efea951ecf4d451d709aed5f7d32";
+      sha256 = "1x1wr4zf7k1kvd6rj06h9shw7p5di1jra9fysyw0jx7riiq0v3ch";
+    };
+  }
+  {
+    name = "base-compat";
+    src = getSubdir "base-compat" (pkgs.fetchgit {
+      url = "https://github.com/haskell-compat/base-compat.git";
+      rev = "e8dbac72251e898fc4b1c1abb34d6578da12f476";
+      sha256 = "1gs15g8h7p8gab9j5fjvjlhrfv112w91plraf9chq80c5slvk016";
+    });
+  }
+  {
+    name = "base-compat-batteries";
+    src = getSubdir "base-compat-batteries" (pkgs.fetchgit {
+      url = "https://github.com/haskell-compat/base-compat.git";
+      rev = "e8dbac72251e898fc4b1c1abb34d6578da12f476";
+      sha256 = "1gs15g8h7p8gab9j5fjvjlhrfv112w91plraf9chq80c5slvk016";
+    });
+  }
+  {
+    name = "aeson";
+    src = patch ./aeson.patch (pkgs.fetchgit {
+      url = "https://github.com/dfordivam/aeson.git";
+      rev = "9a8f57a52eb748a030bc2bcf5c3159a5e2e696b2";
+      sha256 = "1y8j3ddxxddpnb7c0vi73ijb08sr09z1gdzfg1rfyzn82d6i38zv";
+    });
+  }
+]

--- a/compiler/ghcjs/ghcjs810-patched-boot-packages/ghcjs-base.patch
+++ b/compiler/ghcjs/ghcjs810-patched-boot-packages/ghcjs-base.patch
@@ -1,0 +1,471 @@
+diff --git a/Data/JSString.hs b/Data/JSString.hs
+index 176aad4..9ca6693 100644
+--- a/Data/JSString.hs
++++ b/Data/JSString.hs
+@@ -99,6 +99,7 @@ module Data.JSString ( JSString
+                      , breakOnEnd
+                      , break
+                      , span
++                     , span_
+                      , group
+                      , group'
+                      , groupBy
+@@ -1231,19 +1232,23 @@ splitAt (I# n) x = case js_splitAt n x of (# y, z #) -> (y, z)
+ -- of @t@ of elements that satisfy @p@, and whose second is the
+ -- remainder of the list.
+ span :: (Char -> Bool) -> JSString -> (JSString, JSString)
+-span p x = case js_length x of
+-            0# -> (empty, empty)
+-            l  -> let c0 = js_uncheckedIndex 0# x
+-                  in if p (C# (chr# c0)) then loop 0# l else (empty, x)
++span p x = let (# a, b #) = span_ p x in (a, b)
++{-# INLINE span #-}
++
++span_ :: (Char -> Bool) -> JSString -> (# JSString, JSString #)
++span_ p x = case js_length x of
++              0# -> (# empty, empty #)
++              l  -> let c0 = js_uncheckedIndex 0# x
++                    in if p (C# (chr# c0)) then loop 0# l else (# empty, x #)
+   where
+     loop i l
+-      | isTrue# (i >=# l) = (x, empty)
++      | isTrue# (i >=# l) = (# x, empty #)
+       | otherwise         =
+           let c = js_uncheckedIndex i x
+           in  if p (C# (chr# c))
+               then loop (i +# charWidth c) l
+-              else (js_substr 0# i x, js_substr1 i x)
+-{-# INLINE span #-}
++              else (# js_substr 0# i x, js_substr1 i x #)
++{-# INLINE span_ #-}
+ 
+ -- | /O(n)/ 'break' is like 'span', but the prefix returned is
+ -- over elements that fail the predicate @p@.
+diff --git a/GHCJS/Foreign.hs b/GHCJS/Foreign.hs
+index 5bbc5c5..b128f24 100644
+--- a/GHCJS/Foreign.hs
++++ b/GHCJS/Foreign.hs
+@@ -82,7 +82,7 @@ import           GHCJS.Marshal
+ import           GHCJS.Marshal.Pure
+ -}
+ import           Data.String (IsString(..))
+-import qualified Data.Text as T
++-- import qualified Data.Text as T
+ 
+ 
+ class ToJSString a where
+diff --git a/GHCJS/Foreign/Internal.hs b/GHCJS/Foreign/Internal.hs
+index 5ac81f0..449bfe4 100644
+--- a/GHCJS/Foreign/Internal.hs
++++ b/GHCJS/Foreign/Internal.hs
+@@ -100,10 +100,10 @@ import           Data.Typeable (Typeable)
+ import           Data.ByteString (ByteString)
+ import           Data.ByteString.Unsafe (unsafePackAddressLen)
+ 
+-import qualified Data.Text.Array as A
+-import qualified Data.Text as T
+-import qualified Data.Text.Internal as T
+-import qualified Data.Text.Lazy as TL (Text, toStrict, fromStrict)
++-- import qualified Data.Text.Array as A
++-- import qualified Data.Text as T
++-- import qualified Data.Text.Internal as T
++-- import qualified Data.Text.Lazy as TL (Text, toStrict, fromStrict)
+ 
+ import           Unsafe.Coerce
+ 
+diff --git a/GHCJS/Marshal.hs b/GHCJS/Marshal.hs
+index a36aca2..6256a73 100644
+--- a/GHCJS/Marshal.hs
++++ b/GHCJS/Marshal.hs
+@@ -16,7 +16,7 @@
+ 
+ module GHCJS.Marshal ( FromJSVal(..)
+                      , ToJSVal(..)
+-                     , toJSVal_aeson
++                     -- , toJSVal_aeson
+                      , toJSVal_pure
+                      ) where
+ 
+@@ -24,17 +24,17 @@ import           Control.Applicative
+ import           Control.Monad
+ import           Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
+ 
+-import qualified Data.Aeson as AE
+-import           Data.Attoparsec.Number (Number(..))
++-- import qualified Data.Aeson as AE
++-- import           Data.Attoparsec.Number (Number(..))
+ import           Data.Bits ((.&.))
+ import           Data.Char (chr, ord)
+-import qualified Data.HashMap.Strict as H
++-- import qualified Data.HashMap.Strict as H
+ import           Data.Int (Int8, Int16, Int32)
+ import qualified Data.JSString as JSS
+-import qualified Data.JSString.Text as JSS
++-- import qualified Data.JSString.Text as JSS
+ import           Data.Maybe
+-import           Data.Scientific (Scientific, scientific, fromFloatDigits)
+-import           Data.Text (Text)
++-- import           Data.Scientific (Scientific, scientific, fromFloatDigits)
++-- import           Data.Text (Text)
+ import qualified Data.Vector as V
+ import           Data.Word (Word8, Word16, Word32, Word)
+ import           Data.Primitive.ByteArray
+@@ -85,11 +85,11 @@ instance FromJSVal JSString where
+     {-# INLINE fromJSValUnchecked #-}
+     fromJSVal = fromJSVal_pure
+     {-# INLINE fromJSVal #-}
+-instance FromJSVal Text where
+-    fromJSValUnchecked = fromJSValUnchecked_pure
+-    {-# INLINE fromJSValUnchecked #-}
+-    fromJSVal = fromJSVal_pure
+-    {-# INLINE fromJSVal #-}
++-- instance FromJSVal Text where
++--     fromJSValUnchecked = fromJSValUnchecked_pure
++--     {-# INLINE fromJSValUnchecked #-}
++--     fromJSVal = fromJSVal_pure
++--     {-# INLINE fromJSVal #-}
+ instance FromJSVal Char where
+     fromJSValUnchecked = fromJSValUnchecked_pure
+     {-# INLINE fromJSValUnchecked #-}
+@@ -154,24 +154,24 @@ instance FromJSVal Double where
+     {-# INLINE fromJSValUnchecked #-}
+     fromJSVal = fromJSVal_pure
+     {-# INLINE fromJSVal #-}
+-instance FromJSVal AE.Value where
+-    fromJSVal r = case jsonTypeOf r of
+-            JSONNull    -> return (Just AE.Null)
+-            JSONInteger -> liftM (AE.Number . flip scientific 0 . (toInteger :: Int -> Integer))
+-                 <$> fromJSVal r
+-            JSONFloat   -> liftM (AE.Number . (fromFloatDigits :: Double -> Scientific))
+-                 <$> fromJSVal r
+-            JSONBool    -> liftM AE.Bool  <$> fromJSVal r
+-            JSONString  -> liftM AE.String <$> fromJSVal r
+-            JSONArray   -> liftM (AE.Array . V.fromList) <$> fromJSVal r
+-            JSONObject  -> do
+-                props <- OI.listProps (OI.Object r)
+-                runMaybeT $ do
+-                    propVals <- forM props $ \p -> do
+-                        v <- MaybeT (fromJSVal =<< OI.getProp p (OI.Object r))
+-                        return (JSS.textFromJSString p, v)
+-                    return (AE.Object (H.fromList propVals))
+-    {-# INLINE fromJSVal #-}
++-- instance FromJSVal AE.Value where
++--     fromJSVal r = case jsonTypeOf r of
++--             JSONNull    -> return (Just AE.Null)
++--             JSONInteger -> liftM (AE.Number . flip scientific 0 . (toInteger :: Int -> Integer))
++--                  <$> fromJSVal r
++--             JSONFloat   -> liftM (AE.Number . (fromFloatDigits :: Double -> Scientific))
++--                  <$> fromJSVal r
++--             JSONBool    -> liftM AE.Bool  <$> fromJSVal r
++--             JSONString  -> liftM AE.String <$> fromJSVal r
++--             JSONArray   -> liftM (AE.Array . V.fromList) <$> fromJSVal r
++--             JSONObject  -> do
++--                 props <- OI.listProps (OI.Object r)
++--                 runMaybeT $ do
++--                     propVals <- forM props $ \p -> do
++--                         v <- MaybeT (fromJSVal =<< OI.getProp p (OI.Object r))
++--                         return (JSS.textFromJSString p, v)
++--                     return (AE.Object (H.fromList propVals))
++--     {-# INLINE fromJSVal #-}
+ instance (FromJSVal a, FromJSVal b) => FromJSVal (a,b) where
+     fromJSVal r = runMaybeT $ (,) <$> jf r 0 <*> jf r 1
+     {-# INLINE fromJSVal #-}
+@@ -204,15 +204,15 @@ jf r n = MaybeT $ do
+ instance ToJSVal JSVal where
+   toJSVal = toJSVal_pure
+   {-# INLINE toJSVal #-}
+-instance ToJSVal AE.Value where
+-    toJSVal = toJSVal_aeson
+-    {-# INLINE toJSVal #-}
++-- instance ToJSVal AE.Value where
++--     toJSVal = toJSVal_aeson
++--     {-# INLINE toJSVal #-}
+ instance ToJSVal JSString where
+     toJSVal = toJSVal_pure
+     {-# INLINE toJSVal #-}
+-instance ToJSVal Text where
+-    toJSVal = toJSVal_pure
+-    {-# INLINE toJSVal #-}
++-- instance ToJSVal Text where
++--     toJSVal = toJSVal_pure
++--     {-# INLINE toJSVal #-}
+ instance ToJSVal Char where
+     toJSVal = return . pToJSVal
+     {-# INLINE toJSVal #-}
+@@ -285,21 +285,21 @@ foreign import javascript unsafe "[$1,$2,$3,$4,$5]"       arr5     :: JSVal -> J
+ foreign import javascript unsafe "[$1,$2,$3,$4,$5,$6]"    arr6     :: JSVal -> JSVal -> JSVal -> JSVal -> JSVal -> JSVal -> IO JSVal
+ foreign import javascript unsafe "[$1,$2,$3,$4,$5,$6,$7]" arr7     :: JSVal -> JSVal -> JSVal -> JSVal -> JSVal -> JSVal -> JSVal -> IO JSVal
+ 
+-toJSVal_aeson :: AE.ToJSON a => a -> IO JSVal
+-toJSVal_aeson x = cv (AE.toJSON x)
+-  where
+-    cv = convertValue
++-- toJSVal_aeson :: AE.ToJSON a => a -> IO JSVal
++-- toJSVal_aeson x = cv (AE.toJSON x)
++--   where
++--     cv = convertValue
+ 
+-    convertValue :: AE.Value -> IO JSVal
+-    convertValue AE.Null       = return jsNull
+-    convertValue (AE.String t) = return (pToJSVal t)
+-    convertValue (AE.Array a)  = (\(AI.SomeJSArray x) -> x) <$>
+-                                 (AI.fromListIO =<< mapM convertValue (V.toList a))
+-    convertValue (AE.Number n) = toJSVal (realToFrac n :: Double)
+-    convertValue (AE.Bool b)   = return (toJSBool b)
+-    convertValue (AE.Object o) = do
+-      obj@(OI.Object obj') <- OI.create
+-      mapM_ (\(k,v) -> convertValue v >>= \v' -> OI.setProp (JSS.textToJSString k) v' obj) (H.toList o)
+-      return obj'
++--     convertValue :: AE.Value -> IO JSVal
++--     convertValue AE.Null       = return jsNull
++--     convertValue (AE.String t) = return (pToJSVal t)
++--     convertValue (AE.Array a)  = (\(AI.SomeJSArray x) -> x) <$>
++--                                  (AI.fromListIO =<< mapM convertValue (V.toList a))
++--     convertValue (AE.Number n) = toJSVal (realToFrac n :: Double)
++--     convertValue (AE.Bool b)   = return (toJSBool b)
++--     convertValue (AE.Object o) = do
++--       obj@(OI.Object obj') <- OI.create
++--       mapM_ (\(k,v) -> convertValue v >>= \v' -> OI.setProp (JSS.textToJSString k) v' obj) (H.toList o)
++--       return obj'
+ 
+ 
+diff --git a/GHCJS/Marshal/Pure.hs b/GHCJS/Marshal/Pure.hs
+index 902fa20..268489d 100644
+--- a/GHCJS/Marshal/Pure.hs
++++ b/GHCJS/Marshal/Pure.hs
+@@ -28,11 +28,11 @@ import           Data.Data
+ import           Data.Int (Int8, Int16, Int32)
+ import           Data.JSString.Internal.Type
+ import           Data.Maybe
+-import           Data.Text (Text)
++-- import           Data.Text (Text)
+ import           Data.Typeable
+ import           Data.Word (Word8, Word16, Word32, Word)
+ import           Data.JSString
+-import           Data.JSString.Text
++-- import           Data.JSString.Text
+ import           Data.Bits ((.&.))
+ import           Unsafe.Coerce (unsafeCoerce)
+ import           GHC.Int
+@@ -65,8 +65,8 @@ instance PFromJSVal JSString where pFromJSVal = JSString
+                                    {-# INLINE pFromJSVal #-}
+ instance PFromJSVal [Char] where pFromJSVal   = Prim.fromJSString
+                                  {-# INLINE pFromJSVal #-}
+-instance PFromJSVal Text   where pFromJSVal   = textFromJSVal
+-                                 {-# INLINE pFromJSVal #-}
++-- instance PFromJSVal Text   where pFromJSVal   = textFromJSVal
++--                                  {-# INLINE pFromJSVal #-}
+ instance PFromJSVal Char   where pFromJSVal x = C# (jsvalToChar x)
+                                  {-# INLINE pFromJSVal #-}
+ instance PFromJSVal Bool   where pFromJSVal   = isTruthy
+@@ -103,8 +103,8 @@ instance PToJSVal JSString  where pToJSVal          = jsval
+                                   {-# INLINE pToJSVal #-}
+ instance PToJSVal [Char]    where pToJSVal          = Prim.toJSString
+                                   {-# INLINE pToJSVal #-}
+-instance PToJSVal Text      where pToJSVal          = jsval . textToJSString
+-                                  {-# INLINE pToJSVal #-}
++-- instance PToJSVal Text      where pToJSVal          = jsval . textToJSString
++--                                   {-# INLINE pToJSVal #-}
+ instance PToJSVal Char      where pToJSVal (C# c)   = charToJSVal c
+                                   {-# INLINE pToJSVal #-}
+ instance PToJSVal Bool      where pToJSVal True     = jsTrue
+diff --git a/JavaScript/JSON/Types/Instances.hs b/JavaScript/JSON/Types/Instances.hs
+index 2b288ec..6d7074c 100644
+--- a/JavaScript/JSON/Types/Instances.hs
++++ b/JavaScript/JSON/Types/Instances.hs
+@@ -57,7 +57,7 @@ import Control.Applicative ((<$>), (<*>), (<|>), pure, empty)
+ 
+ import           Data.JSString      (JSString)
+ import qualified Data.JSString      as JSS
+-import qualified Data.JSString.Text as JSS
++-- import qualified Data.JSString.Text as JSS
+ 
+ import           JavaScript.Array (JSArray)
+ import qualified JavaScript.Array as JSA
+@@ -335,21 +335,21 @@ instance FromJSON JSString where
+     parseJSON = withJSString "JSString" pure
+     {-# INLINE parseJSON #-}
+ 
+-instance ToJSON Text where
+-    toJSON = stringValue . JSS.textToJSString
+-    {-# INLINE toJSON #-}
++-- instance ToJSON Text where
++--     toJSON = stringValue . JSS.textToJSString
++--     {-# INLINE toJSON #-}
+ 
+-instance FromJSON Text where
+-    parseJSON = withJSString "Text" ( pure . JSS.textFromJSString )
+-    {-# INLINE parseJSON #-}
++-- instance FromJSON Text where
++--     parseJSON = withJSString "Text" ( pure . JSS.textFromJSString )
++--     {-# INLINE parseJSON #-}
+ 
+-instance ToJSON LT.Text where
+-    toJSON = stringValue . JSS.textToJSString . LT.toStrict
+-    {-# INLINE toJSON #-}
++-- instance ToJSON LT.Text where
++--     toJSON = stringValue . JSS.textToJSString . LT.toStrict
++--     {-# INLINE toJSON #-}
+ 
+-instance FromJSON LT.Text where
+-    parseJSON = withJSString "Lazy Text" $ pure . LT.fromStrict . JSS.textFromJSString
+-    {-# INLINE parseJSON #-}
++-- instance FromJSON LT.Text where
++--     parseJSON = withJSString "Lazy Text" $ pure . LT.fromStrict . JSS.textFromJSString
++--     {-# INLINE parseJSON #-}
+ 
+ instance (ToJSON a) => ToJSON [a] where
+     toJSON = arrayValue . arrayValueList . map toJSON
+diff --git a/JavaScript/Web/Canvas.hs b/JavaScript/Web/Canvas.hs
+index 0a7684c..74490c2 100644
+--- a/JavaScript/Web/Canvas.hs
++++ b/JavaScript/Web/Canvas.hs
+@@ -69,7 +69,7 @@ import Control.Monad
+ 
+ import Data.Data
+ import Data.Maybe (fromJust)
+-import Data.Text (Text)
++-- import Data.Text (Text)
+ import Data.Typeable
+ 
+ import GHCJS.Foreign
+diff --git a/ghcjs-base.cabal b/ghcjs-base.cabal
+index 4a64694..acf8806 100644
+--- a/ghcjs-base.cabal
++++ b/ghcjs-base.cabal
+@@ -55,7 +55,7 @@ library
+                    Data.JSString.RealFloat
+                    Data.JSString.RegExp
+                    Data.JSString.Internal
+-                   Data.JSString.Text
++                   -- Data.JSString.Text
+                    Data.JSString.Internal.Fusion
+                    Data.JSString.Internal.Fusion.Types
+                    Data.JSString.Internal.Fusion.Common
+@@ -78,12 +78,12 @@ library
+                    JavaScript.Array.Internal
+                    JavaScript.Array.ST
+                    JavaScript.Cast
+-                   JavaScript.JSON
+-                   JavaScript.JSON.Types
+-                   JavaScript.JSON.Types.Class
+-                   JavaScript.JSON.Types.Generic
+-                   JavaScript.JSON.Types.Instances
+-                   JavaScript.JSON.Types.Internal
++                   -- JavaScript.JSON
++                   -- JavaScript.JSON.Types
++                   -- JavaScript.JSON.Types.Class
++                   -- JavaScript.JSON.Types.Generic
++                   -- JavaScript.JSON.Types.Instances
++                   -- JavaScript.JSON.Types.Internal
+                    JavaScript.Number
+                    JavaScript.Object
+                    JavaScript.Object.Internal
+@@ -115,11 +115,11 @@ library
+                    JavaScript.Web.Storage
+                    JavaScript.Web.Storage.Internal
+                    JavaScript.Web.StorageEvent
+-                   JavaScript.Web.XMLHttpRequest
++                   -- JavaScript.Web.XMLHttpRequest
+                    JavaScript.Web.WebSocket
+                    JavaScript.Web.Worker
+-  other-modules:   GHCJS.Internal.Types
+                    Data.JSString.Internal.Type
++  other-modules:   GHCJS.Internal.Types
+                    JavaScript.TypedArray.Internal.Types
+                    JavaScript.TypedArray.ArrayBuffer.Internal
+                    JavaScript.TypedArray.DataView.Internal
+@@ -144,15 +144,15 @@ library
+                    integer-gmp,
+                    binary               >= 0.8  && < 0.11,
+                    bytestring           >= 0.10 && < 0.11,
+-                   text                 >= 1.1  && < 1.3,
+-                   aeson                >= 0.8  && < 1.6,
+-                   scientific           >= 0.3  && < 0.4,
++                   -- text                 >= 1.1  && < 1.3,
++                   -- aeson                >= 0.8  && < 1.6,
++                   -- scientific           >= 0.3  && < 0.4,
+                    vector               >= 0.10 && < 0.13,
+                    containers           >= 0.5  && < 0.7,
+                    time                 >= 1.5  && < 1.10,
+-                   hashable             >= 1.2  && < 1.4,
+-                   unordered-containers >= 0.2  && < 0.3,
+-                   attoparsec           >= 0.11 && < 0.15,
++                   -- hashable             >= 1.2  && < 1.4,
++                   -- unordered-containers >= 0.2  && < 0.3,
++                   -- attoparsec           >= 0.11 && < 0.15,
+                    transformers         >= 0.3  && < 0.6,
+                    primitive            >= 0.5  && < 0.8,
+                    deepseq              >= 1.3  && < 1.5,
+@@ -161,37 +161,37 @@ library
+   if !impl(ghcjs) && !os(ghcjs)
+     buildable: False
+
+-test-suite tests
+-  type:           exitcode-stdio-1.0
+-  hs-source-dirs: test
+-  main-is:        Tests.hs
+-  other-modules:  Tests.Marshal
+-                  Tests.Properties
+-                  Tests.Properties.Numeric
+-                  Tests.SlowFunctions
+-                  Tests.QuickCheckUtils
+-                  Tests.Regressions
+-                  Tests.Utils
+-  ghc-options:
+-    -Wall -rtsopts
+-  build-depends:
+-    HUnit >= 1.2,
+-    QuickCheck >= 2.7,
+-    array,
+-    text,
+-    base,
+-    bytestring,
+-    deepseq,
+-    directory,
+-    ghc-prim,
+-    ghcjs-prim,
+-    ghcjs-base,
+-    primitive,
+-    quickcheck-unicode,
+-    random,
+-    test-framework >= 0.4,
+-    test-framework-hunit >= 0.2,
+-    test-framework-quickcheck2 >= 0.2
+-  default-language: Haskell2010
+-  if !impl(ghcjs) && !os(ghcjs)
+-    buildable: False
++-- test-suite tests
++--   type:           exitcode-stdio-1.0
++--   hs-source-dirs: test
++--   main-is:        Tests.hs
++--   other-modules:  Tests.Marshal
++--                   Tests.Properties
++--                   Tests.Properties.Numeric
++--                   Tests.SlowFunctions
++--                   Tests.QuickCheckUtils
++--                   Tests.Regressions
++--                   Tests.Utils
++--   ghc-options:
++--     -Wall -rtsopts
++--   build-depends:
++--     HUnit >= 1.2,
++--     QuickCheck >= 2.7,
++--     array,
++--     text,
++--     base,
++--     bytestring,
++--     deepseq,
++--     directory,
++--     ghc-prim,
++--     ghcjs-prim,
++--     ghcjs-base,
++--     primitive,
++--     quickcheck-unicode,
++--     random,
++--     test-framework >= 0.4,
++--     test-framework-hunit >= 0.2,
++--     test-framework-quickcheck2 >= 0.2
++--   default-language: Haskell2010
++--   if !impl(ghcjs) && !os(ghcjs)
++--     buildable: False

--- a/compiler/ghcjs/ghcjs810-patched-boot-packages/hashable.patch
+++ b/compiler/ghcjs/ghcjs810-patched-boot-packages/hashable.patch
@@ -1,0 +1,99 @@
+diff --git a/hashable.cabal b/hashable.cabal
+index 4197060..8c339b1 100755
+--- a/hashable.cabal
++++ b/hashable.cabal
+@@ -88,6 +88,8 @@ library
+     build-depends: ghc-bignum ==1.0.* || ==1.2.*
+ 
+   else
++    if impl(ghcjs)
++      build-depends:   ghcjs-base
+     if flag(integer-gmp)
+       build-depends: integer-gmp >=0.4 && <1.1
+ 
+diff --git a/src/Data/Hashable/Class.hs b/src/Data/Hashable/Class.hs
+index c7dd8c5..0e3bbe7 100755
+--- a/src/Data/Hashable/Class.hs
++++ b/src/Data/Hashable/Class.hs
+@@ -5,6 +5,10 @@
+ 
+ {-# LANGUAGE Trustworthy #-}
+ 
++#ifdef __GHCJS__
++{-# LANGUAGE JavaScriptFFI, UnboxedTuples, GHCForeignImportPrim #-}
++#endif
++
+ #if __GLASGOW_HASKELL__ >= 801
+ {-# LANGUAGE PolyKinds #-} -- For TypeRep instances
+ #endif
+@@ -72,7 +76,9 @@ import Data.Int (Int8, Int16, Int32, Int64)
+ import Data.List (foldl')
+ import Data.Ratio (Ratio, denominator, numerator)
+ import qualified Data.Text as T
++#ifndef __GHCJS__
+ import qualified Data.Text.Array as TA
++#endif
+ import qualified Data.Text.Internal as T
+ import qualified Data.Text.Lazy as TL
+ import Data.Version (Version(..))
+@@ -152,7 +158,11 @@ import GHC.Exts (Int (..), sizeofByteArray#)
+ #  define MIN_VERSION_integer_gmp_1_0_0
+ # endif
+ 
++#ifndef __GHCJS__
+ import GHC.Exts (Int(..))
++#else
++import GHC.Exts (Int(..), Int#)
++#endif
+ import GHC.Integer.GMP.Internals (Integer(..))
+ # if defined(MIN_VERSION_integer_gmp_1_0_0)
+ import GHC.Exts (sizeofByteArray#)
+@@ -195,6 +205,10 @@ import Data.Kind (Type)
+ import Data.Hashable.Imports
+ import Data.Hashable.LowLevel
+ 
++#ifdef __GHCJS__
++import Data.JSString (JSString)
++#endif
++
+ #include "MachDeps.h"
+ 
+ infixl 0 `hashWithSalt`
+@@ -676,17 +690,18 @@ instance Hashable BSI.ShortByteString where
+ #endif
+ 
+ instance Hashable T.Text where
++#ifndef __GHCJS__
+     hashWithSalt salt (T.Text arr off len) =
+         hashByteArrayWithSalt (TA.aBA arr) (off `shiftL` 1) (len `shiftL` 1)
+         (hashWithSalt salt len)
++#else
++    hashWithSalt salt (T.Text txt) =
++        let (# ba, len #) = js_textFromJSString txt
++        in hashByteArrayWithSalt ba (0 `shiftL` 1) (I# len `shiftL` 1) salt
++#endif
+ 
+ instance Hashable TL.Text where
+-    hashWithSalt salt = finalise . TL.foldlChunks step (SP salt 0)
+-      where
+-        finalise (SP s l) = hashWithSalt s l
+-        step (SP s l) (T.Text arr off len) = SP
+-            (hashByteArrayWithSalt (TA.aBA arr) (off `shiftL` 1) (len `shiftL` 1) s)
+-            (l + len)
++    hashWithSalt = TL.foldlChunks hashWithSalt
+ 
+ -- | Compute the hash of a ThreadId.
+ hashThreadId :: ThreadId -> Int
+@@ -880,6 +895,12 @@ instance Hashable1 Option where liftHashWithSalt h salt (Option a) = liftHashWit
+ #endif
+ #endif
+ 
++#ifdef __GHCJS__
++foreign import javascript unsafe
++  "h$textFromString"
++  js_textFromJSString :: JSString -> (# ByteArray#, Int# #)
++#endif
++
+ -- instances for @Data.Functor.{Product,Sum,Compose}@, present
+ -- in base-4.9 and onward.
+ #if MIN_VERSION_base(4,9,0)

--- a/compiler/ghcjs/patches/810/boot-optimization-flags.patch
+++ b/compiler/ghcjs/patches/810/boot-optimization-flags.patch
@@ -1,0 +1,13 @@
+diff --git a/src-bin/Boot.hs b/src-bin/Boot.hs
+index 2e35a26..1f4ff98 100755
+--- a/src-bin/Boot.hs
++++ b/src-bin/Boot.hs
+@@ -721,6 +721,8 @@ cabalConfigureFlags = do
+            , "--prefix",        T.pack (locs ^. blGhcjsTopDir)
+            , "--configure-option", "--host=js-unknown-ghcjs"
+            , "--ghcjs-options=-fwrite-ide-info"
++           , "--ghcjs-options=-O2"
++           , "--ghcjs-options=-fexpose-all-unfoldings"
+            , "--enable-debug-info"
+            , "--disable-library-stripping"
+            , "--disable-executable-stripping"

--- a/compiler/ghcjs/patches/810/boot-optimization-flags.patch
+++ b/compiler/ghcjs/patches/810/boot-optimization-flags.patch
@@ -1,13 +1,14 @@
 diff --git a/src-bin/Boot.hs b/src-bin/Boot.hs
-index 2e35a26..1f4ff98 100755
+index 2e35a26..5db2f9b 100755
 --- a/src-bin/Boot.hs
 +++ b/src-bin/Boot.hs
-@@ -721,6 +721,8 @@ cabalConfigureFlags = do
+@@ -721,6 +721,9 @@ cabalConfigureFlags = do
             , "--prefix",        T.pack (locs ^. blGhcjsTopDir)
             , "--configure-option", "--host=js-unknown-ghcjs"
             , "--ghcjs-options=-fwrite-ide-info"
 +           , "--ghcjs-options=-O2"
 +           , "--ghcjs-options=-fexpose-all-unfoldings"
++           , "--ghcjs-options=-fspecialise-aggressively"
             , "--enable-debug-info"
             , "--disable-library-stripping"
             , "--disable-executable-stripping"

--- a/compiler/ghcjs/patches/810/fast-weak.patch
+++ b/compiler/ghcjs/patches/810/fast-weak.patch
@@ -1,0 +1,87 @@
+diff --git a/lib/boot/shims/src/gc.js.pp b/lib/boot/shims/src/gc.js.pp
+index 76321b2..a2cf416 100644
+--- a/lib/boot/shims/src/gc.js.pp
++++ b/lib/boot/shims/src/gc.js.pp
+@@ -444,6 +444,50 @@ function h$follow(obj, sp) {
+             } else if(typeof c.len === 'number' && c.buf instanceof ArrayBuffer) {
+                 TRACE_GC("marking ByteArray");
+                 MARK_OBJ(c);
++            } else if(c instanceof h$FastWeak) {
++              MARK_OBJ(c);
++              if(c.ticket !== null && !IS_MARKED(c.ticket)) {
++                c.ticket = null; // If the ticket isn't reachable, this will let it get cleaned up by the JS gc; if it is reachable, it'll fill this back in
++              }
++            } else if(c instanceof h$FastWeakTicket) {
++              MARK_OBJ(c);
++              if(!IS_MARKED(c.val)) {
++                ADDW(c.val);
++              }
++              if(IS_MARKED(c.weak)) {
++                // In this case, the weak side has been marked first, which means it's been cleared; restore it
++                c.weak.ticket = c;
++              }
++            } else if(c instanceof h$FastWeakBag) {
++              MARK_OBJ(c);
++              var j = 0; // j should always be equal to the number of not-yet-necessarily-dead tickets that have been traversed; this should always be less than or equal to i
++              for(i = 0; i < c.tickets.length; i++) {
++                // Any nulls left in the array prior to checking on the tickets must be tickets that died in the last GC, so we ignore them
++                if(c.tickets[i] !== null) {
++                  if(j !== i) {
++                    c.tickets[i].pos = j;
++                  }
++                  if(!IS_MARKED(c.tickets[i])) {
++                    // If the ticket isn't reachable, this will let it get cleaned up by the JS gc; if it is reachable, it'll fill this back in
++                    c.tickets[j] = null;
++                  } else if(j !== i) {
++                    // We need to move the item
++                    c.tickets[j] = c.tickets[i];
++                  } // If it's marked and not moving, don't do anything
++                  j++;
++                }
++              }
++              c.tickets.length = j; // Shrink the array if any nulls have been dropped
++            } else if(c instanceof h$FastWeakBagTicket) {
++              MARK_OBJ(c);
++              if(!IS_MARKED(c.val)) {
++                ADDW(c.val);
++              }
++              if(IS_MARKED(c.bag)) {
++                // In this case, the weak side has been marked first, which means it's been cleared; restore it
++                c.bag.tickets[c.pos] = c;
++              }
++
+             } else if(c instanceof h$Weak) {
+                 MARK_OBJ(c);
+             } else if(c instanceof h$MVar) {
+diff --git a/lib/boot/shims/src/weak.js.pp b/lib/boot/shims/src/weak.js.pp
+index 8df313b..d537027 100644
+--- a/lib/boot/shims/src/weak.js.pp
++++ b/lib/boot/shims/src/weak.js.pp
+@@ -87,3 +87,27 @@ function h$finalizeWeak(w) {
+         RETURN_UBX_TUP2(r, 1);
+     }
+ }
++
++function h$FastWeak(ticket) {
++  this.ticket = ticket;
++  this.m = 0;
++}
++
++function h$FastWeakTicket(val) {
++  this.val = val;
++  this.weak = new h$FastWeak(this);
++  this.m = 0;
++}
++
++function h$FastWeakBag() {
++  this.tickets = [];
++  this.m = 0;
++}
++
++function h$FastWeakBagTicket(bag, val) {
++  this.val = val;
++  this.bag = bag;
++  this.pos = bag.tickets.length;
++  bag.tickets.push(this);
++  this.m = 0;
++};

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -795,6 +795,7 @@ in {
                 ghc = buildGHC;
                 ghcVersion = "8.10.5";
                 compiler-nix-name = "ghc8105";
+                overrideBootPackages = final.callPackage ../compiler/ghcjs/ghcjs810-patched-boot-packages {};
             }; in let targetPrefix = "js-unknown-ghcjs-"; in final.runCommand "${targetPrefix}ghc-8.10.5" {
                 nativeBuildInputs = [ final.xorg.lndir ];
                 passthru = {
@@ -829,6 +830,7 @@ in {
                 ghc = buildGHC;
                 ghcVersion = "8.10.6";
                 compiler-nix-name = "ghc8106";
+                overrideBootPackages = final.callPackage ../compiler/ghcjs/ghcjs810-patched-boot-packages {};
             }; in let targetPrefix = "js-unknown-ghcjs-"; in final.runCommand "${targetPrefix}ghc-8.10.6" {
                 nativeBuildInputs = [ final.xorg.lndir ];
                 passthru = {
@@ -863,6 +865,7 @@ in {
                 ghc = buildGHC;
                 ghcVersion = "8.10.7";
                 compiler-nix-name = "ghc8107";
+                overrideBootPackages = final.callPackage ../compiler/ghcjs/ghcjs810-patched-boot-packages {};
             }; in let targetPrefix = "js-unknown-ghcjs-"; in final.runCommand "${targetPrefix}ghc-8.10.7" {
                 nativeBuildInputs = [ final.xorg.lndir ];
                 passthru = {

--- a/overlays/ghcjs.nix
+++ b/overlays/ghcjs.nix
@@ -1,6 +1,6 @@
 final: prev:
 {
-  haskell-nix = prev.haskell-nix // ({
+  haskell-nix = prev.haskell-nix // {
     defaultModules = prev.haskell-nix.defaultModules ++ final.lib.optional final.stdenv.hostPlatform.isGhcjs (
       ({ pkgs, buildModules, config, lib, ... }: {
         # Allow Cabal to be reinstalled so that custom setups will use a Cabal
@@ -17,7 +17,8 @@ final: prev:
             "hpc"
             "mtl" "parsec" "process" "text" "time" "transformers"
             "unix" "xhtml" "terminfo"
-          ];
+          ] ++ lib.optionals (builtins.compareVersions config.compiler.version "8.10.0.0" >= 0) 
+            (map ({name, ...}: name) (import ../compiler/ghcjs/ghcjs810-patched-boot-packages { inherit pkgs; }));
         testWrapper = [((final.writeScriptBin "node-wrapper" ''
           set -euo pipefail
           exe=$1
@@ -55,5 +56,5 @@ final: prev:
           });
       })
     );
-  });
+  };
 }

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -145,8 +145,12 @@ final: prev: {
                   if compiler-nix-name != null
                     then compiler-nix-name
                     else ((plan-pkgs.extras hackage).compiler or (plan-pkgs.pkgs hackage).compiler).nix-name;
+                compiler-nix-name-with-js-prefix = 
+                  if final.stdenv.hostPlatform.isGhcjs
+                    then "js-" + compiler-nix-name'
+                    else compiler-nix-name';
                 pkg-def = excludeBootPackages compiler-nix-name plan-pkgs.pkgs;
-                patchesModule = ghcHackagePatches.${compiler-nix-name'} or {};
+                patchesModule = ghcHackagePatches.${compiler-nix-name-with-js-prefix} or {};
                 package.compiler-nix-name.version = final.buildPackages.haskell-nix.compiler.${compiler-nix-name'}.version;
                 plan.compiler-nix-name.version = final.buildPackages.haskell-nix.compiler.${(plan-pkgs.pkgs hackage).compiler.nix-name}.version;
                 withMsg = final.lib.assertMsg;

--- a/patches/default.nix
+++ b/patches/default.nix
@@ -8,4 +8,5 @@
   ghc863 = import ./ghc863;
   ghc864 = import ./ghc864;
   ghc865 = import ./ghc865;
+  js-ghc8107 = import ./js-ghc8107;
 }

--- a/patches/ghc862/default.nix
+++ b/patches/ghc862/default.nix
@@ -4,8 +4,8 @@
   packages.hpc.patches = [ ({ version, revision }: if version == "0.6.0.3" && revision == 0 then ./hpc-0.6.0.3.patch else null) ];
   packages.parsec.patches = [ ({ version, revision }: if version == "3.1.13.0" && revision == 0 then ./parsec-3.1.13.0.patch else null) ];
   packages.process.patches = [ ({ version, revision }: if version == "1.6.3.0" && revision == 0 then ./process-1.6.3.0.patch else null) ];
+  packages.singletons.patches = [ ({ version, revision }: if version == "2.5.1" && revision == 0 then ./singletons-2.5.1.patch else null) ];
   packages.time.patches = [ ({ version, revision }: if version == "1.8.0.2" && revision == 0 then ./time-1.8.0.2.patch else null) ];
   packages.transformers.patches = [ ({ version, revision }: if version == "0.5.5.0" && revision == 0 then ./transformers-0.5.5.0.patch else null) ];
   packages.unix.patches = [ ({ version, revision }: if version == "2.7.2.2" && revision == 0 then ./unix-2.7.2.2.patch else null) ];
-  packages.singletons.patches = [ ({ version, revision }: if version == "2.5.1" && revision == 0 then ./singletons-2.5.1.patch else null) ];
 }

--- a/patches/ghc863/default.nix
+++ b/patches/ghc863/default.nix
@@ -4,8 +4,8 @@
   packages.hpc.patches = [ ({ version, revision }: if version == "0.6.0.3" && revision == 0 then ./hpc-0.6.0.3.patch else null) ];
   packages.parsec.patches = [ ({ version, revision }: if version == "3.1.13.0" && revision == 0 then ./parsec-3.1.13.0.patch else null) ];
   packages.process.patches = [ ({ version, revision }: if version == "1.6.3.0" && revision == 0 then ./process-1.6.3.0.patch else null) ];
+  packages.singletons.patches = [ ({ version, revision }: if version == "2.5.1" && revision == 0 then ./singletons-2.5.1.patch else null) ];
   packages.time.patches = [ ({ version, revision }: if version == "1.8.0.2" && revision == 0 then ./time-1.8.0.2.patch else null) ];
   packages.transformers.patches = [ ({ version, revision }: if version == "0.5.5.0" && revision == 0 then ./transformers-0.5.5.0.patch else null) ];
   packages.unix.patches = [ ({ version, revision }: if version == "2.7.2.2" && revision == 0 then ./unix-2.7.2.2.patch else null) ];
-  packages.singletons.patches = [ ({ version, revision }: if version == "2.5.1" && revision == 0 then ./singletons-2.5.1.patch else null) ];
 }

--- a/patches/ghc864/default.nix
+++ b/patches/ghc864/default.nix
@@ -3,6 +3,6 @@
   packages.containers.patches = [ ({ version, revision }: if version == "0.6.0.1" && revision == 0 then ./containers-0.6.0.1.patch else null) ];
   packages.hpc.patches = [ ({ version, revision }: if version == "0.6.0.3" && revision == 0 then ./hpc-0.6.0.3.patch else null) ];
   packages.parsec.patches = [ ({ version, revision }: if version == "3.1.13.0" && revision == 0 then ./parsec-3.1.13.0.patch else null) ];
-  packages.unix.patches = [ ({ version, revision }: if version == "2.7.2.2" && revision == 0 then ./unix-2.7.2.2.patch else null) ];
   packages.singletons.patches = [ ({ version, revision }: if version == "2.5.1" && revision == 0 then ./singletons-2.5.1.patch else null) ];
+  packages.unix.patches = [ ({ version, revision }: if version == "2.7.2.2" && revision == 0 then ./unix-2.7.2.2.patch else null) ];
 }

--- a/patches/ghc865/default.nix
+++ b/patches/ghc865/default.nix
@@ -3,6 +3,6 @@
   packages.containers.patches = [ ({ version, revision }: if version == "0.6.0.1" && revision == 0 then ./containers-0.6.0.1.patch else null) ];
   packages.hpc.patches = [ ({ version, revision }: if version == "0.6.0.3" && revision == 0 then ./hpc-0.6.0.3.patch else null) ];
   packages.parsec.patches = [ ({ version, revision }: if version == "3.1.13.0" && revision == 0 then ./parsec-3.1.13.0.patch else null) ];
-  packages.unix.patches = [ ({ version, revision }: if version == "2.7.2.2" && revision == 0 then ./unix-2.7.2.2.patch else null) ];
   packages.singletons.patches = [ ({ version, revision }: if version == "2.5.1" && revision == 0 then ./singletons-2.5.1.patch else null) ];
+  packages.unix.patches = [ ({ version, revision }: if version == "2.7.2.2" && revision == 0 then ./unix-2.7.2.2.patch else null) ];
 }

--- a/patches/js-ghc8107/buffer-builder.patch
+++ b/patches/js-ghc8107/buffer-builder.patch
@@ -1,0 +1,79 @@
+From ece29d689b56e51b22b39c8d0b8740e325830f23 Mon Sep 17 00:00:00 2001
+From: Luigy Leon <luigy@outlook.com>
+Date: Fri, 6 Oct 2017 18:39:35 -0400
+Subject: [PATCH] text-jsstring
+
+---
+ buffer-builder.cabal      |  3 +++
+ src/Data/BufferBuilder.hs | 25 +++++++++++++++++++++++--
+ 2 files changed, 26 insertions(+), 2 deletions(-)
+
+diff --git a/buffer-builder.cabal b/buffer-builder.cabal
+index fe24f73..868d3c1 100644
+--- a/buffer-builder.cabal
++++ b/buffer-builder.cabal
+@@ -65,6 +65,9 @@ library
+   if !impl(ghc >= 8.0)
+     build-depends: semigroups
+ 
++  if impl(ghcjs)
++    build-depends: ghcjs-base
++
+   default-language: Haskell2010
+   ghc-options: -O2 -Wall
+   --ghc-options: -ddump-ds -ddump-simpl -ddump-stg -ddump-opt-cmm -ddump-asm -ddump-to-file
+diff --git a/src/Data/BufferBuilder.hs b/src/Data/BufferBuilder.hs
+index 30b39ce..0468afb 100644
+--- a/src/Data/BufferBuilder.hs
++++ b/src/Data/BufferBuilder.hs
+@@ -1,4 +1,7 @@
+-{-# LANGUAGE OverloadedStrings, MagicHash, BangPatterns, RecordWildCards, DeriveDataTypeable #-}
++{-# LANGUAGE OverloadedStrings, MagicHash, BangPatterns, RecordWildCards, DeriveDataTypeable, CPP #-}
++#ifdef ghcjs_HOST_OS
++{-# LANGUAGE UnboxedTuples, ForeignFunctionInterface, UnliftedFFITypes #-}
++#endif
+ 
+ {-|
+ A library for efficiently building up a buffer of data.  When given data
+@@ -71,6 +74,9 @@ import Data.Typeable (Typeable)
+ import Data.Text () -- Show
+ import Data.Text.Internal (Text (..))
+ import Data.Text.Array (Array (..))
++#ifdef ghcjs_HOST_OS
++import Data.JSString
++#endif
+ 
+ data Handle'
+ type Handle = Ptr Handle'
+@@ -349,8 +355,17 @@ appendEscapedJsonLiteral addr =
+ {-# INLINE appendEscapedJsonLiteral #-}
+ 
+ appendEscapedJsonText :: Text -> BufferBuilder ()
++#ifndef ghcjs_HOST_OS
+ appendEscapedJsonText !(Text arr ofs len) =
+-    let byteArray = aBA arr
++    let
++#else
++appendEscapedJsonText !(Text t) =
++    let (# ba#, len# #) = js_fromString t
++        len = I# len#
++        arr = Array ba#
++        ofs = 0
++#endif
++        byteArray = aBA arr
+     in withHandle $ \h ->
+         bw_append_json_escaped_utf16 h len (Ptr (byteArrayContents# byteArray) `plusPtr` (2 * ofs))
+ {-# INLINE appendEscapedJsonText #-}
+@@ -364,3 +379,9 @@ appendUrlEncoded !(BS.PS (ForeignPtr addr _) offset len) =
+     withHandle $ \h ->
+         bw_append_url_encoded h len (plusPtr (Ptr addr) offset)
+ {-# INLINE appendUrlEncoded #-}
++
++#ifdef ghcjs_HOST_OS
++foreign import javascript unsafe
++  "h$textFromString"
++  js_fromString :: JSString -> (# ByteArray#, Int# #)
++#endif
+-- 
+2.31.1
+

--- a/patches/js-ghc8107/conduit-extra.patch
+++ b/patches/js-ghc8107/conduit-extra.patch
@@ -1,0 +1,48 @@
+diff --git a/Data/Conduit/Attoparsec.hs b/Data/Conduit/Attoparsec.hs
+index bd889f8..a620675 100644
+--- a/Data/Conduit/Attoparsec.hs
++++ b/Data/Conduit/Attoparsec.hs
+@@ -1,4 +1,5 @@
+ {-# LANGUAGE BangPatterns       #-}
++{-# LANGUAGE CPP                #-}
+ {-# LANGUAGE DeriveDataTypeable #-}
+ {-# LANGUAGE FlexibleContexts   #-}
+ {-# LANGUAGE RankNTypes         #-}
+@@ -33,6 +34,9 @@ import qualified Data.Text                  as T
+ import qualified Data.Text.Internal         as TI
+ import           Data.Typeable              (Typeable)
+ import           Prelude                    hiding (lines)
++#ifdef __GHCJS__
++import qualified Data.JSString.Raw as JSS
++#endif
+ 
+ import qualified Data.Attoparsec.ByteString
+ import qualified Data.Attoparsec.Text
+@@ -105,8 +109,13 @@ instance AttoparsecInput T.Text where
+         f (Position l c o) ch
+           | ch == '\n' = Position (l + 1) 0 (o + 1)
+           | otherwise = Position l (c + 1) (o + 1)
++#ifndef __GHCJS__
+     stripFromEnd (TI.Text arr1 off1 len1) (TI.Text _ _ len2) =
+         TI.text arr1 off1 (len1 - len2)
++#else
++    stripFromEnd (TI.Text str1) (TI.Text str2) =
++        TI.Text $ JSS.rawDropEnd (JSS.rawLength str1 - JSS.rawLength str2) str1
++#endif
+ 
+ -- | Convert an Attoparsec 'A.Parser' into a 'Sink'. The parser will
+ -- be streamed bytes until it returns 'A.Done' or 'A.Fail'.
+diff --git a/conduit-extra.cabal b/conduit-extra.cabal
+index f6dfe7a..b5b2515 100644
+--- a/conduit-extra.cabal
++++ b/conduit-extra.cabal
+@@ -58,6 +58,9 @@ Library
+                      , unliftio-core
+                      , typed-process            >= 0.2
+ 
++  if impl(ghcjs)
++      Build-depends: ghcjs-base
++
+   ghc-options:     -Wall
+ 
+ test-suite test

--- a/patches/js-ghc8107/default.nix
+++ b/patches/js-ghc8107/default.nix
@@ -1,0 +1,7 @@
+{
+  packages.buffer-builder.patches = [ ({ version, revision }: ./buffer-builder.patch) ];
+  packages.conduit-extra.patches = [ ({ version, revision }: ./conduit-extra.patch) ];
+  packages.double-conversion.patches = [ ({ version, revision }: ./double-conversion.patch) ];
+  packages.network.patches = [ ({ version, revision }: ./network.patch) ];
+  packages.say.patches = [ ({ version, revision }: ./say.patch) ];
+}

--- a/patches/js-ghc8107/double-conversion.patch
+++ b/patches/js-ghc8107/double-conversion.patch
@@ -1,0 +1,64 @@
+From 0f9ddde468687d25fa6c4c9accb02a034bc2f9c3 Mon Sep 17 00:00:00 2001
+From: Luigy Leon <luigy@outlook.com>
+Date: Thu, 1 Dec 2016 12:43:59 -0500
+Subject: [PATCH] Add text jsstring support for ghcjs.
+
+---
+ Data/Double/Conversion/Text.hs | 17 +++++++++++++++--
+ double-conversion.cabal        |  4 ++++
+ 2 files changed, 19 insertions(+), 2 deletions(-)
+
+diff --git a/Data/Double/Conversion/Text.hs b/Data/Double/Conversion/Text.hs
+index 2e89705..3b315a7 100644
+--- a/Data/Double/Conversion/Text.hs
++++ b/Data/Double/Conversion/Text.hs
+@@ -1,4 +1,4 @@
+-{-# LANGUAGE CPP, MagicHash, Rank2Types #-}
++{-# LANGUAGE CPP, MagicHash, Rank2Types, ForeignFunctionInterface, UnliftedFFITypes #-}
+
+ -- |
+ -- Module      : Data.Double.Conversion.Text
+@@ -33,7 +33,12 @@ import Control.Monad.ST (runST)
+ import Data.Double.Conversion.FFI
+ import Data.Text.Internal (Text(Text))
+ import Foreign.C.Types (CDouble, CInt)
+-import GHC.Prim (MutableByteArray#)
++#ifndef __GHCJS__
++import GHC.Prim (MutableByteArray#, ByteArray#)
++#else
++import GHC.Prim (MutableByteArray#, Int#, ByteArray#)
++import Data.JSString
++#endif
+ import qualified Data.Text.Array as A
+
+ -- | Compute a representation in exponential format with the requested
+@@ -81,4 +86,12 @@ convert func len act val = runST go
+         fail $ "Data.Double.Conversion.Text." ++ func ++
+                ": conversion failed (invalid precision requested)"
+       frozen <- A.unsafeFreeze buf
++#ifndef __GHCJS__
+       return $ Text frozen 0 (fromIntegral size)
++#else
++      return $ Text $ js_toString (A.aBA frozen) 0# (fromIntegral size)
++
++foreign import javascript unsafe
++  "h$textToString"
++  js_toString :: ByteArray# -> Int# -> Int -> JSString
++#endif
+diff --git a/double-conversion.cabal b/double-conversion.cabal
+index d177d3f..5f0527f 100644
+--- a/double-conversion.cabal
++++ b/double-conversion.cabal
+@@ -90,6 +90,10 @@ library
+     ghc-prim,
+     text >= 0.11.0.8
+
++  if impl(ghcjs)
++    build-depends:
++      ghcjs-base
++
+   if flag(developer)
+     ghc-options: -Werror
+     ghc-prof-options: -auto-all
+--
+2.31.1

--- a/patches/js-ghc8107/network.patch
+++ b/patches/js-ghc8107/network.patch
@@ -1,0 +1,16 @@
+diff --git a/Network/Socket.hsc b/Network/Socket.hsc
+index 4edebd4..43ecdb7 100644
+--- a/Network/Socket.hsc
++++ b/Network/Socket.hsc
+@@ -479,11 +479,7 @@ setNonBlockIfNeeded fd =
+ --
+ --   Since 2.7.0.0.
+ setCloseOnExecIfNeeded :: CInt -> IO ()
+-#if defined(mingw32_HOST_OS)
+ setCloseOnExecIfNeeded _ = return ()
+-#else
+-setCloseOnExecIfNeeded fd = System.Posix.Internals.setCloseOnExec fd
+-#endif
+ 
+ #if !defined(mingw32_HOST_OS)
+ foreign import ccall unsafe "fcntl"

--- a/patches/js-ghc8107/say.patch
+++ b/patches/js-ghc8107/say.patch
@@ -1,0 +1,22 @@
+diff --git a/src/Say.hs b/src/Say.hs
+index a1f6802..fd9145d 100644
+--- a/src/Say.hs
++++ b/src/Say.hs
+@@ -146,7 +146,7 @@ hSay h msg =
+                 return new_buf
+ 
+     writeBlocksRaw :: Buffer CharBufElem -> Stream Char -> IO ()
+-    writeBlocksRaw buf0 (Stream next0 s0 _len) =
++    writeBlocksRaw buf0 (Stream next0 s0) =
+         outer s0 buf0
+       where
+         outer s1 Buffer{bufRaw=raw, bufSize=len} =
+@@ -168,7 +168,7 @@ hSay h msg =
+                 flush = commit n True{-needs flush-} False{-don't release-} >>= outer s
+ 
+     writeBlocksCRLF :: Buffer CharBufElem -> Stream Char -> IO ()
+-    writeBlocksCRLF buf0 (Stream next0 s0 _len) =
++    writeBlocksCRLF buf0 (Stream next0 s0) =
+         outer s0 buf0
+       where
+         outer s1 Buffer{bufRaw=raw, bufSize=len} =

--- a/patches/update-patches.sh
+++ b/patches/update-patches.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
-for ghc in $(find . -name "ghc*" -type d | sort); do
+for ghc in $(find .  -maxdepth 1 -mindepth 1 -type d | sort); do
   (cd $ghc
    echo "{" > default.nix
    (for a in $(find . -name "*.patch" -type f | sort); do
      b=${a%%.patch};
      b=${b##./};
-     echo "  packages.${b%%-*}.patches = [ ({ version, revision }: if version == \"${b##*-}\" && revision == 0 then $a else null) ];" >> default.nix
+     if [[ "$ghc" =~ js- ]]; then
+       echo "  packages.$b.patches = [ ({ version, revision }: $a) ];" >> default.nix
+     else
+       echo "  packages.${b%%-*}.patches = [ ({ version, revision }: if version == \"${b##*-}\" && revision == 0 then $a else null) ];" >> default.nix
+     fi
    done) || true
    echo "}" >> default.nix)
 done


### PR DESCRIPTION
closes #1167

This was inspired by https://github.com/reflex-frp/reflex-platform/tree/develop/haskell-overlays.

## Motivation

GHCJS apps are slow and consume a lot of memory. Using patched versions of libraries and runtime yields a significant improvement in both performance and memory usage.

## Architectural decisions

From what I have gathered the haskell.nix ecosystem aims to resolve constraints as much as possible from a given hackage snapshot without any easy way of modifying dependencies. 

The patched versions of libraries are custom forks and are heavily tied to modification in the boot libraries of GHCJS. 
These libraries include:
- text
- aeson
- attoparsec

The other libraries can be patched from hackage versions.


The most reasonable way I found of locking down these forked versions of libraries is making them boot libraries of GHCJS. This way they are always used when solving dependencies.

All dependencies of boot libraries need to be themselves boot libraries. This, unfortunately, forced me to add quite a few libraries to GHCJS boot libraries list.

## The downsides

There are three real downsides I can think of:
1. The projects will be constrained to using only one specific version of a large number of libraries.
2. Resolving the dependencies of a project with GHC and GHCJS will diverge more than it does now. (It already diverges due to conditionals in a large amount of existing GHCJS-related libraries.)
3. If a project does not use the now boot libraries, then it might yield larger GHCJS executables. (Though this is mostly mitigated by [closure-compiler](https://github.com/google/closure-compiler) which is widely used)

## Other changes

In this PR I also added some optimization flags to GHCJS itself, and the boot libraries. GHCJS itself needs all of the help it can get in the performance department, and the user has no real way to get a more optimized version of boot libraries (though many might want to).

I see no real downside to this change as most users will probably pull these from a cache.

## What could be improved

1. The same changes can be applied to GHCJS 8.6, but I did not do it in this PR for time constraint reasons. (Compiling GHCJS takes a _long_ time).
2. The patches should probably be made conditional (allow the user to turn them off), but I couldn't figure out what would be "the correct" way of passing a flag from the user to all of the affected parts.

## Testing

I have tested this on two of my projects and I can confirm that everything works.