### PR TITLE
Make stack more like cabal

### DIFF
--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -415,7 +415,7 @@ final: prev: {
                             )
                         else
                           final.evalPackages.fetchgit { inherit url rev sha256; };
-                    } // final.buildPackages.lib.optionalAttrs (subdir != null) { postUnpack = "sourceRoot+=/${subdir}; echo source root reset to $sourceRoot"; };
+                    } // final.buildPackages.lib.optionalAttrs (subdir != null && subdir != ".") { postUnpack = "sourceRoot+=/${subdir}; echo source root reset to $sourceRoot"; };
                   };
 
                   cacheMap = builtins.map repoToAttr cache;


### PR DESCRIPTION
When comparing `cabalProject` and `stackProject` with `nix-diff` source repository packages sometimes show up differently because an unnecessary `postUnpack` hook is added for `stackProject`.