### PR TITLE
Add mapping to Cabal `extra-libraries: bcrypt`

### DIFF
--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -129,6 +129,7 @@ in
      msvcrt = null; # this is the libc
      Crypt32 = null;
      mswsock = null;
+     bcrypt = null;
    }
 # -- os x
 # NB: these map almost 1:1 to the framework names


### PR DESCRIPTION
https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/

**N.B.** The `BCryptGenRandom` symbol is provided by MinGW `bcrypt.h` and needed by https://github.com/yvan-sraka/greetings (and I guess any project relying on Rust `std`) when cross-compiling to `x86_64-w64-mingw32`.