### PR TITLE
fix binary cache for nixos

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -24,9 +24,25 @@ substituters = [...] https://hydra.iohk.io [...]
 If you're running NixOS, you need to add/update the following in your `/etc/nixos/configuration.nix` files instead.
 
 ```
+# Binary Cache for Haskell.nix
+nix.settings.trusted-public-keys = [
+  "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+];
+nix.settings.substituters = [
+  "https://hydra.iohk.io"
+];
+```
+
+NixOS-21.11 and older use slightly different settings.
+
+```
 # Binary Cache for Haskell.nix  
-nix.binaryCaches = [ "https://hydra.iohk.io" ];   
-nix.binaryCachePublicKeys = [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ]
+nix.binaryCachePublicKeys = [
+  "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+];
+nix.binaryCaches = [
+  "https://hydra.iohk.io"
+];   
 ```
 
 This can be tricky to get setup properly. If you're still having trouble getting cache hits, consult the corresponding [troubleshooting section](../troubleshooting.md#why-am-i-building-ghc).

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -24,13 +24,9 @@ substituters = [...] https://hydra.iohk.io [...]
 If you're running NixOS, you need to add/update the following in your `/etc/nixos/configuration.nix` files instead.
 
 ```
-# Binary Cache for Haskell.nix
-nix.settings.trusted-public-keys = [
-  "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
-];
-nix.settings.substituters = [
-  "https://hydra.iohk.io"
-];
+# Binary Cache for Haskell.nix  
+nix.binaryCaches = [ "https://hydra.iohk.io" ];   
+nix.binaryCachePublicKeys = [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ]
 ```
 
 This can be tricky to get setup properly. If you're still having trouble getting cache hits, consult the corresponding [troubleshooting section](../troubleshooting.md#why-am-i-building-ghc).


### PR DESCRIPTION
The instructions for setting up the binary cache on NixOS produce the following error:

```
[root@r9:~]# nixos-rebuild switch  
error: The option `nix.settings' does not exist. Definition values:  
- In `/etc/nixos/configuration.nix':  
   {  
     substituters = [  
       "https://hydra.iohk.io"  
     ];  
     trusted-public-keys = [  
   ...  
(use '--show-trace' to show detailed location information) 
```

The PR fixes this.  I am using this on my NixOS system and it seems to work fine.