### PR TITLE
Remove `canCleanSource`

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -68,7 +68,11 @@ in rec {
       ];
     };
     check-materialization-concurrency = pkgs.buildPackages.callPackage ./scripts/check-materialization-concurrency/check.nix {};
-    check-path-support = pkgs.buildPackages.callPackage ./scripts/check-path-support.nix {};
+    check-path-support = pkgs.buildPackages.callPackage ./scripts/check-path-support.nix {
+      # TODO remove this when nixpkgs-2205 is released and used for `pkgs`
+      # check-path-support fails unless we have nix 2.4 or newer.
+      inherit (import haskellNix.sources.nixpkgs-unstable {}) nix;
+    };
   };
 
   # These are pure parts of maintainer-script so they can be built by hydra

--- a/lib/call-stack-to-nix.nix
+++ b/lib/call-stack-to-nix.nix
@@ -24,15 +24,12 @@ let
 
   subDir' = src.origSubDir or "";
   subDir = pkgs.lib.strings.removePrefix "/" subDir';
-  maybeCleanedSource =
-    if haskellLib.canCleanSource src
-      then (haskellLib.cleanSourceWith {
-        name = if name != null then "${name}-root-cabal-files" else "source-root-cabal-files";
-        src = src.origSrc or src;
-        filter = path: type: (!(src ? filter) || src.filter path type) && (
-          type == "directory" ||
-          pkgs.lib.any (i: (pkgs.lib.hasSuffix i path)) [ stackYaml ".cabal" "package.yaml" ]); })
-      else src.origSrc or src;
+  cleanedSource = (haskellLib.cleanSourceWith {
+    name = if name != null then "${name}-root-cabal-files" else "source-root-cabal-files";
+    src = src.origSrc or src;
+    filter = path: type: (!(src ? filter) || src.filter path type) && (
+      type == "directory" ||
+      pkgs.lib.any (i: (pkgs.lib.hasSuffix i path)) [ stackYaml ".cabal" "package.yaml" ]); });
 
   stackToNixArgs = builtins.concatStringsSep " " [
     "--full"
@@ -59,14 +56,14 @@ let
     mkdir -p $out${subDir'}
     SRC=$(mktemp -d)
     cd $SRC
-    # if maybeCleanedSource is empty, this means it's a new
+    # if cleanedSource is empty, this means it's a new
     # project where the files haven't been added to the git
     # repo yet. We fail early and provide a useful error
     # message to prevent headaches (#290).
-    if [ -z "$(ls -A ${maybeCleanedSource})" ]; then
+    if [ -z "$(ls -A ${cleanedSource})" ]; then
       echo "cleaned source is empty. Did you forget to 'git add -A'?"; exit 1;
     fi
-    lndir -silent "${maybeCleanedSource}/." $SRC
+    lndir -silent "${cleanedSource}/." $SRC
     ${pkgs.lib.optionalString (subDir != "") "cd ${subDir}"}
     ${
     # If a resolver was fetched use the it instead of the original stack.yaml

--- a/lib/clean-cabal-component.nix
+++ b/lib/clean-cabal-component.nix
@@ -1,6 +1,6 @@
 # Use cleanSourceWith to filter just the files needed for a particular
 # component of the package
-{ lib, cleanSourceWith, canCleanSource }: package: component: componentName: src:
+{ lib, cleanSourceWith }: package: component: componentName: src:
 let
   srcStr' = src.origSrc or null;
   subDir = if src.origSubDir or "" == ""
@@ -56,7 +56,7 @@ let
         then p
         else p + "/";
 in
-  if srcStr' == null || package.detailLevel != "FullDetails" || !canCleanSource src
+  if srcStr' == null || package.detailLevel != "FullDetails"
     then src
     else
       let

--- a/lib/clean-source-with.nix
+++ b/lib/clean-source-with.nix
@@ -2,7 +2,10 @@
 # https://github.com/NixOS/nixpkgs/blob/1d9d31a0eb8e8358830528538a391df52f6a075a/lib/sources.nix#L41
 # It adds a subDir argument in a way that allows descending into a subdirectory
 # to compose with cleaning the source with a filter.
-{ lib }: rec {
+{ lib }:
+if lib.versionOlder builtins.nixVersion "2.4"
+then throw "Nix version 2.4 or higher is required for Haskell.nix"
+else rec {
 
   # Like `builtins.filterSource`, except it will compose with itself,
   # allowing you to chain multiple calls together without any
@@ -113,6 +116,4 @@
       _isLibCleanSourceWith = origSubDir == "";
       name = name';
     };
-
-  pathHasContext = builtins.hasContext or (lib.hasPrefix builtins.storeDir);
 }

--- a/lib/clean-source-with.nix
+++ b/lib/clean-source-with.nix
@@ -115,9 +115,4 @@
     };
 
   pathHasContext = builtins.hasContext or (lib.hasPrefix builtins.storeDir);
-
-  canCleanSource = src:
-       src ? _isLibCleanSourceWithEx
-    || src ? _isLibCleanSourceWith
-    || !(pathHasContext (toString src));
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -192,11 +192,11 @@ in {
   collectChecks' = collectChecks (_: true);
 
   # Replacement for lib.cleanSourceWith that has a subDir argument.
-  inherit (import ./clean-source-with.nix { inherit lib; }) cleanSourceWith canCleanSource;
+  inherit (import ./clean-source-with.nix { inherit lib; }) cleanSourceWith;
 
   # Use cleanSourceWith to filter just the files needed for a particular
   # component of a package
-  cleanCabalComponent = import ./clean-cabal-component.nix { inherit lib cleanSourceWith canCleanSource; };
+  cleanCabalComponent = import ./clean-cabal-component.nix { inherit lib cleanSourceWith; };
 
   # Clean git directory based on `git ls-files --recurse-submodules`
   cleanGit = import ./clean-git.nix {
@@ -290,26 +290,9 @@ in {
     if subDir == ""
       then src
       else
-        if haskellLib.canCleanSource src
-          then haskellLib.cleanSourceWith {
-            inherit src subDir includeSiblings;
-          }
-          else let name = src.name or "source" + "-" + __replaceStrings ["/"] ["-"] subDir;
-            in if includeSiblings
-              then rec {
-                # Keep `src.origSrc` so it can be used to allow references
-                # to other parts of that root.
-                inherit name;
-                origSrc = src.origSrc or src;
-                origSubDir = src.origSubDir or "" + "/" + subDir;
-                outPath = origSrc + origSubDir;
-              }
-              else {
-                # We are not going to need other parts of `origSrc` if there
-                # was one and we can ignore it
-                inherit name;
-                outPath = src + "/" + subDir;
-              };
+        haskellLib.cleanSourceWith {
+          inherit src subDir includeSiblings;
+        };
 
   # Givin a `src` split it into a `root` path (based on `src.origSrc` if
   # present) and `subDir` (based on `src.origSubDir).  The

--- a/lib/import-and-filter-project.nix
+++ b/lib/import-and-filter-project.nix
@@ -6,14 +6,11 @@
 let
   # Full source including possible relative paths form the
   # project directory.
-  srcRoot =
-    if haskellLib.canCleanSource src
-      then haskellLib.cleanSourceWith {
-        name = if src ? name then "${src.name}-root" else "source-root";
-        src = src.origSrc or src;
-        filter = src.filter or (_: _: true);
-      }
-      else src.origSrc or src;
+  srcRoot = haskellLib.cleanSourceWith {
+    name = if src ? name then "${src.name}-root" else "source-root";
+    src = src.origSrc or src;
+    filter = src.filter or (_: _: true);
+  };
   # The sub directory containing the cabal.project or stack.yaml file
   projectSubDir' = src.origSubDir or "";                                     # With leading /
   projectSubDir = pkgs.lib.strings.removePrefix "/" projectSubDir';          # Without /

--- a/lib/stack-cache-generator.nix
+++ b/lib/stack-cache-generator.nix
@@ -30,25 +30,22 @@ let
       }) resolver fetchedResolver;
 
     # Filter just the stack yaml file and any resolver yaml file it points to.
-    maybeCleanedSource =
-      if haskellLib.canCleanSource src
-        then haskellLib.cleanSourceWith {
-          inherit src;
-          filter = path: type:
-            let
-              origSrc = if src ? _isLibCleanSourceWith then src.origSrc else src;
-              origSubDir = if src ? _isLibCleanSourceWithEx then src.origSubDir else "";
-              relPath = pkgs.lib.removePrefix (toString origSrc + origSubDir + "/") path;
+    maybeCleanedSource = haskellLib.cleanSourceWith {
+      inherit src;
+      filter = path: type:
+        let
+          origSrc = if src ? _isLibCleanSourceWith then src.origSrc else src;
+          origSubDir = if src ? _isLibCleanSourceWithEx then src.origSubDir else "";
+          relPath = pkgs.lib.removePrefix (toString origSrc + origSubDir + "/") path;
 
-              # checks if path1 is a parent directory for path2
-              isParent = path1: path2: pkgs.lib.hasPrefix "${path1}/" path2;
+          # checks if path1 is a parent directory for path2
+          isParent = path1: path2: pkgs.lib.hasPrefix "${path1}/" path2;
 
-            in
-              (relPath == stackYaml)
-              || (resolver != null && (relPath == resolver || isParent relPath resolver))
-            ;
-        }
-        else src;
+        in
+          (relPath == stackYaml)
+          || (resolver != null && (relPath == resolver || isParent relPath resolver))
+        ;
+    };
 
     # All repos served via ssh or git protocols are usually private
     private = url: pkgs.lib.substring 0 4 url != "http";

--- a/overlays/hydra.nix
+++ b/overlays/hydra.nix
@@ -1,4 +1,8 @@
 { sources, ...}:
+# This hydra overlay is required to circumvent problems with builtins.path
+# in restricted eval mode.
+# This can be removed once hydra in nixpkgs is based on a recent enough nix,
+# which contains this fix: https://github.com/NixOS/nix/pull/5163
 
 final: prev: {
   hydra-unstable = sources.hydra.defaultPackage.${prev.system};

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 3
+, ifdLevel ? 0
 , checkMaterialization ? false }:
 
 let

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 1
+, ifdLevel ? 2
 , checkMaterialization ? false }:
 
 let

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 2
+, ifdLevel ? 3
 , checkMaterialization ? false }:
 
 let

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 0
+, ifdLevel ? 1
 , checkMaterialization ? false }:
 
 let

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 1
+, ifdLevel ? 0
 , checkMaterialization ? false }:
 
 let


### PR DESCRIPTION
Following up on #1403

Done:
- remove `haskellLib.canCleanSource` including all of its usage
- add comment to hydra overlay
- add nix version check and throw error if nix < 2.4.
