### PR TITLE
Use targetPackages.ncurses for ghc cross compiler

### DIFF
--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -13,7 +13,7 @@ let self =
 , autoreconfHook
 , bash
 
-, libiconv ? null, ncurses
+, libiconv ? null
 
 , installDeps
 
@@ -41,8 +41,7 @@ let self =
 
 , enableDWARF ? false
 
-, # Whether to build terminfo.  Musl fails to build terminfo as ncurses seems to be linked to glibc
-  enableTerminfo ? !stdenv.targetPlatform.isWindows && !stdenv.targetPlatform.isMusl
+, enableTerminfo ? true
 
 , # Wheter to build in NUMA support
   enableNUMA ? true
@@ -144,7 +143,7 @@ let
   '';
 
   # Splicer will pull out correct variations
-  libDeps = platform: lib.optional enableTerminfo [ ncurses ncurses.dev ]
+  libDeps = platform: lib.optional enableTerminfo [ targetPackages.ncurses targetPackages.ncurses.dev ]
     ++ [targetLibffi]
     ++ lib.optional (!enableIntegerSimple) gmp
     ++ lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv
@@ -240,7 +239,7 @@ stdenv.mkDerivation (rec {
   # `--with` flags for libraries needed for RTS linker
   configureFlags = [
         "--datadir=$doc/share/doc/ghc"
-        "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
+        "--with-curses-includes=${targetPackages.ncurses.dev}/include" "--with-curses-libraries=${targetPackages.ncurses.out}/lib"
     ] ++ lib.optionals (targetLibffi != null) ["--with-system-libffi" "--with-ffi-includes=${targetLibffi.dev}/include" "--with-ffi-libraries=${targetLibffi.out}/lib"
     ] ++ lib.optional (!enableIntegerSimple) [
         "--with-gmp-includes=${targetGmp.dev}/include" "--with-gmp-libraries=${targetGmp.out}/lib"

--- a/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-8.10.4-x86_64-linux/ghc-pkg/dump-global
+++ b/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-8.10.4-x86_64-linux/ghc-pkg/dump-global
@@ -710,8 +710,8 @@ depends:
     containers-0.6.2.1 deepseq-1.4.4.0 directory-1.3.6.0
     filepath-1.4.2.1 ghc-boot-8.10.4 ghc-boot-th-8.10.4 ghc-heap-8.10.4
     ghci-8.10.4 hpc-0.6.1.0 integer-gmp-1.0.3.0 process-1.6.9.0
-    template-haskell-2.16.0.0 time-1.9.3 transformers-0.5.6.2
-    unix-2.7.2.2
+    template-haskell-2.16.0.0 terminfo-0.4.1.4 time-1.9.3
+    transformers-0.5.6.2 unix-2.7.2.2
 haddock-interfaces:
 haddock-html:
 ---
@@ -938,6 +938,7 @@ hidden-modules:
     System.Console.Haskeline.Backend.Posix
     System.Console.Haskeline.Backend.Posix.Encoder
     System.Console.Haskeline.Backend.DumbTerm
+    System.Console.Haskeline.Backend.Terminfo
 import-dirs:
 library-dirs:
 dynamic-library-dirs:
@@ -946,7 +947,8 @@ hs-libraries:         HShaskeline-0.8.0.1
 depends:
     base-4.14.1.0 bytestring-0.10.12.0 containers-0.6.2.1
     directory-1.3.6.0 exceptions-0.10.4 filepath-1.4.2.1
-    process-1.6.9.0 stm-2.5.0.0 transformers-0.5.6.2 unix-2.7.2.2
+    process-1.6.9.0 stm-2.5.0.0 terminfo-0.4.1.4 transformers-0.5.6.2
+    unix-2.7.2.2
 haddock-interfaces:
 haddock-html:
 ---
@@ -1252,6 +1254,39 @@ data-dir:
 hs-libraries:         HStemplate-haskell-2.16.0.0
 depends:
     base-4.14.1.0 ghc-boot-th-8.10.4 ghc-prim-0.6.1 pretty-1.1.3.6
+haddock-interfaces:
+haddock-html:
+---
+name:                 terminfo
+version:              0.4.1.4
+visibility:           public
+id:                   terminfo-0.4.1.4
+key:                  terminfo-0.4.1.4
+license:              BSD-3-Clause
+copyright:            (c) Judah Jacobson
+maintainer:           Judah Jacobson <judah.jacobson@gmail.com>
+author:               Judah Jacobson
+stability:            Stable
+homepage:             https://github.com/judah/terminfo
+synopsis:             Haskell bindings to the terminfo library.
+description:
+    This library provides an interface to the terminfo database (via bindings to the
+    curses library).  <http://en.wikipedia.org/wiki/Terminfo Terminfo> allows POSIX
+    systems to interact with a variety of terminals using a standard set of capabilities.
+category:             User Interfaces
+exposed:              True
+exposed-modules:
+    System.Console.Terminfo System.Console.Terminfo.Base
+    System.Console.Terminfo.Color System.Console.Terminfo.Cursor
+    System.Console.Terminfo.Edit System.Console.Terminfo.Effects
+    System.Console.Terminfo.Keys
+import-dirs:
+library-dirs:
+dynamic-library-dirs:
+data-dir:
+hs-libraries:         HSterminfo-0.4.1.4
+extra-libraries:      tinfo
+depends:              base-4.14.1.0
 haddock-interfaces:
 haddock-html:
 ---

--- a/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-8.10.5-x86_64-linux/ghc-pkg/dump-global
+++ b/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-8.10.5-x86_64-linux/ghc-pkg/dump-global
@@ -710,8 +710,8 @@ depends:
     containers-0.6.4.1 deepseq-1.4.4.0 directory-1.3.6.0
     filepath-1.4.2.1 ghc-boot-8.10.5 ghc-boot-th-8.10.5 ghc-heap-8.10.5
     ghci-8.10.5 hpc-0.6.1.0 integer-gmp-1.0.3.0 process-1.6.9.0
-    template-haskell-2.16.0.0 time-1.9.3 transformers-0.5.6.2
-    unix-2.7.2.2
+    template-haskell-2.16.0.0 terminfo-0.4.1.4 time-1.9.3
+    transformers-0.5.6.2 unix-2.7.2.2
 haddock-interfaces:
 haddock-html:
 ---
@@ -938,6 +938,7 @@ hidden-modules:
     System.Console.Haskeline.Backend.Posix
     System.Console.Haskeline.Backend.Posix.Encoder
     System.Console.Haskeline.Backend.DumbTerm
+    System.Console.Haskeline.Backend.Terminfo
 import-dirs:
 library-dirs:
 dynamic-library-dirs:
@@ -946,7 +947,8 @@ hs-libraries:         HShaskeline-0.8.0.1
 depends:
     base-4.14.2.0 bytestring-0.10.12.0 containers-0.6.4.1
     directory-1.3.6.0 exceptions-0.10.4 filepath-1.4.2.1
-    process-1.6.9.0 stm-2.5.0.1 transformers-0.5.6.2 unix-2.7.2.2
+    process-1.6.9.0 stm-2.5.0.1 terminfo-0.4.1.4 transformers-0.5.6.2
+    unix-2.7.2.2
 haddock-interfaces:
 haddock-html:
 ---
@@ -1252,6 +1254,39 @@ data-dir:
 hs-libraries:         HStemplate-haskell-2.16.0.0
 depends:
     base-4.14.2.0 ghc-boot-th-8.10.5 ghc-prim-0.6.1 pretty-1.1.3.6
+haddock-interfaces:
+haddock-html:
+---
+name:                 terminfo
+version:              0.4.1.4
+visibility:           public
+id:                   terminfo-0.4.1.4
+key:                  terminfo-0.4.1.4
+license:              BSD-3-Clause
+copyright:            (c) Judah Jacobson
+maintainer:           Judah Jacobson <judah.jacobson@gmail.com>
+author:               Judah Jacobson
+stability:            Stable
+homepage:             https://github.com/judah/terminfo
+synopsis:             Haskell bindings to the terminfo library.
+description:
+    This library provides an interface to the terminfo database (via bindings to the
+    curses library).  <http://en.wikipedia.org/wiki/Terminfo Terminfo> allows POSIX
+    systems to interact with a variety of terminals using a standard set of capabilities.
+category:             User Interfaces
+exposed:              True
+exposed-modules:
+    System.Console.Terminfo System.Console.Terminfo.Base
+    System.Console.Terminfo.Color System.Console.Terminfo.Cursor
+    System.Console.Terminfo.Edit System.Console.Terminfo.Effects
+    System.Console.Terminfo.Keys
+import-dirs:
+library-dirs:
+dynamic-library-dirs:
+data-dir:
+hs-libraries:         HSterminfo-0.4.1.4
+extra-libraries:      tinfo
+depends:              base-4.14.2.0
 haddock-interfaces:
 haddock-html:
 ---

--- a/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-8.10.6-x86_64-linux/ghc-pkg/dump-global
+++ b/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-8.10.6-x86_64-linux/ghc-pkg/dump-global
@@ -710,8 +710,8 @@ depends:
     containers-0.6.5.1 deepseq-1.4.4.0 directory-1.3.6.0
     filepath-1.4.2.1 ghc-boot-8.10.6 ghc-boot-th-8.10.6 ghc-heap-8.10.6
     ghci-8.10.6 hpc-0.6.1.0 integer-gmp-1.0.3.0 process-1.6.13.2
-    template-haskell-2.16.0.0 time-1.9.3 transformers-0.5.6.2
-    unix-2.7.2.2
+    template-haskell-2.16.0.0 terminfo-0.4.1.4 time-1.9.3
+    transformers-0.5.6.2 unix-2.7.2.2
 haddock-interfaces:
 haddock-html:
 ---
@@ -938,6 +938,7 @@ hidden-modules:
     System.Console.Haskeline.Backend.Posix
     System.Console.Haskeline.Backend.Posix.Encoder
     System.Console.Haskeline.Backend.DumbTerm
+    System.Console.Haskeline.Backend.Terminfo
 import-dirs:
 library-dirs:
 dynamic-library-dirs:
@@ -946,7 +947,8 @@ hs-libraries:         HShaskeline-0.8.2
 depends:
     base-4.14.3.0 bytestring-0.10.12.0 containers-0.6.5.1
     directory-1.3.6.0 exceptions-0.10.4 filepath-1.4.2.1
-    process-1.6.13.2 stm-2.5.0.1 transformers-0.5.6.2 unix-2.7.2.2
+    process-1.6.13.2 stm-2.5.0.1 terminfo-0.4.1.4 transformers-0.5.6.2
+    unix-2.7.2.2
 haddock-interfaces:
 haddock-html:
 ---
@@ -1252,6 +1254,39 @@ data-dir:
 hs-libraries:         HStemplate-haskell-2.16.0.0
 depends:
     base-4.14.3.0 ghc-boot-th-8.10.6 ghc-prim-0.6.1 pretty-1.1.3.6
+haddock-interfaces:
+haddock-html:
+---
+name:                 terminfo
+version:              0.4.1.4
+visibility:           public
+id:                   terminfo-0.4.1.4
+key:                  terminfo-0.4.1.4
+license:              BSD-3-Clause
+copyright:            (c) Judah Jacobson
+maintainer:           Judah Jacobson <judah.jacobson@gmail.com>
+author:               Judah Jacobson
+stability:            Stable
+homepage:             https://github.com/judah/terminfo
+synopsis:             Haskell bindings to the terminfo library.
+description:
+    This library provides an interface to the terminfo database (via bindings to the
+    curses library).  <http://en.wikipedia.org/wiki/Terminfo Terminfo> allows POSIX
+    systems to interact with a variety of terminals using a standard set of capabilities.
+category:             User Interfaces
+exposed:              True
+exposed-modules:
+    System.Console.Terminfo System.Console.Terminfo.Base
+    System.Console.Terminfo.Color System.Console.Terminfo.Cursor
+    System.Console.Terminfo.Edit System.Console.Terminfo.Effects
+    System.Console.Terminfo.Keys
+import-dirs:
+library-dirs:
+dynamic-library-dirs:
+data-dir:
+hs-libraries:         HSterminfo-0.4.1.4
+extra-libraries:      tinfo
+depends:              base-4.14.3.0
 haddock-interfaces:
 haddock-html:
 ---

--- a/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-8.10.7-x86_64-linux/ghc-pkg/dump-global
+++ b/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-8.10.7-x86_64-linux/ghc-pkg/dump-global
@@ -710,8 +710,8 @@ depends:
     containers-0.6.5.1 deepseq-1.4.4.0 directory-1.3.6.0
     filepath-1.4.2.1 ghc-boot-8.10.7 ghc-boot-th-8.10.7 ghc-heap-8.10.7
     ghci-8.10.7 hpc-0.6.1.0 integer-gmp-1.0.3.0 process-1.6.13.2
-    template-haskell-2.16.0.0 time-1.9.3 transformers-0.5.6.2
-    unix-2.7.2.2
+    template-haskell-2.16.0.0 terminfo-0.4.1.4 time-1.9.3
+    transformers-0.5.6.2 unix-2.7.2.2
 haddock-interfaces:
 haddock-html:
 ---
@@ -938,6 +938,7 @@ hidden-modules:
     System.Console.Haskeline.Backend.Posix
     System.Console.Haskeline.Backend.Posix.Encoder
     System.Console.Haskeline.Backend.DumbTerm
+    System.Console.Haskeline.Backend.Terminfo
 import-dirs:
 library-dirs:
 dynamic-library-dirs:
@@ -946,7 +947,8 @@ hs-libraries:         HShaskeline-0.8.2
 depends:
     base-4.14.3.0 bytestring-0.10.12.0 containers-0.6.5.1
     directory-1.3.6.0 exceptions-0.10.4 filepath-1.4.2.1
-    process-1.6.13.2 stm-2.5.0.1 transformers-0.5.6.2 unix-2.7.2.2
+    process-1.6.13.2 stm-2.5.0.1 terminfo-0.4.1.4 transformers-0.5.6.2
+    unix-2.7.2.2
 haddock-interfaces:
 haddock-html:
 ---
@@ -1252,6 +1254,39 @@ data-dir:
 hs-libraries:         HStemplate-haskell-2.16.0.0
 depends:
     base-4.14.3.0 ghc-boot-th-8.10.7 ghc-prim-0.6.1 pretty-1.1.3.6
+haddock-interfaces:
+haddock-html:
+---
+name:                 terminfo
+version:              0.4.1.4
+visibility:           public
+id:                   terminfo-0.4.1.4
+key:                  terminfo-0.4.1.4
+license:              BSD-3-Clause
+copyright:            (c) Judah Jacobson
+maintainer:           Judah Jacobson <judah.jacobson@gmail.com>
+author:               Judah Jacobson
+stability:            Stable
+homepage:             https://github.com/judah/terminfo
+synopsis:             Haskell bindings to the terminfo library.
+description:
+    This library provides an interface to the terminfo database (via bindings to the
+    curses library).  <http://en.wikipedia.org/wiki/Terminfo Terminfo> allows POSIX
+    systems to interact with a variety of terminals using a standard set of capabilities.
+category:             User Interfaces
+exposed:              True
+exposed-modules:
+    System.Console.Terminfo System.Console.Terminfo.Base
+    System.Console.Terminfo.Color System.Console.Terminfo.Cursor
+    System.Console.Terminfo.Edit System.Console.Terminfo.Effects
+    System.Console.Terminfo.Keys
+import-dirs:
+library-dirs:
+dynamic-library-dirs:
+data-dir:
+hs-libraries:         HSterminfo-0.4.1.4
+extra-libraries:      tinfo
+depends:              base-4.14.3.0
 haddock-interfaces:
 haddock-html:
 ---

--- a/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-8.6.5-x86_64-linux/ghc-pkg/dump-global
+++ b/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-8.6.5-x86_64-linux/ghc-pkg/dump-global
@@ -602,7 +602,7 @@ depends:
     containers-0.6.0.1 deepseq-1.4.4.0 directory-1.3.3.0
     filepath-1.4.2.1 ghc-boot-8.6.5 ghc-boot-th-8.6.5 ghc-heap-8.6.5
     ghci-8.6.5 hpc-0.6.0.3 process-1.6.5.0 template-haskell-2.14.0.0
-    time-1.8.0.2 transformers-0.5.6.2 unix-2.7.2.2
+    terminfo-0.4.1.2 time-1.8.0.2 transformers-0.5.6.2 unix-2.7.2.2
 ---
 name: ghc-boot
 version: 8.6.5
@@ -786,11 +786,12 @@ hidden-modules: System.Console.Haskeline.Backend
                 System.Console.Haskeline.Backend.Posix
                 System.Console.Haskeline.Backend.Posix.Encoder
                 System.Console.Haskeline.Backend.DumbTerm
+                System.Console.Haskeline.Backend.Terminfo
 hs-libraries: HShaskeline-0.7.4.3
 depends:
     base-4.12.0.0 bytestring-0.10.8.2 containers-0.6.0.1
     directory-1.3.3.0 filepath-1.4.2.1 process-1.6.5.0 stm-2.5.0.0
-    transformers-0.5.6.2 unix-2.7.2.2
+    terminfo-0.4.1.2 transformers-0.5.6.2 unix-2.7.2.2
 ---
 name: hpc
 version: 0.6.0.3
@@ -1117,6 +1118,34 @@ hidden-modules: Language.Haskell.TH.Lib.Map
 hs-libraries: HStemplate-haskell-2.14.0.0
 depends:
     base-4.12.0.0 ghc-boot-th-8.6.5 pretty-1.1.3.6
+---
+name: terminfo
+version: 0.4.1.2
+id: terminfo-0.4.1.2
+key: terminfo-0.4.1.2
+license: BSD-3-Clause
+copyright: (c) Judah Jacobson
+maintainer: Judah Jacobson <judah.jacobson@gmail.com>
+author: Judah Jacobson
+stability: Stable
+homepage: https://github.com/judah/terminfo
+synopsis: Haskell bindings to the terminfo library.
+description:
+    This library provides an interface to the terminfo database (via bindings to the
+    curses library).  <http://en.wikipedia.org/wiki/Terminfo Terminfo> allows POSIX
+    systems to interact with a variety of terminals using a standard set of capabilities.
+category: User Interfaces
+exposed: True
+exposed-modules:
+    System.Console.Terminfo System.Console.Terminfo.Base
+    System.Console.Terminfo.Color System.Console.Terminfo.Cursor
+    System.Console.Terminfo.Edit System.Console.Terminfo.Effects
+    System.Console.Terminfo.Keys
+hs-libraries: HSterminfo-0.4.1.2
+extra-libraries:
+    tinfo
+depends:
+    base-4.12.0.0
 ---
 name: text
 version: 1.2.3.1

--- a/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-8.8.4-x86_64-linux/ghc-pkg/dump-global
+++ b/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-8.8.4-x86_64-linux/ghc-pkg/dump-global
@@ -667,8 +667,8 @@ depends:
     containers-0.6.2.1 deepseq-1.4.4.0 directory-1.3.6.0
     filepath-1.4.2.1 ghc-boot-8.8.4 ghc-boot-th-8.8.4 ghc-heap-8.8.4
     ghci-8.8.4 hpc-0.6.0.3 integer-gmp-1.0.2.0 process-1.6.9.0
-    template-haskell-2.15.0.0 time-1.9.3 transformers-0.5.6.2
-    unix-2.7.2.2
+    template-haskell-2.15.0.0 terminfo-0.4.1.4 time-1.9.3
+    transformers-0.5.6.2 unix-2.7.2.2
 haddock-interfaces:
 haddock-html:
 ---
@@ -894,6 +894,7 @@ hidden-modules:
     System.Console.Haskeline.Backend.Posix
     System.Console.Haskeline.Backend.Posix.Encoder
     System.Console.Haskeline.Backend.DumbTerm
+    System.Console.Haskeline.Backend.Terminfo
 import-dirs:
 library-dirs:
 dynamic-library-dirs:
@@ -902,7 +903,7 @@ hs-libraries:         HShaskeline-0.7.5.0
 depends:
     base-4.13.0.0 bytestring-0.10.10.1 containers-0.6.2.1
     directory-1.3.6.0 filepath-1.4.2.1 process-1.6.9.0 stm-2.5.0.0
-    transformers-0.5.6.2 unix-2.7.2.2
+    terminfo-0.4.1.4 transformers-0.5.6.2 unix-2.7.2.2
 haddock-interfaces:
 haddock-html:
 ---
@@ -1207,6 +1208,39 @@ dynamic-library-dirs:
 data-dir:
 hs-libraries:         HStemplate-haskell-2.15.0.0
 depends:              base-4.13.0.0 ghc-boot-th-8.8.4 pretty-1.1.3.6
+haddock-interfaces:
+haddock-html:
+---
+name:                 terminfo
+version:              0.4.1.4
+visibility:           public
+id:                   terminfo-0.4.1.4
+key:                  terminfo-0.4.1.4
+license:              BSD-3-Clause
+copyright:            (c) Judah Jacobson
+maintainer:           Judah Jacobson <judah.jacobson@gmail.com>
+author:               Judah Jacobson
+stability:            Stable
+homepage:             https://github.com/judah/terminfo
+synopsis:             Haskell bindings to the terminfo library.
+description:
+    This library provides an interface to the terminfo database (via bindings to the
+    curses library).  <http://en.wikipedia.org/wiki/Terminfo Terminfo> allows POSIX
+    systems to interact with a variety of terminals using a standard set of capabilities.
+category:             User Interfaces
+exposed:              True
+exposed-modules:
+    System.Console.Terminfo System.Console.Terminfo.Base
+    System.Console.Terminfo.Color System.Console.Terminfo.Cursor
+    System.Console.Terminfo.Edit System.Console.Terminfo.Effects
+    System.Console.Terminfo.Keys
+import-dirs:
+library-dirs:
+dynamic-library-dirs:
+data-dir:
+hs-libraries:         HSterminfo-0.4.1.4
+extra-libraries:      tinfo
+depends:              base-4.13.0.0
 haddock-interfaces:
 haddock-html:
 ---

--- a/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-9.0.1-x86_64-linux/ghc-pkg/dump-global
+++ b/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-9.0.1-x86_64-linux/ghc-pkg/dump-global
@@ -798,8 +798,8 @@ depends:
     containers-0.6.4.1 deepseq-1.4.5.0 directory-1.3.6.1
     exceptions-0.10.4 filepath-1.4.2.1 ghc-boot-9.0.1 ghc-boot-th-9.0.1
     ghc-heap-9.0.1 ghci-9.0.1 hpc-0.6.1.0 process-1.6.11.0
-    template-haskell-2.17.0.0 time-1.9.3 transformers-0.5.6.2
-    unix-2.7.2.2
+    template-haskell-2.17.0.0 terminfo-0.4.1.4 time-1.9.3
+    transformers-0.5.6.2 unix-2.7.2.2
 haddock-interfaces:
 haddock-html:
 ---
@@ -1058,6 +1058,7 @@ hidden-modules:
     System.Console.Haskeline.Backend.Posix
     System.Console.Haskeline.Backend.Posix.Encoder
     System.Console.Haskeline.Backend.DumbTerm
+    System.Console.Haskeline.Backend.Terminfo
 import-dirs:
 library-dirs:
 dynamic-library-dirs:
@@ -1066,7 +1067,8 @@ hs-libraries:         HShaskeline-0.8.1.0
 depends:
     base-4.15.0.0 bytestring-0.10.12.1 containers-0.6.4.1
     directory-1.3.6.1 exceptions-0.10.4 filepath-1.4.2.1
-    process-1.6.11.0 stm-2.5.0.0 transformers-0.5.6.2 unix-2.7.2.2
+    process-1.6.11.0 stm-2.5.0.0 terminfo-0.4.1.4 transformers-0.5.6.2
+    unix-2.7.2.2
 haddock-interfaces:
 haddock-html:
 ---
@@ -1368,6 +1370,39 @@ data-dir:
 hs-libraries:         HStemplate-haskell-2.17.0.0
 depends:
     base-4.15.0.0 ghc-boot-th-9.0.1 ghc-prim-0.7.0 pretty-1.1.3.6
+haddock-interfaces:
+haddock-html:
+---
+name:                 terminfo
+version:              0.4.1.4
+visibility:           public
+id:                   terminfo-0.4.1.4
+key:                  terminfo-0.4.1.4
+license:              BSD-3-Clause
+copyright:            (c) Judah Jacobson
+maintainer:           Judah Jacobson <judah.jacobson@gmail.com>
+author:               Judah Jacobson
+stability:            Stable
+homepage:             https://github.com/judah/terminfo
+synopsis:             Haskell bindings to the terminfo library.
+description:
+    This library provides an interface to the terminfo database (via bindings to the
+    curses library).  <http://en.wikipedia.org/wiki/Terminfo Terminfo> allows POSIX
+    systems to interact with a variety of terminals using a standard set of capabilities.
+category:             User Interfaces
+exposed:              True
+exposed-modules:
+    System.Console.Terminfo System.Console.Terminfo.Base
+    System.Console.Terminfo.Color System.Console.Terminfo.Cursor
+    System.Console.Terminfo.Edit System.Console.Terminfo.Effects
+    System.Console.Terminfo.Keys
+import-dirs:
+library-dirs:
+dynamic-library-dirs:
+data-dir:
+hs-libraries:         HSterminfo-0.4.1.4
+extra-libraries:      tinfo
+depends:              base-4.15.0.0
 haddock-interfaces:
 haddock-html:
 ---

--- a/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-9.0.2-x86_64-linux/ghc-pkg/dump-global
+++ b/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-9.0.2-x86_64-linux/ghc-pkg/dump-global
@@ -798,8 +798,8 @@ depends:
     containers-0.6.4.1 deepseq-1.4.5.0 directory-1.3.6.2
     exceptions-0.10.4 filepath-1.4.2.1 ghc-boot-9.0.2 ghc-boot-th-9.0.2
     ghc-heap-9.0.2 ghci-9.0.2 hpc-0.6.1.0 process-1.6.13.2
-    template-haskell-2.17.0.0 time-1.9.3 transformers-0.5.6.2
-    unix-2.7.2.2
+    template-haskell-2.17.0.0 terminfo-0.4.1.5 time-1.9.3
+    transformers-0.5.6.2 unix-2.7.2.2
 haddock-interfaces:
 haddock-html:
 ---
@@ -1062,6 +1062,7 @@ hidden-modules:
     System.Console.Haskeline.Backend.Posix
     System.Console.Haskeline.Backend.Posix.Encoder
     System.Console.Haskeline.Backend.DumbTerm
+    System.Console.Haskeline.Backend.Terminfo
 import-dirs:
 library-dirs:
 dynamic-library-dirs:
@@ -1070,7 +1071,8 @@ hs-libraries:         HShaskeline-0.8.2
 depends:
     base-4.15.1.0 bytestring-0.10.12.1 containers-0.6.4.1
     directory-1.3.6.2 exceptions-0.10.4 filepath-1.4.2.1
-    process-1.6.13.2 stm-2.5.0.0 transformers-0.5.6.2 unix-2.7.2.2
+    process-1.6.13.2 stm-2.5.0.0 terminfo-0.4.1.5 transformers-0.5.6.2
+    unix-2.7.2.2
 haddock-interfaces:
 haddock-html:
 ---
@@ -1375,6 +1377,39 @@ data-dir:
 hs-libraries:         HStemplate-haskell-2.17.0.0
 depends:
     base-4.15.1.0 ghc-boot-th-9.0.2 ghc-prim-0.7.0 pretty-1.1.3.6
+haddock-interfaces:
+haddock-html:
+---
+name:                 terminfo
+version:              0.4.1.5
+visibility:           public
+id:                   terminfo-0.4.1.5
+key:                  terminfo-0.4.1.5
+license:              BSD-3-Clause
+copyright:            (c) Judah Jacobson
+maintainer:           Judah Jacobson <judah.jacobson@gmail.com>
+author:               Judah Jacobson
+stability:            Stable
+homepage:             https://github.com/judah/terminfo
+synopsis:             Haskell bindings to the terminfo library.
+description:
+    This library provides an interface to the terminfo database (via bindings to the
+    curses library).  <http://en.wikipedia.org/wiki/Terminfo Terminfo> allows POSIX
+    systems to interact with a variety of terminals using a standard set of capabilities.
+category:             User Interfaces
+exposed:              True
+exposed-modules:
+    System.Console.Terminfo System.Console.Terminfo.Base
+    System.Console.Terminfo.Color System.Console.Terminfo.Cursor
+    System.Console.Terminfo.Edit System.Console.Terminfo.Effects
+    System.Console.Terminfo.Keys
+import-dirs:
+library-dirs:
+dynamic-library-dirs:
+data-dir:
+hs-libraries:         HSterminfo-0.4.1.5
+extra-libraries:      tinfo
+depends:              base-4.15.1.0
 haddock-interfaces:
 haddock-html:
 ---

--- a/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-9.2.1-x86_64-linux/ghc-pkg/dump-global
+++ b/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-9.2.1-x86_64-linux/ghc-pkg/dump-global
@@ -848,8 +848,8 @@ depends:
     containers-0.6.5.1 deepseq-1.4.6.0 directory-1.3.6.2
     exceptions-0.10.4 filepath-1.4.2.1 ghc-boot-9.2.1 ghc-heap-9.2.1
     ghci-9.2.1 hpc-0.6.1.0 parsec-3.1.14.0 process-1.6.13.2
-    template-haskell-2.18.0.0 time-1.11.1.1 transformers-0.5.6.2
-    unix-2.7.2.2
+    template-haskell-2.18.0.0 terminfo-0.4.1.5 time-1.11.1.1
+    transformers-0.5.6.2 unix-2.7.2.2
 haddock-interfaces:
 haddock-html:
 ---
@@ -1120,6 +1120,7 @@ hidden-modules:
     System.Console.Haskeline.Backend.Posix
     System.Console.Haskeline.Backend.Posix.Encoder
     System.Console.Haskeline.Backend.DumbTerm
+    System.Console.Haskeline.Backend.Terminfo
 import-dirs:
 library-dirs:
 dynamic-library-dirs:
@@ -1128,7 +1129,8 @@ hs-libraries:         HShaskeline-0.8.2
 depends:
     base-4.16.0.0 bytestring-0.11.1.0 containers-0.6.5.1
     directory-1.3.6.2 exceptions-0.10.4 filepath-1.4.2.1
-    process-1.6.13.2 stm-2.5.0.0 transformers-0.5.6.2 unix-2.7.2.2
+    process-1.6.13.2 stm-2.5.0.0 terminfo-0.4.1.5 transformers-0.5.6.2
+    unix-2.7.2.2
 haddock-interfaces:
 haddock-html:
 ---
@@ -1433,6 +1435,39 @@ data-dir:
 hs-libraries:         HStemplate-haskell-2.18.0.0
 depends:
     base-4.16.0.0 ghc-boot-th-9.2.1 ghc-prim-0.8.0 pretty-1.1.3.6
+haddock-interfaces:
+haddock-html:
+---
+name:                 terminfo
+version:              0.4.1.5
+visibility:           public
+id:                   terminfo-0.4.1.5
+key:                  terminfo-0.4.1.5
+license:              BSD-3-Clause
+copyright:            (c) Judah Jacobson
+maintainer:           Judah Jacobson <judah.jacobson@gmail.com>
+author:               Judah Jacobson
+stability:            Stable
+homepage:             https://github.com/judah/terminfo
+synopsis:             Haskell bindings to the terminfo library.
+description:
+    This library provides an interface to the terminfo database (via bindings to the
+    curses library).  <http://en.wikipedia.org/wiki/Terminfo Terminfo> allows POSIX
+    systems to interact with a variety of terminals using a standard set of capabilities.
+category:             User Interfaces
+exposed:              True
+exposed-modules:
+    System.Console.Terminfo System.Console.Terminfo.Base
+    System.Console.Terminfo.Color System.Console.Terminfo.Cursor
+    System.Console.Terminfo.Edit System.Console.Terminfo.Effects
+    System.Console.Terminfo.Keys
+import-dirs:
+library-dirs:
+dynamic-library-dirs:
+data-dir:
+hs-libraries:         HSterminfo-0.4.1.5
+extra-libraries:      tinfo
+depends:              base-4.16.0.0
 haddock-interfaces:
 haddock-html:
 ---

--- a/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-9.2.2-x86_64-linux/ghc-pkg/dump-global
+++ b/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-9.2.2-x86_64-linux/ghc-pkg/dump-global
@@ -854,7 +854,7 @@ depends:
     containers-0.6.5.1 deepseq-1.4.6.1 directory-1.3.6.2
     exceptions-0.10.4 filepath-1.4.2.2 ghc-boot-9.2.2 ghc-heap-9.2.2
     ghci-9.2.2 hpc-0.6.1.0 process-1.6.13.2 template-haskell-2.18.0.0
-    time-1.11.1.1 transformers-0.5.6.2 unix-2.7.2.2
+    terminfo-0.4.1.5 time-1.11.1.1 transformers-0.5.6.2 unix-2.7.2.2
 haddock-interfaces:
 haddock-html:
 ---
@@ -1127,6 +1127,7 @@ hidden-modules:
     System.Console.Haskeline.Backend.Posix
     System.Console.Haskeline.Backend.Posix.Encoder
     System.Console.Haskeline.Backend.DumbTerm
+    System.Console.Haskeline.Backend.Terminfo
 import-dirs:
 library-dirs:
 dynamic-library-dirs:
@@ -1135,7 +1136,8 @@ hs-libraries:         HShaskeline-0.8.2
 depends:
     base-4.16.1.0 bytestring-0.11.3.0 containers-0.6.5.1
     directory-1.3.6.2 exceptions-0.10.4 filepath-1.4.2.2
-    process-1.6.13.2 stm-2.5.0.2 transformers-0.5.6.2 unix-2.7.2.2
+    process-1.6.13.2 stm-2.5.0.2 terminfo-0.4.1.5 transformers-0.5.6.2
+    unix-2.7.2.2
 haddock-interfaces:
 haddock-html:
 ---
@@ -1441,6 +1443,39 @@ data-dir:
 hs-libraries:         HStemplate-haskell-2.18.0.0
 depends:
     base-4.16.1.0 ghc-boot-th-9.2.2 ghc-prim-0.8.0 pretty-1.1.3.6
+haddock-interfaces:
+haddock-html:
+---
+name:                 terminfo
+version:              0.4.1.5
+visibility:           public
+id:                   terminfo-0.4.1.5
+key:                  terminfo-0.4.1.5
+license:              BSD-3-Clause
+copyright:            (c) Judah Jacobson
+maintainer:           Judah Jacobson <judah.jacobson@gmail.com>
+author:               Judah Jacobson
+stability:            Stable
+homepage:             https://github.com/judah/terminfo
+synopsis:             Haskell bindings to the terminfo library.
+description:
+    This library provides an interface to the terminfo database (via bindings to the
+    curses library).  <http://en.wikipedia.org/wiki/Terminfo Terminfo> allows POSIX
+    systems to interact with a variety of terminals using a standard set of capabilities.
+category:             User Interfaces
+exposed:              True
+exposed-modules:
+    System.Console.Terminfo System.Console.Terminfo.Base
+    System.Console.Terminfo.Color System.Console.Terminfo.Cursor
+    System.Console.Terminfo.Edit System.Console.Terminfo.Effects
+    System.Console.Terminfo.Keys
+import-dirs:
+library-dirs:
+dynamic-library-dirs:
+data-dir:
+hs-libraries:         HSterminfo-0.4.1.5
+extra-libraries:      tinfo
+depends:              base-4.16.1.0
 haddock-interfaces:
 haddock-html:
 ---

--- a/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-9.2.3-x86_64-linux/ghc-pkg/dump-global
+++ b/materialized/dummy-ghc/x86_64-unknown-linux-musl-x86_64-unknown-linux-musl-ghc-9.2.3-x86_64-linux/ghc-pkg/dump-global
@@ -855,7 +855,7 @@ depends:
     containers-0.6.5.1 deepseq-1.4.6.1 directory-1.3.6.2
     exceptions-0.10.4 filepath-1.4.2.2 ghc-boot-9.2.3 ghc-heap-9.2.3
     ghci-9.2.3 hpc-0.6.1.0 process-1.6.13.2 template-haskell-2.18.0.0
-    time-1.11.1.1 transformers-0.5.6.2 unix-2.7.2.2
+    terminfo-0.4.1.5 time-1.11.1.1 transformers-0.5.6.2 unix-2.7.2.2
 haddock-interfaces:
 haddock-html:
 ---
@@ -1127,6 +1127,7 @@ hidden-modules:
     System.Console.Haskeline.Backend.Posix
     System.Console.Haskeline.Backend.Posix.Encoder
     System.Console.Haskeline.Backend.DumbTerm
+    System.Console.Haskeline.Backend.Terminfo
 import-dirs:
 library-dirs:
 dynamic-library-dirs:
@@ -1135,7 +1136,8 @@ hs-libraries:         HShaskeline-0.8.2
 depends:
     base-4.16.2.0 bytestring-0.11.3.1 containers-0.6.5.1
     directory-1.3.6.2 exceptions-0.10.4 filepath-1.4.2.2
-    process-1.6.13.2 stm-2.5.0.2 transformers-0.5.6.2 unix-2.7.2.2
+    process-1.6.13.2 stm-2.5.0.2 terminfo-0.4.1.5 transformers-0.5.6.2
+    unix-2.7.2.2
 haddock-interfaces:
 haddock-html:
 ---
@@ -1441,6 +1443,39 @@ data-dir:
 hs-libraries:         HStemplate-haskell-2.18.0.0
 depends:
     base-4.16.2.0 ghc-boot-th-9.2.3 ghc-prim-0.8.0 pretty-1.1.3.6
+haddock-interfaces:
+haddock-html:
+---
+name:                 terminfo
+version:              0.4.1.5
+visibility:           public
+id:                   terminfo-0.4.1.5
+key:                  terminfo-0.4.1.5
+license:              BSD-3-Clause
+copyright:            (c) Judah Jacobson
+maintainer:           Judah Jacobson <judah.jacobson@gmail.com>
+author:               Judah Jacobson
+stability:            Stable
+homepage:             https://github.com/judah/terminfo
+synopsis:             Haskell bindings to the terminfo library.
+description:
+    This library provides an interface to the terminfo database (via bindings to the
+    curses library).  <http://en.wikipedia.org/wiki/Terminfo Terminfo> allows POSIX
+    systems to interact with a variety of terminals using a standard set of capabilities.
+category:             User Interfaces
+exposed:              True
+exposed-modules:
+    System.Console.Terminfo System.Console.Terminfo.Base
+    System.Console.Terminfo.Color System.Console.Terminfo.Cursor
+    System.Console.Terminfo.Edit System.Console.Terminfo.Effects
+    System.Console.Terminfo.Keys
+import-dirs:
+library-dirs:
+dynamic-library-dirs:
+data-dir:
+hs-libraries:         HSterminfo-0.4.1.5
+extra-libraries:      tinfo
+depends:              base-4.16.2.0
 haddock-interfaces:
 haddock-html:
 ---

--- a/materialized/ghc-extra-projects/cross/ghc865/default.nix
+++ b/materialized/ghc-extra-projects/cross/ghc865/default.nix
@@ -7,7 +7,7 @@
         "network".revision = (((hackage."network")."2.8.0.1").revisions).default;
         "bytestring".revision = (((hackage."bytestring")."0.10.8.2").revisions).default;
         "filepath".revision = (((hackage."filepath")."1.4.2.1").revisions).default;
-        "terminfo".revision = (((hackage."terminfo")."0.4.1.5").revisions).default;
+        "terminfo".revision = (((hackage."terminfo")."0.4.1.2").revisions).default;
         "ghc-heap".revision = (((hackage."ghc-heap")."8.6.5").revisions).default;
         "ghc-prim".revision = (((hackage."ghc-prim")."0.5.3").revisions).default;
         "ghc-boot-th".revision = (((hackage."ghc-boot-th")."8.6.5").revisions).default;
@@ -32,6 +32,7 @@
           "array" = "0.5.3.0";
           "bytestring" = "0.10.8.2";
           "filepath" = "1.4.2.1";
+          "terminfo" = "0.4.1.2";
           "ghc-heap" = "8.6.5";
           "ghc-prim" = "0.5.3";
           "ghc-boot-th" = "8.6.5";

--- a/materialized/ghc-extra-projects/cross/ghc902/default.nix
+++ b/materialized/ghc-extra-projects/cross/ghc902/default.nix
@@ -37,6 +37,7 @@
           "bytestring" = "0.10.12.1";
           "filepath" = "1.4.2.1";
           "stm" = "2.5.0.0";
+          "terminfo" = "0.4.1.5";
           "ghc-heap" = "9.0.2";
           "ghc-prim" = "0.7.0";
           "ghc-boot-th" = "9.0.2";

--- a/materialized/ghc-extra-projects/cross/ghc922/default.nix
+++ b/materialized/ghc-extra-projects/cross/ghc922/default.nix
@@ -37,6 +37,7 @@
           "bytestring" = "0.11.3.0";
           "filepath" = "1.4.2.2";
           "stm" = "2.5.0.2";
+          "terminfo" = "0.4.1.5";
           "ghc-heap" = "9.2.2";
           "ghc-prim" = "0.8.0";
           "ghc-boot-th" = "9.2.2";

--- a/materialized/ghc-extra-projects/cross/ghc923/default.nix
+++ b/materialized/ghc-extra-projects/cross/ghc923/default.nix
@@ -37,6 +37,7 @@
           "bytestring" = "0.11.3.1";
           "filepath" = "1.4.2.2";
           "stm" = "2.5.0.2";
+          "terminfo" = "0.4.1.5";
           "ghc-heap" = "9.2.3";
           "ghc-prim" = "0.8.0";
           "ghc-boot-th" = "9.2.3";

--- a/overlays/ghc-packages.nix
+++ b/overlays/ghc-packages.nix
@@ -88,7 +88,7 @@ let
       then "windows"
       else if final.stdenv.hostPlatform.isGhcjs
         then "ghcjs"
-        else if final.stdenv.buildPlatform != final.stdenv.hostPlatform
+        else if final.haskell-nix.haskellLib.isCrossHost
           then "cross"
           else "default";
 

--- a/overlays/wine.nix
+++ b/overlays/wine.nix
@@ -1,6 +1,7 @@
-# fix wine at 3.0.2; the 4.x branch breaks windows cross compilation.
-# this will inevitably replace *any* wine version. Thus this might not
-# really be what we ultimately want.
+# fix wine at 5.4; later versions build with ucrt and this can break TH code (for instance accessing
+# files from TH code) for GHC built with msvcrt (ghc<9.6).
+# This will inevitably replace *any* wine version. Thus this might not really be what we ultimately want.
+# Wine 5.4 does not build on macOS so that is not pinned and TH code will probably break.
 final: prev:
 prev.lib.optionalAttrs (!prev.stdenv.hostPlatform.isDarwin) {
     winePackages = prev.winePackages // {

--- a/overlays/wine.nix
+++ b/overlays/wine.nix
@@ -2,7 +2,7 @@
 # this will inevitably replace *any* wine version. Thus this might not
 # really be what we ultimately want.
 final: prev:
-{
+prev.lib.optionalAttrs (!prev.stdenv.hostPlatform.isDarwin) {
     winePackages = prev.winePackages // {
         minimal = prev.winePackages.minimal.overrideAttrs (oldAttrs: {
             name = "wine-5.4";


### PR DESCRIPTION
We have been disabling terminfo in our GHC builds for cross compilers (windows and musl).  This leads to an interesting problem when we `cabal configure` a project that needs `ghc`. The resulting `plan.json` might suggest that we should use the preexisting `ghc`.  When it does though it does not include the `flags` needed to build it.

One fix would be to default the the `ghc` `terminfo` flag to `false` for cross compilers.

It turns out though that the reason we could not get the `terminfo` package to work with our cross compilers was that we were providing the `hostPlatform` `ncursers` when we needed the `targetPlatform` `ncursers`.  Fixing that makes the cross compilers more like the native ones.