### PR TITLE
Revert "Don't duplicate the configureFlags when not on Windows (#1420)"

### DIFF
--- a/overlays/windows.nix
+++ b/overlays/windows.nix
@@ -16,12 +16,12 @@ final: prev:
   #   postFixup = "";
   #  });
 } // prev.lib.optionalAttrs (prev ? mfpr) {
-   mfpr = if !prev.stdenv.hostPlatform.isWindows then prev.mpfr else prev.mfpr.overrideAttrs (drv: {
-     configureFlags = (drv.configureFlags or []) ++ [ "--enable-static --disable-shared" ];
+   mfpr = prev.mfpr.overrideAttrs (drv: {
+     configureFlags = (drv.configureFlags or []) ++ prev.lib.optional prev.stdenv.hostPlatform.isWindows "--enable-static --disable-shared" ;
    });
 } // {
-   libmpc = if !prev.stdenv.hostPlatform.isWindows then prev.libmpc else prev.libmpc.overrideAttrs (drv: {
-     configureFlags = (drv.configureFlags or []) ++ [ "--enable-static --disable-shared" ];
+   libmpc = prev.libmpc.overrideAttrs (drv: {
+     configureFlags = (drv.configureFlags or []) ++ prev.lib.optional prev.stdenv.hostPlatform.isWindows "--enable-static --disable-shared" ;
    });
 
    binutils-unwrapped = prev.binutils-unwrapped.overrideAttrs (attrs: {


### PR DESCRIPTION
I have no idea what this is for but it is causing so much breakage for us. https://github.com/input-output-hk/haskell.nix/issues/1444