### PR TITLE
implement fix for Ormolu in `nix-shell`

### DIFF
--- a/overlays/hackage-quirks.nix
+++ b/overlays/hackage-quirks.nix
@@ -66,6 +66,15 @@ in { haskell-nix = prev.haskell-nix // {
       })];
     };
 
+    ormolu = {
+      modules = [
+        ({ lib, ... }: {
+          options.nonReinstallablePkgs =
+            lib.mkOption { apply = lib.remove "Cabal"; };
+        })
+      ];
+    };
+
   }."${name}" or {};
 
 }; }


### PR DESCRIPTION
Closes https://github.com/input-output-hk/haskell.nix/issues/1337

Implemented this suggestion: https://github.com/input-output-hk/haskell.nix/issues/1337#issuecomment-1011372895

It is tested here: https://github.com/peterbecich/haskell.nix-ghcjs-issue/tree/test-ormolu
`nix-shell` works; `ormolu` is available

```
[nix-shell:~/haskell/haskell.nix-ghcjs-issue]$ ormolu --version
ormolu 0.5.0.0 UNKNOWN UNKNOWN
using ghc-lib-parser 9.2.2.20220307

[nix-shell:~/haskell/haskell.nix-ghcjs-issue]$ which ormolu
/nix/store/61zk1g60k5m0lq8nxw3i4dhqyafar954-ormolu-exe-ormolu-0.5.0.0/bin/ormolu
```