### PR TITLE
Don't set LANG and LOCALE_ARCHIVE in shellFor

### DIFF
--- a/builder/shell-for.nix
+++ b/builder/shell-for.nix
@@ -165,8 +165,6 @@ in
       echo "${"Shell for " + toString (builtins.map (p : p.identifier.name) selectedPackages)}"
       echo $nativeBuildInputs $buildInputs > $out
     '';
-    LANG = "en_US.UTF-8";
-    LOCALE_ARCHIVE = lib.optionalString (stdenv.hostPlatform.libc == "glibc") "${glibcLocales}/lib/locale/locale-archive";
 
     # This helps tools like `ghcide` (that use the ghc api) to find
     # the correct global package DB.


### PR DESCRIPTION
Users will likely have these set already, and would probably prefer to
get their own versions (e.g. I would like to keep my en_GB `LANG`,
please!).

This might mean that some tools struggle in `nix-shell --pure`, but it
seems at least that `cabal build` is fine.

Also, empirically other shell derivations in e.g. nixpkgs don't set
these variables.

Fixes #1336.

(Possibly cc @rvl, who wrote this originally, perhaps you had a reason?)