### PR TITLE
Add mapping between Cabal `pkgconfig-depends: bcrypt` and `libxcrypt`

### DIFF
--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -12,6 +12,7 @@ pkgs:
     "asound"                             = [ pkgs."alsaLib" ];
     "atk"                                = [ pkgs."atk" ];
     "b2"                                 = [ pkgs."libb2" ];
+    "bcrypt"                             = [ pkgs."libxcrypt" ];
     "bdw-gc"                             = [ pkgs."boehmgc" ];
     "bz2"                                = [ pkgs."bzip2" ];
     "c++"                                = []; # What is that?


### PR DESCRIPTION
Defined in `nixpkgs` here [`/pkgs/development/libraries/libxcrypt/default.nix`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/libxcrypt/default.nix)

> Extended crypt library for `descrypt`, `md5crypt`, `bcrypt`, and others
> https://github.com/besser82/libxcrypt/

The `BCryptGenRandom` symbol provided is needed by https://github.com/yvan-sraka/greetings (and I guess any project relying on Rust `std`) when cross-compiling to `x86_64-w64-mingw32`