### PR TITLE
update `flake.nix` for Cabal 3.6

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -50,6 +50,23 @@
         "type": "github"
       }
     },
+    "cabal-36": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1640163203,
+        "narHash": "sha256-TwDWP2CffT0j40W6zr0J1Qbu+oh3nsF1lUx9446qxZM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "ecf418050c1821f25e2e218f1be94c31e0465df1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "cardano-shell": {
       "flake": false,
       "locked": {
@@ -232,6 +249,7 @@
         "HTTP": "HTTP",
         "cabal-32": "cabal-32",
         "cabal-34": "cabal-34",
+        "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
         "flake-utils": "flake-utils",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,10 @@
       url = "github:haskell/cabal/3.4";
       flake = false;
     };
+    cabal-36 = {
+      url = "github:haskell/cabal/3.6";
+      flake = false;
+    };
     cardano-shell = {
       url = "github:input-output-hk/cardano-shell";
       flake = false;


### PR DESCRIPTION
Uses https://github.com/haskell/cabal/tree/3.6