### PR TITLE
Replace deprecated NixOS binary cache settings

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -25,10 +25,10 @@ If you're running NixOS, you need to add/update the following in your `/etc/nixo
 
 ```
 # Binary Cache for Haskell.nix
-nix.binaryCachePublicKeys = [
+nix.settings.trusted-public-keys = [
   "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
 ];
-nix.binaryCaches = [
+nix.settings.substituters = [
   "https://hydra.iohk.io"
 ];
 ```


### PR DESCRIPTION
`nix.binaryCachePublicKeys` and `nix.binaryCaches` are now deprecated in NixOS: the current names for these settings are `nix.settings.trusted-public-keys` and `nix.settings.substituters`, respectively