### PR TITLE
Build bzip2 & xz with static libs in musl crossPkgs

### DIFF
--- a/overlays/musl.nix
+++ b/overlays/musl.nix
@@ -14,6 +14,8 @@ final: prev: prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl ({
   ncurses = prev.ncurses.override { enableStatic = true; };
   libsodium = prev.libsodium.overrideAttrs (_: { dontDisableStatic = true; });
   zstd = prev.zstd.override { static = true; };
+  xz = prev.xz.override { enableStatic = true; };
+  lzma = prev.lzma.override { enableStatic = true; };
   pcre = prev.pcre.overrideAttrs (_: { dontDisableStatic = true; });
   secp256k1 = prev.secp256k1.overrideAttrs ( oldAttrs: {
     configureFlags = oldAttrs.configureFlags ++ ["--enable-static"];  });

--- a/overlays/musl.nix
+++ b/overlays/musl.nix
@@ -9,7 +9,7 @@ final: prev: prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl ({
   zlib = prev.zlib.override { splitStaticOutput = false; };
 
   # and a few more packages that need their static libs explicitly enabled
-  bzip2 = prev.bzip2.overrideAttrs (_: { dontDisableStatic = true; });
+  bzip2 = prev.bzip2.override { linkStatic = true; };
   gmp = prev.gmp.override { withStatic = true; };
   ncurses = prev.ncurses.override { enableStatic = true; };
   libsodium = prev.libsodium.overrideAttrs (_: { dontDisableStatic = true; });


### PR DESCRIPTION
I am not sure why the previous `bzip2` fix (using `dontDisableStatic = true`) didn't work, but it led to missing libraries. This patch also seems more consistent with how the rest of the packages are handled, though.

The `xz`/`lzma` override is a new addition, but I think fits in the spirit of the existing ones

Using these two fixes, [NGless](https://github.com/ngless-toolkit/ngless) now builds correctly in static mode and I hope to use this method to build package for users (your efforts are much appreciated).