### PR TITLE
Fix cleanGit when src is a git submodule.

### DIFF
--- a/lib/clean-git.nix
+++ b/lib/clean-git.nix
@@ -65,9 +65,13 @@ then
                 first_line = head git_content;
                 prefix = "gitdir: ";
                 ok = length git_content == 1 && lib.hasPrefix prefix first_line;
+                raw_path = remove_prefix prefix first_line;
               in
                 if ok
-                then /. + remove_prefix prefix first_line
+                then
+                  if lib.hasPrefix "/" raw_path
+                  then /. + raw_path
+                  else /. + builtins.toPath (origSrcSubDir + "/" + raw_path)
                 else abort "gitSource.nix: Cannot parse ${origSrcSubDir + "/.git"}";
     }));
 


### PR DESCRIPTION
Suppose you have a repository with a submodule checked out in the
subdirectory `smod`.

`cleanGit { src = ./smod; }` would return the following error:

    error: getting status of '/.git/modules/smod': No such file or directory

`smod/.git` is a file that contains a reference to the git module repo.

    gitdir: ../.git/modules/smod

This is the same as a worktree (in fact, isWorktree = true here),
but it's a relative path instead of an absolute path.