### PR TITLE
Remove propagatedBuildInputs from ghc

### DIFF
--- a/compiler/ghc/configured-src.nix
+++ b/compiler/ghc/configured-src.nix
@@ -33,9 +33,6 @@ stdenv.mkDerivation (rec {
 
     buildInputs = [ perl bash ] ++ (libDeps hostPlatform);
 
-    propagatedBuildInputs = [ targetPackages.stdenv.cc ]
-        ++ lib.optional useLLVM llvmPackages.llvm;
-
     depsTargetTarget = map lib.getDev (libDeps targetPlatform);
     depsTargetTargetPropagated = map (lib.getOutput "out") (libDeps targetPlatform);
 
@@ -65,6 +62,9 @@ stdenv.mkDerivation (rec {
 
         echo -n "${buildMK}" > mk/build.mk
         sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure
+    '' + lib.optionalString useLLVM ''
+        export LLC="${llvmPackages.llvm}/bin/llc"
+        export OPT="${llvmPackages.llvm}/bin/opt"
     '' + lib.optionalString (!stdenv.isDarwin) ''
         export NIX_LDFLAGS+=" -rpath $out/lib/${targetPrefix}ghc-${version}"
     '' + lib.optionalString stdenv.isDarwin ''

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -230,9 +230,6 @@ stdenv.mkDerivation (rec {
 
   buildInputs = [ perl bash ] ++ (libDeps hostPlatform);
 
-  propagatedBuildInputs = [ targetPackages.stdenv.cc ]
-    ++ lib.optional useLLVM llvmPackages.llvm;
-
   depsTargetTarget = map lib.getDev (libDeps targetPlatform);
   depsTargetTargetPropagated = map (lib.getOutput "out") (libDeps targetPlatform);
 

--- a/lib/ghcjs-project.nix
+++ b/lib/ghcjs-project.nix
@@ -76,7 +76,7 @@ let
     # Inputs needed to boot the GHCJS compiler
     bootInputs = with pkgs.buildPackages; [
             # pin nodejs to the 12 series for now, as strings can only be half the length in node 14+
-            # see https://github.com/nodejs/node/issues/33960, this can break large TH splices for now.            
+            # see https://github.com/nodejs/node/issues/33960, this can break large TH splices for now.
             nodejs-12_x
             makeWrapper
             xorg.lndir
@@ -85,7 +85,7 @@ let
         ]
         ++ [ ghc cabal-install emsdk ];
     # Configured the GHCJS source
-    configured-src = pkgs.runCommand "configured-ghcjs-src" {
+    configured-src = pkgs.runCommandCC "configured-ghcjs-src" {
         buildInputs = configureInputs;
         inherit src;
         } ''
@@ -132,7 +132,7 @@ let
         # see https://github.com/ghcjs/ghcjs/issues/751 for the happy upper bound.
 
     ghcjsProject = pkgs.haskell-nix.cabalProject' (
-        (pkgs.lib.filterAttrs 
+        (pkgs.lib.filterAttrs
             (n: _: !(builtins.any (x: x == n)
                 ["src" "ghcjsVersion" "ghcVersion" "happy" "alex" "cabal-install"])) args) // {
         src = configured-src;
@@ -187,4 +187,3 @@ in ghcjsProject // {
     };
     inherit configureInputs bootInputs configured-src emscriptenupstream emscripten emsdk;
 }
-


### PR DESCRIPTION
Rationale for this change: I'm using ghc to generate configured ghc src for asterius, which requires a non-standard `stdenv` that uses wasm32 cross compile toolchain. `ghc` brings in `gcc` as `propagatedBuildInput` and interferes with the wasm32 C toolchain in subtle ways.

In general, the C compiler path of ghc should have already been hardwired in `settings` file, and ghc shouldn't need to look up `gcc` in `$PATH`.