### PR TITLE
Avoid using `srcOnly`

### DIFF
--- a/lib/check.nix
+++ b/lib/check.nix
@@ -1,26 +1,30 @@
-{ stdenv, lib, haskellLib, srcOnly }:
+{ stdenv, lib, haskellLib }:
 drv:
 
 let
   component = drv.config;
 
-  subdir =
-    if drv?source
-      then
-        drv.srcSubDir or ""
-      else
-        # srcOnly returns just the subdir, so we're already in it.
-        "";
-
 # This derivation can be used to execute test component.
 # The $out of the derivation is a file containing the resulting
 # stdout output.
-in stdenv.mkDerivation ({
+in stdenv.mkDerivation ((
+  if drv ? source
+    then {
+      src = drv.source;
+      patchPhase =
+        # This `cd` is normally done in the `prePatch` of the drv
+        lib.optionalString (drv.srcSubDir != "") ''
+          cd ${lib.removePrefix "/" drv.srcSubDir}
+        '';
+    }
+    else
+      # This makes the derivation work a bit like `srcOnly`,
+      # using the original derivation, but replacing the `buildPhase`.
+      (drv.drvAttrs or drv) // {
+        outputs = [ "out" ];
+        separateDebugInfo = false;
+      }) // {
   name = (drv.name + "-check");
-
-  # Using `srcOnly` (rather than getting the `src` via a `drv.passthru`)
-  # should correctly apply the patches from `drv` (if any).
-  src = drv.source or (srcOnly drv);
 
   passthru = {
     inherit (drv) identifier config configFiles executableToolDepends cleanSrc env exeName;
@@ -30,19 +34,12 @@ in stdenv.mkDerivation ({
 
   inherit (component) doCheck doCrossCheck;
 
-  phases = ["unpackPhase" "buildPhase"];
+  phases = ["unpackPhase" "patchPhase" "buildPhase"];
 
   # If doCheck or doCrossCheck are false we may still build this
   # component and we want it to quietly succeed.
   buildPhase = ''
     mkdir $out
-    ${
-      # Change to the source sub directory if there is one.
-      lib.optionalString (subdir != "") ''
-        cd ${lib.removePrefix "/" subdir}
-      ''
-    }
-
     runHook preCheck
 
     ${toString component.testWrapper} ${drv}/bin/${drv.exeName} ${lib.concatStringsSep " " component.testFlags} | tee $out/test-stdout

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -229,7 +229,7 @@ in {
 
   # Check a test component
   check = import ./check.nix {
-    inherit stdenv lib haskellLib srcOnly;
+    inherit stdenv lib haskellLib;
   };
 
   # Do coverage of a package


### PR DESCRIPTION
New versions of `srcOnly` pass the `prePatch` hook in and we `cd` into the sub directory for the package in that hook.  This means that the output includes only the package subdirectory.

We worked around this, but the work around breaks for older nixpkgs where `prePatch` is not passed.

This change replaces the use of `srcOnly` and instead uses the same trick as source so that the `buildPhase` is replaced and runs in the expected source directory (including and it should still include any sibling directories that have not been filtered).