### PR TITLE
fix: stack cache generator sha256 is a string not a lambda

### DIFF
--- a/lib/stack-cache-generator.nix
+++ b/lib/stack-cache-generator.nix
@@ -83,7 +83,7 @@ concatMap (dep:
             is-private = private dep.url;
             sha256 =
               if dep.sha256 != null then dep.sha256
-              else if sha256map != null then { location, tag, ...}: sha256map."${dep.url}"."${dep.rev}"
+              else if sha256map != null then sha256map."${dep.url}"."${dep.rev}"
               else null;
             branch = lookupBranch {
               location = dep.url;


### PR DESCRIPTION
Making `sha256` attribute a string fixes the following problem with `fetchgit`:

```
error: cannot coerce a function to a string

       at /nix/store/6k0ifa8p59k7snfaxiz4sgqqfvad412p-source/pkgs/build-support/fetchgit/default.nix:70:3:

           69|   outputHashMode = "recursive";
           70|   outputHash = if hash != "" then
             |   ^
           71|     hash
```

(happens only in nixos version is `22.05`)