### PR TITLE
Fix links to troubleshooting Markdown pages

### DIFF
--- a/docs/tutorials/getting-started-flakes.md
+++ b/docs/tutorials/getting-started-flakes.md
@@ -25,7 +25,7 @@ trusted-public-keys = [...] hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNG
 substituters = [...] https://hydra.iohk.io [...]
 ```
 
-This can be tricky to get setup properly. If you're still having trouble getting cache hits, consult the corresponding [troubleshooting section](../reference/troubleshooting#why-am-i-building-ghc).
+This can be tricky to get setup properly. If you're still having trouble getting cache hits, consult the corresponding [troubleshooting section](../troubleshooting.md#why-am-i-building-ghc).
 
 ## Scaffolding
 

--- a/docs/tutorials/getting-started-hix.md
+++ b/docs/tutorials/getting-started-hix.md
@@ -32,7 +32,7 @@ trusted-public-keys = [...] hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNG
 substituters = [...] https://hydra.iohk.io [...]
 ```
 
-This can be tricky to get setup properly. If you're still having trouble getting cache hits, consult the corresponding [troubleshooting section](../reference/troubleshooting#why-am-i-building-ghc).
+This can be tricky to get setup properly. If you're still having trouble getting cache hits, consult the corresponding [troubleshooting section](../troubleshooting.md#why-am-i-building-ghc).
 
 ## Installing Hix
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -33,7 +33,7 @@ nix.settings.substituters = [
 ];
 ```
 
-This can be tricky to get setup properly. If you're still having trouble getting cache hits, consult the corresponding [troubleshooting section](../../troubleshooting#why-am-i-building-ghc).
+This can be tricky to get setup properly. If you're still having trouble getting cache hits, consult the corresponding [troubleshooting section](../troubleshooting.md#why-am-i-building-ghc).
 
 ## Niv
 


### PR DESCRIPTION
Just a small documentation improvement: I ran into one of the broken links when going through the Flakes tutorial, and found two more similar ones.