### PR TITLE
Improve coverage reports

### DIFF
--- a/lib/cover-project.nix
+++ b/lib/cover-project.nix
@@ -10,19 +10,12 @@ coverageReports:
 let
   toBashArray = arr: "(" + (lib.concatStringsSep " " arr) + ")";
 
-  # Create table rows for a project coverage index page that look something like:
-  #
-  # | Package          |
-  # |------------------|
-  # | cardano-shell    |
-  # | cardano-launcher |
-  coverageTableRows = coverageReport:
+  # Create a list element for a project coverage index page.
+  coverageListElement = coverageReport:
       ''
-      <tr>
-        <td>
-          <a href="${coverageReport.passthru.name}/hpc_index.html">${coverageReport.passthru.name}</href>
-        </td>
-      </tr>
+      <li>
+        <a href="${coverageReport.passthru.name}/hpc_index.html">${coverageReport.passthru.name}</a>
+      </li>
       '';
 
   projectIndexHtml = pkgs.writeText "index.html" ''
@@ -31,16 +24,22 @@ let
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     </head>
     <body>
-      <table border="1" width="100%">
-        <tbody>
-          <tr>
-            <th>Report</th>
-          </tr>
-
-          ${with lib; concatStringsSep "\n" (map coverageTableRows coverageReports)}
-
-        </tbody>
-      </table>
+      <div>
+        <h2>Union Report</h2>
+        <p>The following report shows how each module is covered by any test in the project:</p>
+        <ul>
+          <li>
+            <a href="all/hpc_index.html">all</a>
+          </li>
+        </ul>
+      </div>
+      <div>
+        <h2>Individual Reports</h2>
+        <p>The following reports show how each module is covered by tests in its own package:</p>
+        <ul>
+          ${with lib; concatStringsSep "\n" (map coverageListElement coverageReports)}
+        </ul>
+      </div>
     </body>
   </html>
   '';

--- a/lib/cover-project.nix
+++ b/lib/cover-project.nix
@@ -25,6 +25,9 @@ let
     </head>
     <body>
       <div>
+        WARNING: Modules with no coverage are not included in any of these reports, this is just how HPC works under the hood.
+      </div>
+      <div>
         <h2>Union Report</h2>
         <p>The following report shows how each module is covered by any test in the project:</p>
         <ul>

--- a/lib/cover-project.nix
+++ b/lib/cover-project.nix
@@ -38,7 +38,7 @@ let
       </div>
       <div>
         <h2>Individual Reports</h2>
-        <p>The following reports show how each module is covered by tests in its own package:</p>
+        <p>The following reports show how the tests of each package cover modules in the project:</p>
         <ul>
           ${with lib; concatStringsSep "\n" (map coverageListElement coverageReports)}
         </ul>
@@ -49,7 +49,7 @@ let
 
   ghc = project.pkg-set.config.ghc.package;
 
-  libs = lib.remove null (map (r: r.library) coverageReports);
+  libs = lib.unique (lib.concatMap (r: r.mixLibraries) coverageReports);
 
   mixDirs =
     map
@@ -57,6 +57,17 @@ let
       libs;
 
   srcDirs = map (l: l.srcSubDirPath) libs;
+
+  allCoverageReport = haskellLib.coverageReport {
+    name = "all";
+    checks = lib.flatten (lib.concatMap
+      (pkg: lib.optional (pkg ? checks) (lib.filter lib.isDerivation (lib.attrValues pkg.checks)))
+      (lib.attrValues (haskellLib.selectProjectPackages project.hsPkgs)));
+    mixLibraries = lib.concatMap
+      (pkg: lib.optional (pkg.components ? library) pkg.components.library)
+      (lib.attrValues (haskellLib.selectProjectPackages project.hsPkgs));
+    ghc = project.pkg-set.config.ghc.package;
+  };
 
 in pkgs.runCommand "project-coverage-report"
   ({ nativeBuildInputs = [ (ghc.buildGHC or ghc) pkgs.buildPackages.zip ];
@@ -126,30 +137,14 @@ in pkgs.runCommand "project-coverage-report"
       cp -R $report/share/hpc/vanilla/html/* $out/share/hpc/vanilla/html/
     '') coverageReports)}
 
-    if [ ''${#tixFiles[@]} -ne 0 ]; then
-      # Create tix file with test run information for all packages
-      tixFile="$out/share/hpc/vanilla/tix/all/all.tix"
-      hpcSumCmd=("hpc" "sum" "--union" "--output=$tixFile")
-      hpcSumCmd+=("''${tixFiles[@]}")
-      echo "''${hpcSumCmd[@]}"
-      eval "''${hpcSumCmd[@]}"
+    # Copy out "all" coverage report
+    cp -R ${allCoverageReport}/share/hpc/vanilla/tix/all $out/share/hpc/vanilla/tix
+    cp -R ${allCoverageReport}/share/hpc/vanilla/html/all $out/share/hpc/vanilla/html
 
-      # Markup a HTML coverage report for the entire project
-      cp ${projectIndexHtml} $out/share/hpc/vanilla/html/index.html
-      echo "report coverage-per-package $out/share/hpc/vanilla/html/index.html" >> $out/nix-support/hydra-build-products
+    # Markup a HTML coverage summary report for the entire project
+    cp ${projectIndexHtml} $out/share/hpc/vanilla/html/index.html
 
-      local markupOutDir="$out/share/hpc/vanilla/html/all"
-      local srcDirs=${toBashArray srcDirs}
-      local mixDirs=${toBashArray mixDirs}
-      local allMixModules=()
-
-      mkdir $markupOutDir
-      findModules allMixModules "$out/share/hpc/vanilla/mix/" "*.mix"
-
-      markup srcDirs mixDirs allMixModules "$markupOutDir" "$tixFile"
-
-      echo "report coverage $markupOutDir/hpc_index.html" >> $out/nix-support/hydra-build-products
-      ( cd $out/share/hpc/vanilla/html ; zip -r $out/share/hpc/vanilla/html.zip . )
-      echo "file zip $out/share/hpc/vanilla/html.zip" >> $out/nix-support/hydra-build-products
-    fi
+    echo "report coverage $out/share/hpc/vanilla/html/index.html" >> $out/nix-support/hydra-build-products
+    ( cd $out/share/hpc/vanilla/html ; zip -r $out/share/hpc/vanilla/html.zip . )
+    echo "file zip $out/share/hpc/vanilla/html.zip" >> $out/nix-support/hydra-build-products
   ''

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -591,8 +591,9 @@ final: prev: {
 
                       coverageReport = haskellLib.coverageReport (rec {
                         name = package.identifier.name + "-" + package.identifier.version;
-                        library = if components ? library then components.library else null;
+                        # Include the checks for a single package.
                         checks = final.lib.filter (final.lib.isDerivation) (final.lib.attrValues package'.checks);
+                        # Checks from that package may provide coverage information for any library in the project.
                         mixLibraries = final.lib.concatMap
                           (pkg: final.lib.optional (pkg.components ? library) pkg.components.library)
                             (final.lib.attrValues (haskellLib.selectProjectPackages project.hsPkgs));


### PR DESCRIPTION
After a request from the ouroboros-network team to add coverage reports to their repository, I realized the coverage reports provided by haskell.nix have a few deficiencies:

- If a package has no coverage of any of its modules, no coverage report is generated - leading to broken links in the project coverage report index page.
  - Fixed in b245f7e548fc60732dfa8614a6812fdf73cba271.
- There is no link to the unioned project coverage report on the project coverage report index page.
  - Fixed in 4aa1063e430db266596b253405ff1904715865cd
- HPC won't generate any coverage output if a module has 0% coverage.
  - Added a warning in 3820af5b059cdc4c127fdc315e2895986505e723.
  - This will require further work/investigation to fix.
  - Investigated this further and concluded this will require work on the `hpc` executable provided by GHC (https://gitlab.haskell.org/ghc/ghc/-/tree/ghc-8.10.7-release/utils/hpc). There's no easy way (from bash) to generate a .tix file that provides 0% coverage.
- If a test-suite depends on a module via "other-modules", the module is addressed differently in the mix file than usual. This caused the coverage report to fail to find the module.
  - Fixed this in e01f641144837f989b4a10e64b8aa81671836554 by expanding the search directories.
- Refactored the interface for generating coverage reports:
  - Remove the concept of "package boundaries" from the "coverageReport" function.
  - The "coverageReport" is now a function of:
    - arbitrary checks generating tix files
    - arbitrary mix modules
  - This more closely reflects the model of hpc, which doesn't care about package boundaries.
  - Use this new "coverageReport" function to simplify the "projectCoverageReport" implementation.