### PR TITLE
hackage-project: Use given `src`

### DIFF
--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -482,7 +482,7 @@ final: prev: {
                 '');
           in cabalProject' (
             (final.haskell-nix.hackageQuirks { inherit name; version = version'; }) //
-              builtins.removeAttrs args [ "version" "revision" ] // { inherit src; });
+              builtins.removeAttrs args [ "version" "revision" ] // { src = args.src or src; });
 
         # This function is like `cabalProject` but it makes the plan-nix available
         # separately from the hsPkgs.  The advantage is that the you can get the


### PR DESCRIPTION
This was preventing use of custom versions of tools in `cabalProject'`
and similar. E.g. this allows me to use the latest version of HLS that
supports GHC 9.2.1.