### PR TITLE
Fix when `materialized` dir is deep

### DIFF
--- a/lib/materialize.nix
+++ b/lib/materialize.nix
@@ -143,6 +143,7 @@ let
       fi
 
       # Generate the files
+      mkdir -p $TARGET
       rm -rf $TARGET
       cp -r ${calculateNoHash} "$TARGET"
       chmod -R +w "$TARGET"


### PR DESCRIPTION
Consider following `hlint.nix` like [materialization tutorial](https://input-output-hk.github.io/haskell.nix/tutorials/materialization.html).
This file specifies a deep level directory to `materialized`.

```
let sources = import ./nix/sources.nix {};
    haskellNix = import sources.haskellNix {};
    pkgs = import
      haskellNix.sources.nixpkgs-unstable
      haskellNix.nixpkgsArgs;
    hlint = pkgs.haskell-nix.hackage-package {
      compiler-nix-name = "ghc8107";
      name = "hlint";
      version = "2.2.11";
      index-state = "2021-01-04T00:00:00Z";
      plan-sha256 = "0rfiir8ymrrl80lrn77xh6rdkw02kw9gwpcm2qrf4v836yv0wplj";
      materialized = ./deep/dir/to/hlint.materialized;
    };
in hlint
```

In this case materialization failed like this:

```
$ nix-build hlint.nix 2>&1 | grep -om1 '/nix/store/.*-updateMaterialized' | bash
cp: cannot create directory '/private/tmp/sandbox/deep/dir/to/hlint.materialized': No such file or directory
chmod: cannot access '/private/tmp/sandbox/deep/dir/to/hlint.materialized': No such file or directory
```


## Environment:

- MacOS 10.15.7
