### PR TITLE
Update pkgconf-nixpkgs-map.nix

### DIFF
--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -117,6 +117,7 @@ pkgs:
     "pfs-1.2"                            = [ pkgs."pfstools" ];
     "png"                                = [ pkgs."libpng" ];
     "poppler-glib"                       = [ pkgs."poppler" ];
+    "poppler-cpp"                        = [ pkgs."poppler" ];
     "pq"                                 = [ pkgs."postgresql" ];
     "libpq"                              = [ pkgs."postgresql" ];
     "pthread"                            = [];


### PR DESCRIPTION
poppler-cpp is required in package-depends of
https://hg.sr.ht/~geyaeb/haskell-pdftotext/browse/pdftotext.cabal
a.k.a pdftotext on hackage. Successfully tested with aliasing to
poppler in nixpkgs.