### PR TITLE
Fix typo in GHC versions table: ghc2105 → ghc2111

### DIFF
--- a/docs/reference/supported-ghc-versions.md
+++ b/docs/reference/supported-ghc-versions.md
@@ -22,8 +22,8 @@ really should use an instance of Nixpkgs provided by `haskell.nix` itself.
 |------------------|--------------------|-------------|-----------------------|---------------|
 | 21.05            | `nixpkgs-2105`     | 8.6.5       | `ghc865`              | No            |
 | 21.05            | `nixpkgs-2105`     | 8.10.7      | `ghc8107`             | No            |
-| 21.11            | `nixpkgs-2105`     | 8.6.5       | `ghc865`              | No            |
-| 21.11            | `nixpkgs-2105`     | 8.10.7      | `ghc8107`             | Yes           |
+| 21.11            | `nixpkgs-2111`     | 8.6.5       | `ghc865`              | No            |
+| 21.11            | `nixpkgs-2111`     | 8.10.7      | `ghc8107`             | Yes           |
 | unstable         | `nixpkgs-unstable` | 8.6.5       | `ghc865`              | No            |
 | unstable         | `nixpkgs-unstable` | 8.8.4       | `ghc884`              | No            |
 | unstable         | `nixpkgs-unstable` | 8.10.4      | `ghc8104`             | No            |


### PR DESCRIPTION
There's a typo in the table of supported versions: two of the 21.11 rows should say `nixpkgs-2111` rather than `nixpkgs-2105`. This threw me off for a bit earlier because I skimmed the table and thought 21.11 wasn't supported yet.