### PR TITLE
Add `icu-i18n` as alias to `nixpks-map`

### DIFF
--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -80,6 +80,7 @@ with pkgs;
   opencv = [ opencv3 ];
   icuuc = [ icu ];
   icui18n = [ icu ];
+  icu-i18n = [ icu ];
   icudata = [ icu ];
   vulkan = [ vulkan-loader ];
   sodium = [ libsodium ];


### PR DESCRIPTION
This is necessary because this alias is used by `text-icu` https://github.com/haskell/text-icu/blob/master/text-icu.cabal#L72