### PR TITLE
Workaround possible TH environment overflow running `wine`

### DIFF
--- a/overlays/mingw_w64.nix
+++ b/overlays/mingw_w64.nix
@@ -44,6 +44,8 @@ let
       ln -s "$l" "''${l#lib}"
     done
     )
+    # Not sure why this `unset` helps.  It might avoids some kind of overflow issue.  We see `wine` fail to start when building `cardano-wallet-cli` test `unit`.
+    unset pkgsHostTargetAsString
     WINEDLLOVERRIDES="winemac.drv=d" WINEDEBUG=warn-all,fixme-all,-menubuilder,-mscoree,-ole,-secur32,-winediag WINEPREFIX=$TMP ${wine}/bin/wine64 $REMOTE_ISERV/remote-iserv.exe tmp $PORT &
     (>&2 echo "---| remote-iserv should have started on $PORT")
     RISERV_PID="$!"


### PR DESCRIPTION
We still do not understand the cause, but wine seems to fail to start (we get a segfault) when building `cardano-wallet-cli` test `unit`.  It seems to be an overflow somewhere in bash or very early in the `wine` startup code (since nothing is logged even with `WINEDEBUG=+all`).

This changes `unsets` the large `pkgsHostTargetAsString` environment variable before wine is started (after that variable has been used).  This seems to be enough to avoid the issue though it is worrying that it is not clear why.