### PR TITLE
support cabal.project source-repository-package commit

### DIFF
--- a/lib/cabal-project-parser.nix
+++ b/lib/cabal-project-parser.nix
@@ -76,7 +76,7 @@ let
   # (used in call-cabal-project-to-nix.nix to create a fixed-output derivation)
   extractSourceRepoPackageData = cabalProjectFileName: sha256map: repo: {
     url = repo.location;
-    ref = repo.tag;
+    ref = if repo ? commit then repo.commit else repo.tag;
     sha256 = repo."--sha256" or (
       if sha256map != null
         then sha256map."${repo.location}"."${repo.tag}"


### PR DESCRIPTION
Support using a commit hash instead of tag on `cabal.project` `source-repository-package`.

If one puts the commit has in the `tag:` field instead, `cabal-project-parser` works, but `cabal` crashes while trying to download a tag instead of a commit.
