### PR TITLE
Issue 18708 patch for GHC 8.10

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -186,6 +186,7 @@ in {
                 ++ fromUntil "8.10"   "9.2.2"  ./patches/ghc/MR6654-nonmoving-maxmem.patch  # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6654
                 ++ fromUntil "8.10"   "8.10.8" ./patches/ghc/MR6617-nonmoving-mvar.patch    # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6617
                 ++ fromUntil "8.10"   "8.10.8" ./patches/ghc/MR6595-nonmoving-mutvar.patch  # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6595
+                ++ fromUntil "8.10"   "8.10.8" ./patches/ghc/issue-18708.patch              # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6554
                 ;
         in ({
             ghc844 = final.callPackage ../compiler/ghc {

--- a/overlays/patches/ghc/issue-18708.patch
+++ b/overlays/patches/ghc/issue-18708.patch
@@ -1,0 +1,39 @@
+diff --git a/compiler/GHC/HsToCore/PmCheck/Types.hs b/compiler/GHC/HsToCore/PmCheck/Types.hs
+index 10f172a430..06678b4060 100644
+--- a/compiler/GHC/HsToCore/PmCheck/Types.hs
++++ b/compiler/GHC/HsToCore/PmCheck/Types.hs
+@@ -299,16 +299,17 @@ coreExprAsPmLit e = case collectArgs e of
+     -- Take care of -XRebindableSyntax. The last argument should be the (only)
+     -- integer literal, otherwise we can't really do much about it.
+     | [Lit l] <- dropWhile (not . is_lit) args
+-    -- getOccFS because of -XRebindableSyntax
+-    , getOccFS (idName x) == getOccFS fromIntegerName
++    , is_rebound_name x fromIntegerName
+     -> literalToPmLit (literalType l) l >>= overloadPmLit (exprType e)
+   (Var x, args)
+     -- Similar to fromInteger case
+     | [r] <- dropWhile (not . is_ratio) args
+-    , getOccFS (idName x) == getOccFS fromRationalName
++    , is_rebound_name x fromRationalName
+     -> coreExprAsPmLit r >>= overloadPmLit (exprType e)
+-  (Var x, [Type _ty, _dict, s])
+-    | idName x == fromStringName
++  (Var x, args)
++    | is_rebound_name x fromStringName
++    -- With -XRebindableSyntax or without: The first String argument is what we are after
++    , s:_ <- filter (eqType stringTy . exprType) args
+     -- NB: Calls coreExprAsPmLit and then overloadPmLit, so that we return PmLitOverStrings
+     -> coreExprAsPmLit s >>= overloadPmLit (exprType e)
+   -- These last two cases handle String literals
+@@ -331,6 +332,11 @@ coreExprAsPmLit e = case collectArgs e of
+       | otherwise
+       = False
+ 
++    -- | Compares the given Id to the Name based on OccName, to detect
++    -- -XRebindableSyntax.
++    is_rebound_name :: Id -> Name -> Bool
++    is_rebound_name x n = getOccFS (idName x) == getOccFS n
++
+ instance Outputable PmLitValue where
+   ppr (PmLitInt i)        = ppr i
+   ppr (PmLitRat r)        = ppr (double (fromRat r)) -- good enough


### PR DESCRIPTION
This PR copies a patch authored by @sgraf812 https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6554/diffs?commit_id=917195a1943b783e3745a5e486ee2684c42c1664 for issue https://gitlab.haskell.org/ghc/ghc/-/issues/18708

The patch was backported to the release branch for GHC 8.10.8: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6554?commit_id=917195a1943b783e3745a5e486ee2684c42c1664

I have tested this patch here using GHC 8.10.7: https://github.com/peterbecich/codeworld/tree/nix-ghc-8107

This error occurs with Haskell.nix and unpatched GHC:
```
       > <no location info>: error:
       >     expectJust failed to detect OverLit
```
The error is fixed by using this PR.

--------------

I am not certain this range (8.10 to 8.10.8) is correct https://github.com/input-output-hk/haskell.nix/blob/ba6a539a83fc87083b56eacf0c38a89683b4c682/overlays/bootstrap.nix#L189
because I have only tested the patch for GHC 8.10.7.
