### PR TITLE
Only pass `--index-state` to `cabal` when asked

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -530,12 +530,12 @@ let
         index-state = cached-index-state;
         sha256 = index-sha256-found;
       }
-    } cabal v2-freeze \
-        --index-state=${
-            # Setting the desired `index-state` here in case it was not
-            # from the cabal.project file. This will further restrict the
-            # packages used by the solver (cached-index-state >= index-state-found).
-           index-state-found} \
+    } cabal v2-freeze ${
+          # Setting the desired `index-state` here in case it is not
+          # in the cabal.project file. This will further restrict the
+          # packages used by the solver (cached-index-state >= index-state-found).
+          pkgs.lib.optionalString (index-state != null) "--index-state=${index-state}"
+        } \
         -w ${
           # We are using `-w` rather than `--with-ghc` here to override
           # the `with-compiler:` in the `cabal.project` file.


### PR DESCRIPTION
Currently we pass the `--index-state` argument to `cabal` for configuration of a project even if it was found in the `cabal.project` file.  This must have seemed harmless enough when we set it up that way, but it causes problems if there are `repository` blocks in the `cabal.project` file.

So for instance if we have a `cabal.project` with:

```
index-state: 2022-01-22T00:00:00Z
index-state: ghcjs-overlay HEAD

repository ghcjs-overlay
  url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/8756b0891a0a550cc8b00dacd24227aee483c0ca
  secure: True
  root-keys:
  key-threshold: 0
```

With the intention of using the `HEAD` version of the `ghcjs-overlay` and letting the commit hash in the `url` ensure it is stable.  The first `index-state` is found and `--index-state 2022-01-22T00:00:00Z` is passed on the command line to `cabal`.  This overrides the `HEAD` setting for `ghcjs-overlay` and because the timestamps in the `ghcjs-overlay` depend solely on when the `hackage-overlay-repo-tool` ran none of them are included.

The solution is to pass `--index-state` to `cabal` only when it was passed into the project function.  When it is not provided `cabal` should still respect the setting in the `cabal.project` file, but it will not elevate it to replace other settings as it does now.