### PR TITLE
Add `extraSources` option to `cabalProject` and such

### DIFF
--- a/modules/cabal-project.nix
+++ b/modules/cabal-project.nix
@@ -115,6 +115,21 @@ in {
       type = nullOr (listOf unspecified);
       default = [];
     };
+    extraSources = mkOption {
+      type = nullOr (listOf unspecified);
+      default = null;
+      description = ''
+        Alternative to `source-repository-package` in `cabal.project`:
+        ```nix
+        [
+          {
+            src = somesrc;
+            subdirs = [ "a" "b" "." ];
+          }
+        ]
+        ```
+      '';
+    };
 
     # Used by mkCabalProjectPkgSet
     pkg-def-extras = mkOption {


### PR DESCRIPTION
This allows you to specify the source repositories from Nix in a reliable way.

Example: https://github.com/Plutonomicon/plutarch/blob/d0724a26a81480d17106dff1e542576e1b7ac446/flake.nix#L35