### PR TITLE
update GHC used for aarch64 bootstrap

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -40,7 +40,7 @@ let
         }
         else if final.targetPlatform.isAarch64 || final.buildPlatform.isAarch64
         then {
-            compilerNixName = "ghc882";
+            compilerNixName = "ghc884";
         }
         else {
             compilerNixName = "ghc844";


### PR DESCRIPTION
GHC 8.8.2 -> 8.8.4

Might fix this warning?
```
trace: WARNING: 8.8.2 is out of date, consider using 8.8.4.
```
https://github.com/input-output-hk/haskell.nix/issues/1207