### PR TITLE
fix roots: eliminate boolean value from path set for linkFarm

### DIFF
--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -910,8 +910,9 @@ final: prev: {
         # project as it will automatically match the `compiler-nix-name`
         # of the project.
         roots = compiler-nix-name: final.linkFarm "haskell-nix-roots-${compiler-nix-name}"
-          (final.lib.mapAttrsToList (name: path: { inherit name path; })
-            (roots' compiler-nix-name 2));
+          (final.lib.filter (x: x.name != "recurseForDerivations")
+            (final.lib.mapAttrsToList (name: path: { inherit name path; })
+              (roots' compiler-nix-name 2)));
 
         roots' = compiler-nix-name: ifdLevel:
           	final.recurseIntoAttrs ({


### PR DESCRIPTION
When using haskell.nix with recent nixpkgs, building `roots` of Haskell project (that is, something like
```nix
((import <nixpkgs> (import <haskellnix> {}).nixpkgsArgs).haskell-nix.stackProject { some = stuff; }).roots
```
) results in the following evaluation error inside `linkFarm`:

```
error: cannot coerce a Boolean to a string
       at /nix/store/XXX-nixpkgs/pkgs/build-support/trivial-builders.nix:480:39:
          479|           mkdir -p "$(dirname ${lib.escapeShellArg x.name})"
          480|           ln -s ${lib.escapeShellArg "${x.path}"} ${lib.escapeShellArg x.name}
             |                                       ^
          481|       '') entries}
       … while evaluating 'escapeShellArg'
...
```

The problem is that the attrset in `roots` contains, among others, the `recurseForDerivations: true` key-value, which is then passed into `linkFarm`. It looks like it shouldn't be there, but anyway, it's been fine until recently - specifically since https://github.com/NixOS/nixpkgs/commit/f2a91a66798a192fa14f94a04aad1e9ce5ea1814 `linkFarm` does not coerce booleans into strings anymore.

The fix in this PR is straightforward and dumb, but it seems to solve the problem for my build server - I'd be glad to see a smarter fix, but I'm not very familiar with haskell.nix internals.

Thanks.