### PR TITLE
git-ls-files should prefer local building

### DIFF
--- a/lib/clean-git.nix
+++ b/lib/clean-git.nix
@@ -1,5 +1,5 @@
 # From https://github.com/NixOS/nix/issues/2944
-{ lib, runCommand, git, cleanSourceWith }:
+{ lib, runCommandLocal, git, cleanSourceWith }:
 { name ? null, src, subDir ? "", includeSiblings ? false, keepGitDir ? false }:
 
 # The function call
@@ -112,7 +112,7 @@ then
     # `git ls-files --recurse-submodules` to give us an accurate list
     # of all the files in the index.
     whitelist_files = knownSubmoduleDirs:
-      runCommand "git-ls-files" {} ''
+      runCommandLocal "git-ls-files" {} ''
         tmp=$(mktemp -d)
         cd $tmp
         ${ lib.optionalString hasSubmodules ''
@@ -135,7 +135,7 @@ then
         ${git}/bin/git ls-files --recurse-submodules > $out/files
       '';
 
-    # Find the submodules 
+    # Find the submodules
     whitelist_recursive = knownSubmoduleDirs:
       let
         # Get the new list of submoduleDirs and files
@@ -176,7 +176,7 @@ then
       );
 
     # Identify files in the `.git` dir
-    isGitDirPath = path: 
+    isGitDirPath = path:
           path == origSrcSubDir + "/.git"
         || lib.hasPrefix (origSrcSubDir + "/.git/") path;
 


### PR DESCRIPTION
This derivation should have little cache hit chance, so this should speed up evaluation a little bit in case there are slow substituters.