### PR TITLE
Look for DLLs in /bin directory of pkgconfig deps

### DIFF
--- a/builder/make-config-files.nix
+++ b/builder/make-config-files.nix
@@ -82,7 +82,10 @@ let
 
     ${lib.concatStringsSep "\n" (lib.mapAttrsToList flagsAndConfig {
       "extra-lib-dirs" = map (p: "${lib.getLib p}/lib") component.libs
-        ++ lib.optionals (stdenv.hostPlatform.isWindows) (map (p: "${lib.getBin p}/bin") component.libs);
+        # On windows also include `bin` directories that may contain DLLs
+        ++ lib.optionals (stdenv.hostPlatform.isWindows)
+          (map (p: "${lib.getBin p}/bin")
+               (component.libs ++ lib.concatLists component.pkgconfig));
       "extra-include-dirs" = map (p: "${lib.getDev p}/include") component.libs;
       "extra-framework-dirs" = map (p: "${p}/Library/Frameworks") component.frameworks;
     })}

--- a/builder/shell-for.nix
+++ b/builder/shell-for.nix
@@ -96,6 +96,7 @@ let
   component = {
     depends = packageInputs;
     libs = [];
+    pkgconfig = [];
     frameworks = [];
     doExactConfig = false;
   };


### PR DESCRIPTION
We include the /bin directory of `component.libs` in `extra-lib-dirs` on windows, but not `components.pkgconfig`.  This causes confusing differences between the behavior depending on how a dependency was specified in the `.cabal` file or added in a module.  If it wounds up in `components.libs` the need for DLLs would propagate correctly, but if it was only in `componets.pkgconfig` DLLs would not be included when building TH code and did not get symlinked to `exe` component output /bin dirs.