### PR TITLE
devshell: only provide binutils on gnu plateform

### DIFF
--- a/lib/project-overlays.nix
+++ b/lib/project-overlays.nix
@@ -12,7 +12,7 @@
       # so we need to explicit required dependencies which
       # are provided implicitely by stdenv when using the normal shell:
       ++ (lib.filter lib.isDerivation final.shell.stdenv.defaultNativeBuildInputs)
-      ++ [ final.pkgs.buildPackages.binutils ];
+      ++ lib.optional final.shell.stdenv.targetPlatform.isGnu final.pkgs.buildPackages.binutils;
       env = lib.mapAttrsToList lib.nameValuePair {
         inherit (final.shell) CABAL_CONFIG NIX_GHC_LIBDIR;
       };


### PR DESCRIPTION
(equivalent bintools already provided by clang-wrapper on darwin).