### PR TITLE
Support 'extra-libraries: m'

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -23,6 +23,7 @@ let
     hix = import ./hix.nix;
     eval-packages = import ./eval-packages.nix combined;
     ghcjs = import ./ghcjs.nix;
+    libm = import ./libm.nix;
   };
 
   composeExtensions = f: g: final: prev:
@@ -58,6 +59,7 @@ let
     hix
     eval-packages
     hydra
+    libm
     # Restore nixpkgs haskell and haskellPackages
     (_: prev: { inherit (prev.haskell-nix-prev) haskell haskellPackages; })
   ];

--- a/overlays/libm.nix
+++ b/overlays/libm.nix
@@ -1,0 +1,15 @@
+self: super:
+
+{
+  # Some packages have cabal deps on `m`, which just comes with the C compiler.
+  # So we create a dummy package to satisfy haskell.nix's dependency resolution.
+  m = self.stdenv.mkDerivation {
+    name = "m";
+    unpackPhase = "true";
+    # We have to create lib and bin to make it "look like" a library
+    installPhase = ''
+    mkdir -p $out/lib
+    mkdir -p $out/bin
+    '';
+  };
+}


### PR DESCRIPTION
I've been using this overlay in my project (compiling natively on NixOS + x-compiling to Windows) for over a year now.

`hgeometry` is the most notable Haskell library I know of that does this.