### PR TITLE
Set meta.mainProgram for executable components

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -356,6 +356,14 @@ let
       description = package.synopsis or "";
       license = haskellLib.cabalToNixpkgsLicense package.license;
       platforms = if platforms == null then lib.platforms.all else platforms;
+    } // lib.optionalAttrs (haskellLib.isExecutableType componentId) {
+      # Set main executable name for executable components, so that `nix run` in
+      # nix flakes will work correctly. When not set, `nix run` would (typically
+      # erroneously) deduce the executable name from the derivation name and
+      # attempt to run, for example,
+      # `/nix/store/...-project-exe-app-0.1.0.0/bin/project-exe-app` instead of
+      # `/nix/store/...-project-exe-app-0.1.0.0/bin/app`.
+      mainProgram = exeName;
     };
 
     propagatedBuildInputs =


### PR DESCRIPTION
This allows `nix run` to work correctly, so that it knows the correct name of the executable, as it would otherwise attempt to execute an executable named `project-name-exe-exeName` for the component `project-name:exe:exeName`, for example. It sets it to the empty string for non-executable components.

Fixes #1231.

---

Tests I ran include:
- [x] Tested by hand for exe, lib and test components on a skeleton project:
  - `meta.mainProgram` is set correctly, and
  - `nix run` works out of the box.
- [x] Full test suite (incl. impure) as described [in the docs](https://input-output-hk.github.io/haskell.nix/dev/tests.html), for `ghc902` (I ran `./tests.sh ghc902`).
  - Succeeds up until I encounter #1482.
- [ ] Currently running the full test suite for `ghc8107` due to the above issue.

---

As I'm completely new to haskell.nix, I'm not sure what else I should look out for or test. I based this off [@hamishmack's suggestion in #1231](https://github.com/input-output-hk/haskell.nix/issues/1231#issuecomment-1174734062), and if I'm not wrong the check component would inherit `meta` from `drv` and hence doesn't need `meta.mainProgram` to be set again.
