### PR TITLE
Make DLLs in deps available to wine TH runner

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -161,6 +161,8 @@ in {
                 ++ fromUntil "8.8.2" "8.9"                ./patches/ghc/ghc-8.8.2-reinstallable-lib-ghc.patch
                 ++ final.lib.optional (version == "8.6.4") ./patches/ghc/ghc-8.6.4-better-plusSimplCountErrors.patch
                 ++ final.lib.optional (versionAtLeast "8.6.4" && versionLessThan "9.0" && final.stdenv.isDarwin) ./patches/ghc/ghc-macOS-loadArchive-fix.patch
+                ++ final.lib.optional (versionAtLeast "9.0.0" && versionLessThan "9.2" && final.stdenv.isDarwin) ./patches/ghc/ghc-9.0-macOS-loadArchive-fix.patch
+                ++ final.lib.optional (versionAtLeast "9.2.0" && versionLessThan "9.3" && final.stdenv.isDarwin) ./patches/ghc/ghc-9.2-macOS-loadArchive-fix.patch
                 ++ final.lib.optional (versionAtLeast "8.4.4" && versionLessThan "8.10" && final.stdenv.isDarwin) ./patches/ghc/ghc-darwin-gcc-version-fix.patch
                 ++ final.lib.optional (versionAtLeast "8.10.1" && versionLessThan "9.0.2" && final.stdenv.isDarwin) ./patches/ghc/ghc-8.10-darwin-gcc-version-fix.patch
                 # backport of https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3227

--- a/overlays/mingw_w64.nix
+++ b/overlays/mingw_w64.nix
@@ -39,7 +39,7 @@ let
     # This was a problem for `double-conversion` package when used in TH code.
     # Creating links from the `X.dll` to `libX.dll` works around this issue.
     (
-    cd $out/bin
+    cd $REMOTE_ISERV
     for l in lib*.dll; do
       ln -s "$l" "''${l#lib}"
     done

--- a/overlays/mingw_w64.nix
+++ b/overlays/mingw_w64.nix
@@ -35,12 +35,6 @@ let
       find "$p" -iname '*.dll' -exec ln -s {} $REMOTE_ISERV \;
       find "$p" -iname '*.dll.a' -exec ln -s {} $REMOTE_ISERV \;
     done
-    (
-    cd $REMOTE_ISERV
-    for l in lib*.dll; do
-      if [[ ! -e "''${l#lib}" ]]; then ln -s "$l" "''${l#lib}"; fi
-    done
-    )
     WINEDLLOVERRIDES="winemac.drv=d" WINEDEBUG=warn-all,fixme-all,-menubuilder,-mscoree,-ole,-secur32,-winediag WINEPREFIX=$TMP ${wine}/bin/wine64 $REMOTE_ISERV/remote-iserv.exe tmp $PORT &
     (>&2 echo "---| remote-iserv should have started on $PORT")
     RISERV_PID="$!"

--- a/overlays/mingw_w64.nix
+++ b/overlays/mingw_w64.nix
@@ -30,7 +30,7 @@ let
     (>&2 echo "---> Starting remote-iserv on port $PORT")
     REMOTE_ISERV=$(mktemp -d)
     ln -s ${if enableProfiling then remote-iserv.override { inherit enableProfiling; } else remote-iserv}/bin/* $REMOTE_ISERV
-    -- See coment in comp-builder.nix for where this comes from and why it's here
+    # See coment in comp-builder.nix for where this comes from and why it's here
     for p in $pkgsHostTargetAsString; do
       find "$p" -iname '*.dll' -exec ln -s {} $REMOTE_ISERV \;
       find "$p" -iname '*.dll.a' -exec ln -s {} $REMOTE_ISERV \;

--- a/overlays/mingw_w64.nix
+++ b/overlays/mingw_w64.nix
@@ -28,7 +28,19 @@ let
     unset configureFlags
     PORT=$((5000 + $RANDOM % 5000))
     (>&2 echo "---> Starting remote-iserv on port $PORT")
-    WINEDLLOVERRIDES="winemac.drv=d" WINEDEBUG=warn-all,fixme-all,-menubuilder,-mscoree,-ole,-secur32,-winediag WINEPREFIX=$TMP ${wine}/bin/wine64 ${remote-iserv}/bin/remote-iserv.exe tmp $PORT &
+    REMOTE_ISERV=$(mktemp -d)
+    ln -s ${remote-iserv}/bin/* $REMOTE_ISERV
+    for p in $pkgsHostTargetAsString; do
+      find "$p" -iname '*.dll' -exec ln -s {} $REMOTE_ISERV \;
+      find "$p" -iname '*.dll.a' -exec ln -s {} $REMOTE_ISERV \;
+    done
+    (
+    cd $REMOTE_ISERV
+    for l in lib*.dll; do
+      if [[ ! -e "''${l#lib}" ]]; then ln -s "$l" "''${l#lib}"; fi
+    done
+    )
+    WINEDLLOVERRIDES="winemac.drv=d" WINEDEBUG=warn-all,fixme-all,-menubuilder,-mscoree,-ole,-secur32,-winediag WINEPREFIX=$TMP ${wine}/bin/wine64 $REMOTE_ISERV/remote-iserv.exe tmp $PORT &
     (>&2 echo "---| remote-iserv should have started on $PORT")
     RISERV_PID="$!"
     ${iserv-proxy}/bin/iserv-proxy $@ 127.0.0.1 "$PORT"
@@ -46,7 +58,19 @@ let
     unset configureFlags
     PORT=$((5000 + $RANDOM % 5000))
     (>&2 echo "---> Starting remote-iserv on port $PORT")
-    WINEDLLOVERRIDES="winemac.drv=d" WINEDEBUG=warn-all,fixme-all,-menubuilder,-mscoree,-ole,-secur32,-winediag WINEPREFIX=$TMP ${wine}/bin/wine64 ${remote-iserv.override { enableProfiling = true; }}/bin/remote-iserv.exe tmp $PORT &
+    REMOTE_ISERV=$(mktemp -d)
+    ln -s ${remote-iserv.override { enableProfiling = true; }}/bin/* $REMOTE_ISERV
+    for p in $pkgsHostTargetAsString; do
+      find "$p" -iname '*.dll' -exec ln -s {} $REMOTE_ISERV \;
+      find "$p" -iname '*.dll.a' -exec ln -s {} $REMOTE_ISERV \;
+    done
+    (
+    cd $REMOTE_ISERV
+    for l in lib*.dll; do
+      if [[ ! -e "''${l#lib}" ]]; then ln -s "$l" "''${l#lib}"; fi
+    done
+    )
+    WINEDLLOVERRIDES="winemac.drv=d" WINEDEBUG=warn-all,fixme-all,-menubuilder,-mscoree,-ole,-secur32,-winediag WINEPREFIX=$TMP ${wine}/bin/wine64 $REMOTE_ISERV/remote-iserv.exe tmp $PORT &
     (>&2 echo "---| remote-iserv should have started on $PORT")
     RISERV_PID="$!"
     ${iserv-proxy}/bin/iserv-proxy $@ 127.0.0.1 "$PORT"

--- a/overlays/mingw_w64.nix
+++ b/overlays/mingw_w64.nix
@@ -30,6 +30,7 @@ let
     (>&2 echo "---> Starting remote-iserv on port $PORT")
     REMOTE_ISERV=$(mktemp -d)
     ln -s ${remote-iserv.override { inherit enableProfiling; }}/bin/* $REMOTE_ISERV
+    -- See coment in comp-builder.nix for where this comes from and why it's here
     for p in $pkgsHostTargetAsString; do
       find "$p" -iname '*.dll' -exec ln -s {} $REMOTE_ISERV \;
       find "$p" -iname '*.dll.a' -exec ln -s {} $REMOTE_ISERV \;

--- a/overlays/mingw_w64.nix
+++ b/overlays/mingw_w64.nix
@@ -35,6 +35,15 @@ let
       find "$p" -iname '*.dll' -exec ln -s {} $REMOTE_ISERV \;
       find "$p" -iname '*.dll.a' -exec ln -s {} $REMOTE_ISERV \;
     done
+    # Some DLLs have a `lib` prefix but we attempt to load them without the prefix.
+    # This was a problem for `double-conversion` package when used in TH code.
+    # Creating links from the `X.dll` to `libX.dll` works around this issue.
+    (
+    cd $out/bin
+    for l in lib*.dll; do
+      ln -s "$l" "''${l#lib}"
+    done
+    )
     WINEDLLOVERRIDES="winemac.drv=d" WINEDEBUG=warn-all,fixme-all,-menubuilder,-mscoree,-ole,-secur32,-winediag WINEPREFIX=$TMP ${wine}/bin/wine64 $REMOTE_ISERV/remote-iserv.exe tmp $PORT &
     (>&2 echo "---| remote-iserv should have started on $PORT")
     RISERV_PID="$!"

--- a/overlays/mingw_w64.nix
+++ b/overlays/mingw_w64.nix
@@ -29,7 +29,7 @@ let
     PORT=$((5000 + $RANDOM % 5000))
     (>&2 echo "---> Starting remote-iserv on port $PORT")
     REMOTE_ISERV=$(mktemp -d)
-    ln -s ${remote-iserv.override { inherit enableProfiling; }}/bin/* $REMOTE_ISERV
+    ln -s ${if enableProfiling then remote-iserv.override { inherit enableProfiling; } else remote-iserv}/bin/* $REMOTE_ISERV
     -- See coment in comp-builder.nix for where this comes from and why it's here
     for p in $pkgsHostTargetAsString; do
       find "$p" -iname '*.dll' -exec ln -s {} $REMOTE_ISERV \;

--- a/overlays/patches/ghc/ghc-9.0-macOS-loadArchive-fix.patch
+++ b/overlays/patches/ghc/ghc-9.0-macOS-loadArchive-fix.patch
@@ -1,0 +1,9 @@
+--- a/compiler/GHC/Runtime/Linker.hs
++++ b/compiler/GHC/Runtime/Linker.hs
+@@ -1487,7 +1487,6 @@ locateLib hsc_env is_hs lib_dirs gcc_dirs lib
+      dyn_obj_file = lib <.> "dyn_o"
+      arch_files = [ "lib" ++ lib ++ lib_tag <.> "a"
+                   , lib <.> "a" -- native code has no lib_tag
+-                  , "lib" ++ lib, lib
+                   ]
+      lib_tag = if is_hs && loading_profiled_hs_libs then "_p" else ""

--- a/overlays/patches/ghc/ghc-9.2-macOS-loadArchive-fix.patch
+++ b/overlays/patches/ghc/ghc-9.2-macOS-loadArchive-fix.patch
@@ -1,0 +1,9 @@
+--- a/compiler/GHC/Linker/Loader.hs
++++ b/compiler/GHC/Linker/Loader.hs
+@@ -1487,7 +1487,6 @@ locateLib hsc_env is_hs lib_dirs gcc_dirs lib
+      dyn_obj_file = lib <.> "dyn_o"
+      arch_files = [ "lib" ++ lib ++ lib_tag <.> "a"
+                   , lib <.> "a" -- native code has no lib_tag
+-                  , "lib" ++ lib, lib
+                   ]
+      lib_tag = if is_hs && loading_profiled_hs_libs then "_p" else ""

--- a/overlays/windows.nix
+++ b/overlays/windows.nix
@@ -78,12 +78,6 @@ final: prev:
               find "$p" -iname '*.dll' -exec cp {} $out/bin/ \;
               find "$p" -iname '*.dll.a' -exec cp {} $out/bin/ \;
             done
-            (
-            cd $out/bin
-            for l in lib*.dll; do
-              ln -s "$l" "''${l#lib}"
-            done
-            )
           '');
 
           # Apply https://github.com/haskell/cabal/pull/6055

--- a/overlays/windows.nix
+++ b/overlays/windows.nix
@@ -73,7 +73,7 @@ final: prev:
           # dependencies) and then placing them somewhere where wine+remote-iserv
           # will find them.
           remote-iserv.postInstall = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isWindows (
-            let extra-libs = [ pkgs.openssl.bin pkgs.libffi pkgs.gmp (pkgs.libsodium-vrf or pkgs.libsodium) pkgs.windows.mcfgthreads pkgs.buildPackages.gcc.cc pkgs.secp256k1 ]; in ''
+            let extra-libs = [ pkgs.libffi pkgs.gmp pkgs.windows.mcfgthreads pkgs.buildPackages.gcc.cc ]; in ''
             for p in ${lib.concatStringsSep " "extra-libs}; do
               find "$p" -iname '*.dll' -exec cp {} $out/bin/ \;
               find "$p" -iname '*.dll.a' -exec cp {} $out/bin/ \;

--- a/test/default.nix
+++ b/test/default.nix
@@ -202,6 +202,7 @@ let
     sublib-docs = callTest ./sublib-docs { inherit util compiler-nix-name; };
     githash = haskell-nix.callPackage ./githash { inherit compiler-nix-name; testSrc = testSrcWithGitDir; };
     c-ffi = callTest ./c-ffi { inherit util compiler-nix-name; };
+    th-dlls = callTest ./th-dlls { inherit util compiler-nix-name; };
 
     unit = unitTests;
   };

--- a/test/th-dlls/default.nix
+++ b/test/th-dlls/default.nix
@@ -21,6 +21,8 @@ let
   packages = project.hsPkgs;
 
 in recurseIntoAttrs {
+  meta.disabled = stdenv.hostPlatform.isGhcjs;
+
   ifdInputs = {
     inherit (project) plan-nix;
   };

--- a/test/th-dlls/default.nix
+++ b/test/th-dlls/default.nix
@@ -1,0 +1,30 @@
+# Test a package set
+{ stdenv, lib, util, mkCabalProjectPkgSet, project', haskellLib, recurseIntoAttrs, testSrc, compiler-nix-name }:
+
+with lib;
+
+let
+  modules = [
+     {
+       # Package has no exposed modules which causes
+       #   haddock: No input file(s)
+       packages.cabal-simple.doHaddock = false;
+     }
+  ];
+
+  project = project' {
+    inherit compiler-nix-name;
+    src = testSrc "th-dlls";
+    inherit modules;
+  };
+
+  packages = project.hsPkgs;
+
+in recurseIntoAttrs {
+  ifdInputs = {
+    inherit (project) plan-nix;
+  };
+
+  build = packages.th-dlls.components.library;
+  build-profiled = packages.th-dlls.components.library.profiled;
+}

--- a/test/th-dlls/default.nix
+++ b/test/th-dlls/default.nix
@@ -1,21 +1,12 @@
-# Test a package set
-{ stdenv, lib, util, mkCabalProjectPkgSet, project', haskellLib, recurseIntoAttrs, testSrc, compiler-nix-name }:
+# Test building TH code that needs DLLs when cross compiling for windows
+{ stdenv, lib, project', haskellLib, recurseIntoAttrs, testSrc, compiler-nix-name }:
 
 with lib;
 
 let
-  modules = [
-     {
-       # Package has no exposed modules which causes
-       #   haddock: No input file(s)
-       packages.cabal-simple.doHaddock = false;
-     }
-  ];
-
   project = project' {
     inherit compiler-nix-name;
     src = testSrc "th-dlls";
-    inherit modules;
   };
 
   packages = project.hsPkgs;

--- a/test/th-dlls/default.nix
+++ b/test/th-dlls/default.nix
@@ -1,5 +1,5 @@
 # Test building TH code that needs DLLs when cross compiling for windows
-{ stdenv, lib, project', haskellLib, recurseIntoAttrs, testSrc, compiler-nix-name }:
+{ stdenv, lib, util, project', haskellLib, recurseIntoAttrs, testSrc, compiler-nix-name }:
 
 with lib;
 

--- a/test/th-dlls/src/Lib.hs
+++ b/test/th-dlls/src/Lib.hs
@@ -6,6 +6,9 @@ import OpenSSL (withOpenSSL)
 import OpenSSL.BN (withBN)
 import Libsodium (sodium_init)
 import Language.Haskell.TH.Syntax (Exp(..), Lit(..))
+import Data.Text as T
+import Data.Double.Conversion.Text (toShortest)
 
 x = $(liftIO (withOpenSSL (withBN 0 (\_ -> return (LitE (IntegerL 0))))))
 y = $(liftIO (sodium_init >> return (LitE (IntegerL 0))))
+z = $(liftIO (return (LitE (IntegerL (fromIntegral (T.length (toShortest 1.0)))))))

--- a/test/th-dlls/src/Lib.hs
+++ b/test/th-dlls/src/Lib.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Lib where
+
+import Control.Monad.IO.Class (liftIO)
+import OpenSSL (withOpenSSL)
+import OpenSSL.BN (withBN)
+import Libsodium (sodium_init)
+import Language.Haskell.TH.Syntax (Exp(..), Lit(..))
+
+x = $(liftIO (withOpenSSL (withBN 0 (\_ -> return (LitE (IntegerL 0))))))
+y = $(liftIO (sodium_init >> return (LitE (IntegerL 0))))

--- a/test/th-dlls/th-dlls.cabal
+++ b/test/th-dlls/th-dlls.cabal
@@ -1,0 +1,16 @@
+cabal-version:       >=1.10
+name:                th-dlls
+version:             0.1.0.0
+license:             PublicDomain
+author:              Hamish Mackenzie
+maintainer:          Hamish.K.Mackenzie@gmail.com
+build-type:          Simple
+
+library
+  build-depends:       base
+                     , HsOpenSSL
+                     , libsodium
+                     , template-haskell
+  exposed-modules:     Lib
+  hs-source-dirs:      src
+  default-language:    Haskell2010

--- a/test/th-dlls/th-dlls.cabal
+++ b/test/th-dlls/th-dlls.cabal
@@ -11,6 +11,8 @@ library
                      , HsOpenSSL
                      , libsodium
                      , template-haskell
+                     , text
+                     , double-conversion
   exposed-modules:     Lib
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
This is a better fix to the problem of making DLLs available to the process running in wine that is used to evaluate TH code when cross compiling for Windows.