### PR TITLE
Don't use allowSubstitutes=false

### DIFF
--- a/lib/cabal-project-parser.nix
+++ b/lib/cabal-project-parser.nix
@@ -137,10 +137,11 @@ let
       name = __head lines;
       # The $HOME dir with `.cabal` sub directory after running `cabal new-update` to download the repository
       home =
-        pkgs.evalPackages.runCommandLocal name ({
+        pkgs.evalPackages.runCommand name ({
           nativeBuildInputs = [ cabal-install pkgs.evalPackages.curl nix-tools ];
           LOCALE_ARCHIVE = pkgs.lib.optionalString (pkgs.evalPackages.stdenv.buildPlatform.libc == "glibc") "${pkgs.evalPackages.glibcLocales}/lib/locale/locale-archive";
           LANG = "en_US.UTF-8";
+          preferLocalBuild = true;
         } // pkgs.lib.optionalAttrs (sha256 != null) {
           outputHashMode = "recursive";
           outputHashAlgo = "sha256";
@@ -161,10 +162,11 @@ let
         '';
       # Output of hackage-to-nix
       hackage = import (
-        pkgs.evalPackages.runCommandLocal ("hackage-to-nix-" + name) {
+        pkgs.evalPackages.runCommand ("hackage-to-nix-" + name) {
           nativeBuildInputs = [ cabal-install pkgs.evalPackages.curl nix-tools ];
           LOCALE_ARCHIVE = pkgs.lib.optionalString (pkgs.evalPackages.stdenv.buildPlatform.libc == "glibc") "${pkgs.evalPackages.glibcLocales}/lib/locale/locale-archive";
           LANG = "en_US.UTF-8";
+          preferLocalBuild = true;
         } ''
           mkdir -p $out
           hackage-to-nix $out ${home}/.cabal/packages/${name}/01-index.tar ${attrs.url}

--- a/lib/clean-git.nix
+++ b/lib/clean-git.nix
@@ -1,5 +1,5 @@
 # From https://github.com/NixOS/nix/issues/2944
-{ lib, runCommandLocal, git, cleanSourceWith }:
+{ lib, runCommand, git, cleanSourceWith }:
 { name ? null, src, subDir ? "", includeSiblings ? false, keepGitDir ? false }:
 
 # The function call
@@ -112,7 +112,7 @@ then
     # `git ls-files --recurse-submodules` to give us an accurate list
     # of all the files in the index.
     whitelist_files = knownSubmoduleDirs:
-      runCommandLocal "git-ls-files" {} ''
+      runCommand "git-ls-files" { preferLocalBuild = true; } ''
         tmp=$(mktemp -d)
         cd $tmp
         ${ lib.optionalString hasSubmodules ''

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -202,7 +202,7 @@ in {
   cleanGit = import ./clean-git.nix {
     inherit lib cleanSourceWith;
     git = gitMinimal;
-    inherit (pkgs.evalPackages.buildPackages) runCommandLocal;
+    inherit (pkgs.evalPackages.buildPackages) runCommand;
   };
 
   # Some times it is handy to temporarily use a relative path between git

--- a/mk-local-hackage-repo/default.nix
+++ b/mk-local-hackage-repo/default.nix
@@ -17,7 +17,7 @@
 pkgs:
 { name, index }:
 
-pkgs.evalPackages.runCommandLocal "hackage-repo-${name}" {} ''
+pkgs.evalPackages.runCommand "hackage-repo-${name}" { preferLocalBuild = true; } ''
 mkdir -p $out
 export expires="4000-01-01T00:00:00Z"
 

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -211,8 +211,8 @@ final: prev: {
               # dotCabalName anyway.
               dotCabalName = "dot-cabal-" + allNames;
             in
-            # This is very big, and cheap to build: use runCommandLocal to prefer building it locally
-            final.evalPackages.runCommandLocal dotCabalName { nativeBuildInputs = [ cabal-install ]; } ''
+            # This is very big, and cheap to build: prefer building it locally
+            final.evalPackages.runCommand dotCabalName { nativeBuildInputs = [ cabal-install ]; preferLocalBuild = true; } ''
                 mkdir -p $out/.cabal
                 cat <<EOF > $out/.cabal/config
                 ${final.lib.concatStrings (


### PR DESCRIPTION
`runCommandLocal` sets both `preferLocalBuild=true` and
`allowSubstitutes=false`. There's an
[argument](https://github.com/NixOS/nix/issues/4442) that the latter is a
misfeature. There's really no reason not to download something from a
substitutor if it's actually been built already.

We can get the effect that we want easily enough by just setting
`preferLocalBuild=true` alone.