### PR TITLE
Use fixed ghc version when building hoogle

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -45,7 +45,7 @@ let
 
   hoogleLocal = let
     nixpkgsHoogle = import (pkgs.path + /pkgs/development/haskell-modules/hoogle.nix);
-  in { packages ? [], hoogle ? pkgs.buildPackages.haskell-nix.tool compiler.nix-name "hoogle" {
+  in { packages ? [], hoogle ? pkgs.buildPackages.haskell-nix.tool "ghc8107" "hoogle" {
         version = "5.0.18.2";
         index-state = pkgs.haskell-nix.internalHackageIndexState;
       }


### PR DESCRIPTION
Originally, when specifying `withHoogle = true` in `shellFor` without explicit `hoogle` entry in `tools`, `hoogle` will be built with the same GHC version of that project. This is wasteful when testing a matrix of projects instantiated with different GHC versions, since `hoogle` is not dependent on GHC API. Furthermore, the default build doesn't work with `ghc921`, extra modules are needed.

For simplicity, this PR uses `ghc8107` to build the default `hoogle` (same version for `internal-cabal-install` and `internal-nix-tools`), therefore fixing the issue for `ghc921`. We can add a condition check to still use project GHC version for non-`ghc921` versions, but IMHO that's not worth the complexity.