### PR TITLE
Use ghc 8.8.3 to boot native aarch64-linux compiler

### DIFF
--- a/materialized/bootstrap/ghc883/alex/.plan.nix/alex.nix
+++ b/materialized/bootstrap/ghc883/alex/.plan.nix/alex.nix
@@ -1,0 +1,160 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = { small_base = true; };
+    package = {
+      specVersion = "1.8";
+      identifier = { name = "alex"; version = "3.2.4"; };
+      license = "BSD-3-Clause";
+      copyright = "(c) Chis Dornan, Simon Marlow";
+      maintainer = "Simon Marlow <marlowsd@gmail.com>";
+      author = "Chris Dornan and Simon Marlow";
+      homepage = "http://www.haskell.org/alex/";
+      url = "";
+      synopsis = "Alex is a tool for generating lexical analysers in Haskell";
+      description = "Alex is a tool for generating lexical analysers in Haskell.\nIt takes a description of tokens based on regular\nexpressions and generates a Haskell module containing code\nfor scanning text efficiently. It is similar to the tool\nlex or flex for C/C++.";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" ];
+      dataDir = "data/";
+      dataFiles = [
+        "AlexTemplate"
+        "AlexTemplate-ghc"
+        "AlexTemplate-ghc-nopred"
+        "AlexTemplate-ghc-debug"
+        "AlexTemplate-debug"
+        "AlexWrapper-basic"
+        "AlexWrapper-basic-bytestring"
+        "AlexWrapper-strict-bytestring"
+        "AlexWrapper-posn"
+        "AlexWrapper-posn-bytestring"
+        "AlexWrapper-monad"
+        "AlexWrapper-monad-bytestring"
+        "AlexWrapper-monadUserState"
+        "AlexWrapper-monadUserState-bytestring"
+        "AlexWrapper-gscan"
+        ];
+      extraSrcFiles = [
+        "CHANGELOG.md"
+        "README.md"
+        "TODO"
+        "alex.spec"
+        "doc/Makefile"
+        "doc/aclocal.m4"
+        "doc/alex.1.in"
+        "doc/alex.xml"
+        "doc/config.mk.in"
+        "doc/configure.ac"
+        "doc/docbook-xml.mk"
+        "doc/fptools.css"
+        "examples/Makefile"
+        "examples/Tokens.x"
+        "examples/Tokens_gscan.x"
+        "examples/Tokens_posn.x"
+        "examples/examples.x"
+        "examples/haskell.x"
+        "examples/lit.x"
+        "examples/pp.x"
+        "examples/state.x"
+        "examples/tiny.y"
+        "examples/words.x"
+        "examples/words_monad.x"
+        "examples/words_posn.x"
+        "src/Parser.y.boot"
+        "src/Scan.x.boot"
+        "src/ghc_hooks.c"
+        "templates/GenericTemplate.hs"
+        "templates/wrappers.hs"
+        "tests/Makefile"
+        "tests/simple.x"
+        "tests/null.x"
+        "tests/tokens.x"
+        "tests/tokens_gscan.x"
+        "tests/tokens_posn.x"
+        "tests/tokens_bytestring.x"
+        "tests/tokens_posn_bytestring.x"
+        "tests/tokens_scan_user.x"
+        "tests/tokens_strict_bytestring.x"
+        "tests/tokens_monad_bytestring.x"
+        "tests/tokens_monadUserState_bytestring.x"
+        "tests/tokens_bytestring_unicode.x"
+        "tests/basic_typeclass.x"
+        "tests/basic_typeclass_bytestring.x"
+        "tests/default_typeclass.x"
+        "tests/gscan_typeclass.x"
+        "tests/posn_typeclass.x"
+        "tests/monad_typeclass.x"
+        "tests/monad_typeclass_bytestring.x"
+        "tests/monadUserState_typeclass.x"
+        "tests/monadUserState_typeclass_bytestring.x"
+        "tests/posn_typeclass_bytestring.x"
+        "tests/strict_typeclass.x"
+        "tests/unicode.x"
+        ];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      exes = {
+        "alex" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            ] ++ (if flags.small_base
+            then [
+              (hsPkgs."base" or (errorHandler.buildDepError "base"))
+              (hsPkgs."array" or (errorHandler.buildDepError "array"))
+              (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+              (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+              ]
+            else [ (hsPkgs."base" or (errorHandler.buildDepError "base")) ]);
+          buildable = true;
+          modules = [
+            "AbsSyn"
+            "CharSet"
+            "DFA"
+            "DFAMin"
+            "DFS"
+            "Info"
+            "Map"
+            "NFA"
+            "Output"
+            "Paths_alex"
+            "Parser"
+            "ParseMonad"
+            "Scan"
+            "Set"
+            "Sort"
+            "Util"
+            "UTF8"
+            "Data/Ranged"
+            "Data/Ranged/Boundaries"
+            "Data/Ranged/RangedSet"
+            "Data/Ranged/Ranges"
+            ];
+          hsSourceDirs = [ "src" ];
+          mainPath = [ "Main.hs" ] ++ [ "" ];
+          };
+        };
+      tests = {
+        "tests" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."process" or (errorHandler.buildDepError "process"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.alex.components.exes.alex or (pkgs.buildPackages.alex or (errorHandler.buildToolDepError "alex:alex")))
+            ];
+          buildable = true;
+          mainPath = [ "test.hs" ];
+          };
+        };
+      };
+    } // rec { src = (pkgs.lib).mkDefault ../.; }

--- a/materialized/bootstrap/ghc883/alex/default.nix
+++ b/materialized/bootstrap/ghc883/alex/default.nix
@@ -1,0 +1,65 @@
+{
+  pkgs = hackage:
+    {
+      packages = {
+        "array".revision = (((hackage."array")."0.5.4.0").revisions).default;
+        "bytestring".revision = (((hackage."bytestring")."0.10.10.0").revisions).default;
+        "filepath".revision = (((hackage."filepath")."1.4.2.1").revisions).default;
+        "ghc-prim".revision = (((hackage."ghc-prim")."0.5.3").revisions).default;
+        "base".revision = (((hackage."base")."4.13.0.0").revisions).default;
+        "time".revision = (((hackage."time")."1.9.3").revisions).default;
+        "directory".revision = (((hackage."directory")."1.3.6.0").revisions).default;
+        "rts".revision = (((hackage."rts")."1.0").revisions).default;
+        "deepseq".revision = (((hackage."deepseq")."1.4.4.0").revisions).default;
+        "unix".revision = (((hackage."unix")."2.7.2.2").revisions).default;
+        "integer-gmp".revision = (((hackage."integer-gmp")."1.0.2.0").revisions).default;
+        "containers".revision = (((hackage."containers")."0.6.2.1").revisions).default;
+        };
+      compiler = {
+        version = "8.8.3";
+        nix-name = "ghc883";
+        packages = {
+          "array" = "0.5.4.0";
+          "bytestring" = "0.10.10.0";
+          "filepath" = "1.4.2.1";
+          "ghc-prim" = "0.5.3";
+          "base" = "4.13.0.0";
+          "time" = "1.9.3";
+          "directory" = "1.3.6.0";
+          "rts" = "1.0";
+          "deepseq" = "1.4.4.0";
+          "unix" = "2.7.2.2";
+          "integer-gmp" = "1.0.2.0";
+          "containers" = "0.6.2.1";
+          };
+        };
+      };
+  extras = hackage:
+    { packages = { alex = ./.plan.nix/alex.nix; }; };
+  modules = [
+    ({ lib, ... }:
+      {
+        packages = {
+          "alex" = { flags = { "small_base" = lib.mkOverride 900 true; }; };
+          };
+        })
+    ({ lib, ... }:
+      {
+        packages = {
+          "filepath".components.library.planned = lib.mkOverride 900 true;
+          "bytestring".components.library.planned = lib.mkOverride 900 true;
+          "ghc-prim".components.library.planned = lib.mkOverride 900 true;
+          "array".components.library.planned = lib.mkOverride 900 true;
+          "rts".components.library.planned = lib.mkOverride 900 true;
+          "unix".components.library.planned = lib.mkOverride 900 true;
+          "directory".components.library.planned = lib.mkOverride 900 true;
+          "time".components.library.planned = lib.mkOverride 900 true;
+          "alex".components.exes."alex".planned = lib.mkOverride 900 true;
+          "deepseq".components.library.planned = lib.mkOverride 900 true;
+          "base".components.library.planned = lib.mkOverride 900 true;
+          "integer-gmp".components.library.planned = lib.mkOverride 900 true;
+          "containers".components.library.planned = lib.mkOverride 900 true;
+          };
+        })
+    ];
+  }

--- a/materialized/bootstrap/ghc883/happy-1.19.12/.plan.nix/happy.nix
+++ b/materialized/bootstrap/ghc883/happy-1.19.12/.plan.nix/happy.nix
@@ -1,0 +1,200 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = { small_base = true; };
+    package = {
+      specVersion = "1.8";
+      identifier = { name = "happy"; version = "1.19.12"; };
+      license = "BSD-2-Clause";
+      copyright = "(c) Andy Gill, Simon Marlow";
+      maintainer = "Simon Marlow <marlowsd@gmail.com>";
+      author = "Andy Gill and Simon Marlow";
+      homepage = "https://www.haskell.org/happy/";
+      url = "";
+      synopsis = "Happy is a parser generator for Haskell";
+      description = "Happy is a parser generator for Haskell.  Given a grammar\nspecification in BNF, Happy generates Haskell code to parse the\ngrammar.  Happy works in a similar way to the @yacc@ tool for C.";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" ];
+      dataDir = "data/";
+      dataFiles = [
+        "HappyTemplate"
+        "HappyTemplate-arrays"
+        "HappyTemplate-arrays-coerce"
+        "HappyTemplate-arrays-coerce-debug"
+        "HappyTemplate-arrays-debug"
+        "HappyTemplate-arrays-ghc"
+        "HappyTemplate-arrays-ghc-debug"
+        "HappyTemplate-coerce"
+        "HappyTemplate-ghc"
+        "GLR_Base"
+        "GLR_Lib"
+        "GLR_Lib-ghc"
+        "GLR_Lib-ghc-debug"
+        ];
+      extraSrcFiles = [
+        "ANNOUNCE"
+        "CHANGES"
+        "Makefile"
+        "README.md"
+        "TODO"
+        "doc/Makefile"
+        "doc/aclocal.m4"
+        "doc/config.mk.in"
+        "doc/configure.ac"
+        "doc/docbook-xml.mk"
+        "doc/fptools.css"
+        "doc/happy.1.in"
+        "doc/happy.xml"
+        "examples/glr/nlp/Main.lhs"
+        "examples/glr/nlp/Makefile"
+        "examples/glr/nlp/README"
+        "examples/glr/nlp/English.y"
+        "examples/glr/nlp/Hugs.lhs"
+        "examples/glr/Makefile"
+        "examples/glr/Makefile.defs"
+        "examples/glr/expr-eval/Main.lhs"
+        "examples/glr/expr-eval/Makefile"
+        "examples/glr/expr-eval/Expr.y"
+        "examples/glr/expr-eval/README"
+        "examples/glr/expr-eval/Hugs.lhs"
+        "examples/glr/expr-tree/Main.lhs"
+        "examples/glr/expr-tree/Makefile"
+        "examples/glr/expr-tree/Expr.y"
+        "examples/glr/expr-tree/README"
+        "examples/glr/expr-tree/Tree.lhs"
+        "examples/glr/expr-tree/Hugs.lhs"
+        "examples/glr/highly-ambiguous/Main.lhs"
+        "examples/glr/highly-ambiguous/Makefile"
+        "examples/glr/highly-ambiguous/Expr.y"
+        "examples/glr/highly-ambiguous/README"
+        "examples/glr/highly-ambiguous/Hugs.lhs"
+        "examples/glr/hidden-leftrec/Main.lhs"
+        "examples/glr/hidden-leftrec/Makefile"
+        "examples/glr/hidden-leftrec/Expr.y"
+        "examples/glr/hidden-leftrec/README"
+        "examples/glr/hidden-leftrec/Hugs.lhs"
+        "examples/glr/expr-monad/Main.lhs"
+        "examples/glr/expr-monad/Makefile"
+        "examples/glr/expr-monad/Expr.y"
+        "examples/glr/expr-monad/README"
+        "examples/glr/expr-monad/Hugs.lhs"
+        "examples/glr/bio-eg/Main.lhs"
+        "examples/glr/bio-eg/Makefile"
+        "examples/glr/bio-eg/Bio.y"
+        "examples/glr/bio-eg/README"
+        "examples/glr/bio-eg/1-1200.dna"
+        "examples/glr/bio-eg/1-600.dna"
+        "examples/glr/common/DV_lhs"
+        "examples/glr/common/DaVinciTypes.hs"
+        "examples/glr/packing/Main.lhs"
+        "examples/glr/packing/Makefile"
+        "examples/glr/packing/Expr.y"
+        "examples/glr/packing/README"
+        "examples/glr/packing/Hugs.lhs"
+        "examples/PgnParser.ly"
+        "examples/MonadTest.ly"
+        "examples/igloo/ParserM.hs"
+        "examples/igloo/Makefile"
+        "examples/igloo/Parser.y"
+        "examples/igloo/Foo.hs"
+        "examples/igloo/README"
+        "examples/igloo/Lexer.x"
+        "examples/README"
+        "examples/Calc.ly"
+        "examples/DavesExample.ly"
+        "examples/ErrorTest.ly"
+        "examples/ErlParser.ly"
+        "examples/SimonsExample.ly"
+        "examples/LexerTest.ly"
+        "happy.spec"
+        "src/ARRAY-NOTES"
+        "tests/AttrGrammar001.y"
+        "tests/AttrGrammar002.y"
+        "tests/Makefile"
+        "tests/Partial.ly"
+        "tests/Test.ly"
+        "tests/TestMulti.ly"
+        "tests/TestPrecedence.ly"
+        "tests/bogus-token.y"
+        "tests/bug001.ly"
+        "tests/bug002.y"
+        "tests/error001.stderr"
+        "tests/error001.stdout"
+        "tests/error001.y"
+        "tests/monad001.y"
+        "tests/monad002.ly"
+        "tests/monaderror.y"
+        "tests/precedence001.ly"
+        "tests/precedence002.y"
+        "tests/test_rules.y"
+        "tests/issue91.y"
+        "tests/issue93.y"
+        "tests/issue94.y"
+        "tests/issue95.y"
+        "tests/monaderror-explist.y"
+        "tests/typeclass_monad001.y"
+        "tests/typeclass_monad002.ly"
+        "tests/typeclass_monad_lexer.y"
+        "tests/rank2.y"
+        ];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      exes = {
+        "happy" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."array" or (errorHandler.buildDepError "array"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+            ];
+          buildable = true;
+          modules = [
+            "Paths_happy"
+            "AbsSyn"
+            "First"
+            "GenUtils"
+            "Grammar"
+            "Info"
+            "LALR"
+            "Lexer"
+            "ParseMonad"
+            "Parser"
+            "ProduceCode"
+            "ProduceGLRCode"
+            "NameSet"
+            "Target"
+            "AttrGrammar"
+            "AttrGrammarParser"
+            "ParamRules"
+            "PrettyGrammar"
+            ];
+          hsSourceDirs = [ "src" ];
+          mainPath = [ "Main.lhs" ];
+          };
+        };
+      tests = {
+        "tests" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."process" or (errorHandler.buildDepError "process"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.happy.components.exes.happy or (pkgs.buildPackages.happy or (errorHandler.buildToolDepError "happy:happy")))
+            ];
+          buildable = true;
+          mainPath = [ "test.hs" ];
+          };
+        };
+      };
+    } // rec { src = (pkgs.lib).mkDefault ../.; }

--- a/materialized/bootstrap/ghc883/happy-1.19.12/default.nix
+++ b/materialized/bootstrap/ghc883/happy-1.19.12/default.nix
@@ -1,0 +1,56 @@
+{
+  pkgs = hackage:
+    {
+      packages = {
+        "array".revision = (((hackage."array")."0.5.4.0").revisions).default;
+        "mtl".revision = (((hackage."mtl")."2.2.2").revisions).default;
+        "ghc-prim".revision = (((hackage."ghc-prim")."0.5.3").revisions).default;
+        "base".revision = (((hackage."base")."4.13.0.0").revisions).default;
+        "rts".revision = (((hackage."rts")."1.0").revisions).default;
+        "transformers".revision = (((hackage."transformers")."0.5.6.2").revisions).default;
+        "deepseq".revision = (((hackage."deepseq")."1.4.4.0").revisions).default;
+        "integer-gmp".revision = (((hackage."integer-gmp")."1.0.2.0").revisions).default;
+        "containers".revision = (((hackage."containers")."0.6.2.1").revisions).default;
+        };
+      compiler = {
+        version = "8.8.3";
+        nix-name = "ghc883";
+        packages = {
+          "array" = "0.5.4.0";
+          "mtl" = "2.2.2";
+          "ghc-prim" = "0.5.3";
+          "base" = "4.13.0.0";
+          "rts" = "1.0";
+          "transformers" = "0.5.6.2";
+          "deepseq" = "1.4.4.0";
+          "integer-gmp" = "1.0.2.0";
+          "containers" = "0.6.2.1";
+          };
+        };
+      };
+  extras = hackage:
+    { packages = { happy = ./.plan.nix/happy.nix; }; };
+  modules = [
+    ({ lib, ... }:
+      {
+        packages = {
+          "happy" = { flags = { "small_base" = lib.mkOverride 900 true; }; };
+          };
+        })
+    ({ lib, ... }:
+      {
+        packages = {
+          "ghc-prim".components.library.planned = lib.mkOverride 900 true;
+          "array".components.library.planned = lib.mkOverride 900 true;
+          "rts".components.library.planned = lib.mkOverride 900 true;
+          "happy".components.exes."happy".planned = lib.mkOverride 900 true;
+          "mtl".components.library.planned = lib.mkOverride 900 true;
+          "transformers".components.library.planned = lib.mkOverride 900 true;
+          "deepseq".components.library.planned = lib.mkOverride 900 true;
+          "base".components.library.planned = lib.mkOverride 900 true;
+          "integer-gmp".components.library.planned = lib.mkOverride 900 true;
+          "containers".components.library.planned = lib.mkOverride 900 true;
+          };
+        })
+    ];
+  }

--- a/materialized/bootstrap/ghc883/hscolour/.plan.nix/hscolour.nix
+++ b/materialized/bootstrap/ghc883/hscolour/.plan.nix/hscolour.nix
@@ -1,0 +1,70 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.6";
+      identifier = { name = "hscolour"; version = "1.24.4"; };
+      license = "LicenseRef-LGPL";
+      copyright = "2003-2017 Malcolm Wallace; 2006 Bjorn Bringert";
+      maintainer = "Malcolm Wallace";
+      author = "Malcolm Wallace";
+      homepage = "http://code.haskell.org/~malcolm/hscolour/";
+      url = "";
+      synopsis = "Colourise Haskell code.";
+      description = "hscolour is a small Haskell script to colourise Haskell code. It currently\nhas six output formats:\nANSI terminal codes (optionally XTerm-256colour codes),\nHTML 3.2 with <font> tags,\nHTML 4.01 with CSS,\nHTML 4.01 with CSS and mouseover annotations,\nXHTML 1.0 with inline CSS styling,\nLaTeX,\nand mIRC chat codes.";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENCE-LGPL" ];
+      dataDir = ".";
+      dataFiles = [ "hscolour.css" "data/rgb24-example-.hscolour" ];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          ];
+        buildable = true;
+        modules = [
+          "Language/Haskell/HsColour"
+          "Language/Haskell/HsColour/ANSI"
+          "Language/Haskell/HsColour/Anchors"
+          "Language/Haskell/HsColour/ACSS"
+          "Language/Haskell/HsColour/CSS"
+          "Language/Haskell/HsColour/Classify"
+          "Language/Haskell/HsColour/ColourHighlight"
+          "Language/Haskell/HsColour/Colourise"
+          "Language/Haskell/HsColour/General"
+          "Language/Haskell/HsColour/HTML"
+          "Language/Haskell/HsColour/InlineCSS"
+          "Language/Haskell/HsColour/LaTeX"
+          "Language/Haskell/HsColour/MIRC"
+          "Language/Haskell/HsColour/Options"
+          "Language/Haskell/HsColour/Output"
+          "Language/Haskell/HsColour/TTY"
+          ];
+        };
+      exes = {
+        "HsColour" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            ];
+          buildable = true;
+          mainPath = [ "HsColour.hs" ];
+          };
+        };
+      };
+    } // rec { src = (pkgs.lib).mkDefault ../.; }

--- a/materialized/bootstrap/ghc883/hscolour/default.nix
+++ b/materialized/bootstrap/ghc883/hscolour/default.nix
@@ -1,0 +1,47 @@
+{
+  pkgs = hackage:
+    {
+      packages = {
+        "array".revision = (((hackage."array")."0.5.4.0").revisions).default;
+        "ghc-prim".revision = (((hackage."ghc-prim")."0.5.3").revisions).default;
+        "base".revision = (((hackage."base")."4.13.0.0").revisions).default;
+        "rts".revision = (((hackage."rts")."1.0").revisions).default;
+        "deepseq".revision = (((hackage."deepseq")."1.4.4.0").revisions).default;
+        "integer-gmp".revision = (((hackage."integer-gmp")."1.0.2.0").revisions).default;
+        "containers".revision = (((hackage."containers")."0.6.2.1").revisions).default;
+        };
+      compiler = {
+        version = "8.8.3";
+        nix-name = "ghc883";
+        packages = {
+          "array" = "0.5.4.0";
+          "ghc-prim" = "0.5.3";
+          "base" = "4.13.0.0";
+          "rts" = "1.0";
+          "deepseq" = "1.4.4.0";
+          "integer-gmp" = "1.0.2.0";
+          "containers" = "0.6.2.1";
+          };
+        };
+      };
+  extras = hackage:
+    { packages = { hscolour = ./.plan.nix/hscolour.nix; }; };
+  modules = [
+    ({ lib, ... }:
+      { packages = { "hscolour" = { flags = {}; }; }; })
+    ({ lib, ... }:
+      {
+        packages = {
+          "ghc-prim".components.library.planned = lib.mkOverride 900 true;
+          "array".components.library.planned = lib.mkOverride 900 true;
+          "rts".components.library.planned = lib.mkOverride 900 true;
+          "hscolour".components.library.planned = lib.mkOverride 900 true;
+          "hscolour".components.exes."HsColour".planned = lib.mkOverride 900 true;
+          "deepseq".components.library.planned = lib.mkOverride 900 true;
+          "base".components.library.planned = lib.mkOverride 900 true;
+          "integer-gmp".components.library.planned = lib.mkOverride 900 true;
+          "containers".components.library.planned = lib.mkOverride 900 true;
+          };
+        })
+    ];
+  }

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -38,7 +38,11 @@ let
         then {
             compilerNixName = "ghc8107";
         }
-        else if final.targetPlatform.isAarch64 || final.buildPlatform.isAarch64
+        else if final.buildPlatform.isAarch64
+        then {
+            compilerNixName = "ghc883";
+        }
+        else if final.targetPlatform.isAarch64
         then {
             compilerNixName = "ghc884";
         }
@@ -62,8 +66,12 @@ let
       "8.8" = "8.8.4";
       "8.10" = "8.10.7";
     };
-    traceWarnOld = v: x: __trace
-      "WARNING: ${x.src-spec.version} is out of date, consider using ${latestVer.${v}}." x;
+    traceWarnOld = v: x:
+      # There is no binary for aarch64-linux ghc 8.8.4 so don't warn about 8.8.3
+      if x.src-spec.version == "8.8.3" && (final.targetPlatform.isAarch64 || final.buildPlatform.isAarch64)
+        then x
+        else __trace
+          "WARNING: ${x.src-spec.version} is out of date, consider using ${latestVer.${v}}." x;
     errorOldGhcjs = v: up: throw "ghcjs ${v} is no longer supported by haskell.nix. Consider using ${latestVer.${up}}";
 in {
   haskell-nix = prev.haskell-nix // {


### PR DESCRIPTION
For some reason there is no binary for 8.8.4 see:

https://downloads.haskell.org/ghc/8.8.3/
https://downloads.haskell.org/ghc/8.8.4/