### PR TITLE
Fix for ghc-lib-parser 9.2 and haskell.nix patched ghc

### DIFF
--- a/modules/configuration-nix.nix
+++ b/modules/configuration-nix.nix
@@ -58,7 +58,8 @@ in {
   packages.mintty.components.library.build-tools = pkgs.lib.mkForce [];
 
   packages.ghc-lib-parser.patches = [
-    (fromUntil "8.10.0.0" "9.1" ../overlays/patches/ghc-lib-parser-8.10-global-unique-counters-in-rts.patch)
+    (fromUntil "8.10.0.0" "9.2" ../overlays/patches/ghc-lib-parser-8.10-global-unique-counters-in-rts.patch)
+    (fromUntil "9.2.0.0" "9.3" ../overlays/patches/ghc-lib-parser-9.2-global-unique-counters-in-rts.patch)
   ];
 
   # See https://github.com/haskell-nix/hnix/pull/1053

--- a/overlays/patches/ghc-lib-parser-9.2-global-unique-counters-in-rts.patch
+++ b/overlays/patches/ghc-lib-parser-9.2-global-unique-counters-in-rts.patch
@@ -1,0 +1,20 @@
+diff --git a/compiler/cbits/genSym.c b/compiler/cbits/genSym.c
+index ecb318d5a8..8e70db33fc 100644
+--- a/compiler/cbits/genSym.c
++++ b/compiler/cbits/genSym.c
+@@ -1,9 +1,15 @@
+ #include <Rts.h>
+ #include <assert.h>
+ #include "Unique.h"
++#include "ghcversion.h"
+
++// These global variables have been moved into the RTS.  It allows them to be
++// shared with plugins even if two different instances of the GHC library are
++// loaded at the same time (#19940)
++#if !MIN_VERSION_GLASGOW_HASKELL(9,2,0,0)
+ HsInt ghc_unique_counter = 0;
+ HsInt ghc_unique_inc     = 1;
++#endif
+
+ #define UNIQUE_BITS (sizeof (HsInt) * 8 - UNIQUE_TAG_BITS)
+ #define UNIQUE_MASK ((1ULL << UNIQUE_BITS) - 1)


### PR DESCRIPTION
Fixes #1488