### PR TITLE
configureFlags must be a list in newer nixpkgs

### DIFF
--- a/overlays/musl.nix
+++ b/overlays/musl.nix
@@ -16,7 +16,7 @@ final: prev: prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl ({
   zstd = prev.zstd.override { static = true; };
   pcre = prev.pcre.overrideAttrs (_: { dontDisableStatic = true; });
 
-  numactl = prev.numactl.overrideAttrs (_: { configureFlags = "--enable-static"; });
+  numactl = prev.numactl.overrideAttrs (_: { configureFlags = ["--enable-static"];});
 
   # See https://github.com/input-output-hk/haskell.nix/issues/948
   postgresql = (prev.postgresql.overrideAttrs (old: { dontDisableStatic = true; }))


### PR DESCRIPTION
When compiling against the `musl` ABI with `isStatic = true` the following line throws an error because `configureFlags` is assumed to be a list:
https://github.com/NixOS/nixpkgs/blob/7cd9f4e83350c564bb3c0a2da80677d97cef5d4c/pkgs/stdenv/adapters.nix#L66