### PR TITLE
Build ghc 9.2 with internal interpreter

### DIFF
--- a/modules/configuration-nix.nix
+++ b/modules/configuration-nix.nix
@@ -117,6 +117,7 @@ in {
   # `reinstallableLibGhc` build more like the boot version.
   # See https://github.com/input-output-hk/haskell.nix/issues/1512
   packages.ghc.flags.ghci = true;
+  packages.ghc.flags.internal-interpreter = true;
   packages.ghci.flags.ghci = true;
   packages.ghci.flags.internal-interpreter = true;
 }


### PR DESCRIPTION
#1520 doesn't work for GHC 9.2.
Cabal package [ghc](https://hackage.haskell.org/package/ghc-9.2.2) no longer has the flag `ghci`. Instead, it got a new flag `internal-interpreter`.