### PR TITLE
Don't duplicate the `configureFlags` when not on Windows

### DIFF
--- a/overlays/windows.nix
+++ b/overlays/windows.nix
@@ -16,12 +16,12 @@ final: prev:
   #   postFixup = "";
   #  });
 } // prev.lib.optionalAttrs (prev ? mfpr) {
-   mfpr = prev.mfpr.overrideAttrs (drv: {
-     configureFlags = (drv.configureFlags or []) ++ prev.lib.optional prev.stdenv.hostPlatform.isWindows "--enable-static --disable-shared" ;
+   mfpr = if !prev.stdenv.hostPlatform.isWindows then prev.mpfr else prev.mfpr.overrideAttrs (drv: {
+     configureFlags = (drv.configureFlags or []) ++ [ "--enable-static --disable-shared" ];
    });
 } // {
-   libmpc = prev.libmpc.overrideAttrs (drv: {
-     configureFlags = (drv.configureFlags or []) ++ prev.lib.optional prev.stdenv.hostPlatform.isWindows "--enable-static --disable-shared" ;
+   libmpc = if !prev.stdenv.hostPlatform.isWindows then prev.libmpc else prev.libmpc.overrideAttrs (drv: {
+     configureFlags = (drv.configureFlags or []) ++ [ "--enable-static --disable-shared" ];
    });
 
    binutils-unwrapped = prev.binutils-unwrapped.overrideAttrs (attrs: {


### PR DESCRIPTION
When not on Windows, the `configureFlags` attr of `libmpc` is set to
`(drv.configureFlags or [])`. Since `drv.configureFlags` seems to be equal to
`["--enable-static" "--disable-shared"]` (at least on my machine),
`configureFlags` appears to be merged with itself and in the end, it is equal
to:
`["--enable-static" "--disable-shared" "--enable-static" "--disable-shared"]`.

You can verify this by comparing the derivations of `libmpc` with and without
this patch.

This changes the derivation of `libmpc` as well the derivation of all dependent
packages, like `gcc`, causing cache misses from https://cache.nixos.org/.

Because these packages are built and stored in the IOHK cache, users don't
notice this, until they use a different version of `nixpkgs` than the one pinned
by `haskell.nix`, e.g., one with a different version of `glibc` so that the IOHK
cache cannot be used. This results in `gcc` and other packages being built from
scratch instead of being downloaded from https://cache.nixos.org/.

Fix this by hoisting the conditional one level higher so that `overrideAttrs`
isn't even called on non-Windows OSes. Do the same for `mpfr` for consistency.

I haven't tested this on Windows. I'm not sure whether I have hoisted the
conditional too high, see the first comment in the file.