### PR TITLE
Nixify hackage-to-nix output

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,15 +118,16 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1659489414,
-        "narHash": "sha256-AghgUkUv0hIBh+PvODngYL+ejwhCn2O2OUkVaAZYkCU=",
+        "lastModified": 1659489607,
+        "narHash": "sha256-2eCSYdnfMihFApAT68IbTk71lZeizT9CVeGjkITs5P8=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "056c6ce7014adaf887b8e4cad15ef6fd926ea568",
+        "rev": "da7d2347d40dde04e089c5d536b295e846f56e91",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "hkm/nixify",
         "repo": "hackage.nix",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -118,16 +118,15 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1659489607,
-        "narHash": "sha256-2eCSYdnfMihFApAT68IbTk71lZeizT9CVeGjkITs5P8=",
+        "lastModified": 1659489414,
+        "narHash": "sha256-AghgUkUv0hIBh+PvODngYL+ejwhCn2O2OUkVaAZYkCU=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "da7d2347d40dde04e089c5d536b295e846f56e91",
+        "rev": "056c6ce7014adaf887b8e4cad15ef6fd926ea568",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "hkm/nixify",
         "repo": "hackage.nix",
         "type": "github"
       }
@@ -210,11 +209,11 @@
     "nix-tools": {
       "flake": false,
       "locked": {
-        "lastModified": 1658968505,
-        "narHash": "sha256-UnbQ/Ig/23e9hUdDOBwYHwHgHmQawZ2uazpJ8DLIJgE=",
+        "lastModified": 1659569011,
+        "narHash": "sha256-wHS0H5+TERmDnPCfzH4A+rSR5TvjYMWus9BNeNAMyUM=",
         "owner": "input-output-hk",
         "repo": "nix-tools",
-        "rev": "8a754bdcf20b20e116409c2341cf69065d083053",
+        "rev": "555d57e1ea81b79945f2608aa261df20f6b602a5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     flake-utils = { url = "github:numtide/flake-utils"; };
     hydra.url = "hydra";
     hackage = {
-      url = "github:input-output-hk/hackage.nix/hkm/nixify";
+      url = "github:input-output-hk/hackage.nix";
       flake = false;
     };
     stackage = {

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     flake-utils = { url = "github:numtide/flake-utils"; };
     hydra.url = "hydra";
     hackage = {
-      url = "github:input-output-hk/hackage.nix";
+      url = "github:input-output-hk/hackage.nix/hkm/nixify";
       flake = false;
     };
     stackage = {

--- a/modules/hackage.nix
+++ b/modules/hackage.nix
@@ -6,7 +6,7 @@ let
   #   { "a.b.c.d" =
   #     rec { sha256 = $pkgVersionSha256;
   #           revisions =
-  #           { r0 = { outPath = ./hackage/...; revNum = 0; sha256 = $revisionSha256; };
+  #           { r0 = { nix = import ../hackage/...; revNum = 0; sha256 = $revisionSha256; };
   #             default = revisions.r0; };
   #         };
   #     };
@@ -24,7 +24,7 @@ let
   #   { "a.b.c.d" =
   #     rec { sha256 = $packageVersionSha256;
   #           revisions =
-  #           { r0 = { outPath = ./hackage/...;
+  #           { r0 = { nix = import ../hackage/...;
   #                    sha256 = $packageVersionSha256;
   #                    revision = $revNum;
   #                    revisionSha256 = $revisionSha256; };
@@ -45,7 +45,7 @@ let
                 inherit (version) sha256;
                 revision = rev.revNum;
                 revisionSha256 = rev.sha256;
-              } // (rev.nix or (import rev)) modArgs;
+              } // (x: (rev.nix or (import rev)) x) modArgs;
               f = rev: acc: acc // {
                 # If there's a collision (e.g. a revision was
                 # reverted), pick the one with the smaller

--- a/modules/hackage.nix
+++ b/modules/hackage.nix
@@ -45,7 +45,7 @@ let
                 inherit (version) sha256;
                 revision = rev.revNum;
                 revisionSha256 = rev.sha256;
-              } // import rev modArgs;
+              } // (rev.nix or (import rev)) modArgs;
               f = rev: acc: acc // {
                 # If there's a collision (e.g. a revision was
                 # reverted), pick the one with the smaller

--- a/test/unit.nix
+++ b/test/unit.nix
@@ -118,8 +118,21 @@ lib.runTests {
     };
   };
 
-  testParseRepositoryBlock = {
-      expr = __toJSON (haskellLib.parseRepositoryBlock evalPackages "cabal.project" {} {}
+  testParseRepositoryBlock =
+    let
+      # The Cabal2Nix output in hackage-to-nix is imported into a lambda
+      # and connot be easily compared.
+      removeNix = x: x // {
+        hackage =
+          lib.mapAttrs (packageName: vers:
+            lib.mapAttrs (ver: data: data // {
+              revisions =
+                lib.mapAttrs (rev: x: x // { nix = __typeOf x.nix; }) data.revisions;
+            }) vers
+          ) x.hackage;
+      };
+    in rec {
+      expr = __toJSON (removeNix (haskellLib.parseRepositoryBlock evalPackages "cabal.project" {} {}
         evalPackages.haskell-nix.cabal-install.${compiler-nix-name}
         evalPackages.haskell-nix.nix-tools.${compiler-nix-name} ''
           ghcjs-overlay
@@ -129,7 +142,7 @@ lib.runTests {
             key-threshold: 0
             --sha256: sha256-y1vQnXI1XzkjnC4h66tVDmu2TZjZPcMrZEnE3m0XOfg=
           -- end of block
-      '');
+      ''));
       expected = __toJSON {
         name = "ghcjs-overlay";
         repoContents = "/nix/store/gzjj6rjjgvkm5midldy292ghbq7hszna-ghcjs-overlay";
@@ -140,8 +153,16 @@ lib.runTests {
           Cabal = {
             "3.2.1.0" = {
               revisions = {
-                default = "/nix/store/3ndxx3k43gmjkfl1qn1x39g15hz5amad-Cabal-3.2.1.0-r0-2b5309e942658e3b16e6938115867538e70a647d98e3dc967f2be20d6b886e61.nix";
-                r0 = "/nix/store/3ndxx3k43gmjkfl1qn1x39g15hz5amad-Cabal-3.2.1.0-r0-2b5309e942658e3b16e6938115867538e70a647d98e3dc967f2be20d6b886e61.nix";
+                default = {
+                  nix = "lambda";
+                  revNum = 0;
+                  sha256 = "2b5309e942658e3b16e6938115867538e70a647d98e3dc967f2be20d6b886e61";
+                };
+                r0 = {
+                  nix = "lambda";
+                  revNum = 0;
+                  sha256 = "2b5309e942658e3b16e6938115867538e70a647d98e3dc967f2be20d6b886e61";
+                };
               };
               sha256 = "826970f742b63d751f6fe3be7f862b7b1e419ddfafef3014c01de54f12874a4a";
             };
@@ -149,8 +170,16 @@ lib.runTests {
           basement = {
             "0.0.12"= {
               revisions = {
-                default = "/nix/store/3h1xwcij240kj243f23siw3p30hdbnrj-basement-0.0.12-r0-600669787199915545f99754496f13f955203b94dbb31de50093362c03367bb7.nix";
-                r0 = "/nix/store/3h1xwcij240kj243f23siw3p30hdbnrj-basement-0.0.12-r0-600669787199915545f99754496f13f955203b94dbb31de50093362c03367bb7.nix";
+                default = {
+                  nix = "lambda";
+                  revNum = 0;
+                  sha256 = "600669787199915545f99754496f13f955203b94dbb31de50093362c03367bb7";
+                };
+                r0 = {
+                  nix = "lambda";
+                  revNum = 0;
+                  sha256 = "600669787199915545f99754496f13f955203b94dbb31de50093362c03367bb7";
+                };
               };
               sha256 = "cf8f96fd92438739a516881abb7e14747118e82a12634d44acc83173fb87f535";
             };
@@ -158,8 +187,16 @@ lib.runTests {
           clock = {
             "0.8.2" = {
               revisions = {
-                default = "/nix/store/mdsf1fgbpi4m1yvsg5z8z4hk5w7i63x7-clock-0.8.2-r0-2a8441d9f531bb51bb1806e56e9e9a43e5f0214faea4f31219c15120128ca43a.nix";
-                r0 = "/nix/store/mdsf1fgbpi4m1yvsg5z8z4hk5w7i63x7-clock-0.8.2-r0-2a8441d9f531bb51bb1806e56e9e9a43e5f0214faea4f31219c15120128ca43a.nix";
+                default = {
+                  nix = "lambda";
+                  revNum = 0;
+                  sha256 = "2a8441d9f531bb51bb1806e56e9e9a43e5f0214faea4f31219c15120128ca43a";
+                };
+                r0 = {
+                  nix = "lambda";
+                  revNum = 0;
+                  sha256 = "2a8441d9f531bb51bb1806e56e9e9a43e5f0214faea4f31219c15120128ca43a";
+                };
               };
               sha256 = "57715a01df74568c638f1138b53642094de420bafd519e9f53ec7fe92876121e";
             };
@@ -167,8 +204,16 @@ lib.runTests {
           cryptonite = {
             "0.29" = {
               revisions = {
-                default = "/nix/store/i84rvw53j9b6p53dalg6xq85blrkrk01-cryptonite-0.29-r0-231db2acdaefc978865af9b72a6e65c4ebc70238174a7ad9076d68900f3d866d.nix";
-                r0 = "/nix/store/i84rvw53j9b6p53dalg6xq85blrkrk01-cryptonite-0.29-r0-231db2acdaefc978865af9b72a6e65c4ebc70238174a7ad9076d68900f3d866d.nix";
+                default = {
+                  nix = "lambda";
+                  revNum = 0;
+                  sha256 = "231db2acdaefc978865af9b72a6e65c4ebc70238174a7ad9076d68900f3d866d";
+                };
+                r0 = {
+                  nix = "lambda";
+                  revNum = 0;
+                  sha256 = "231db2acdaefc978865af9b72a6e65c4ebc70238174a7ad9076d68900f3d866d";
+                };
               };
               sha256 = "f104836bdaeed5243ff7e9fc0757d7255778f0af22976eef2b7789e7e1094283";
             };
@@ -176,8 +221,16 @@ lib.runTests {
           double-conversion = {
             "2.0.2.0" = {
               revisions = {
-                default = "/nix/store/cb41xbmf6abcq30sj2a1b00qim8nyhqx-double-conversion-2.0.2.0-r0-698f94e66b6263a1049b56ede47aa48e224c764f345c3130265742513443595b.nix";
-                r0 = "/nix/store/cb41xbmf6abcq30sj2a1b00qim8nyhqx-double-conversion-2.0.2.0-r0-698f94e66b6263a1049b56ede47aa48e224c764f345c3130265742513443595b.nix";
+                default = {
+                  nix = "lambda";
+                  revNum = 0;
+                  sha256 = "698f94e66b6263a1049b56ede47aa48e224c764f345c3130265742513443595b";
+                };
+                r0 = {
+                  nix = "lambda";
+                  revNum = 0;
+                  sha256 = "698f94e66b6263a1049b56ede47aa48e224c764f345c3130265742513443595b";
+                };
               };
               sha256 = "67c83bf4619624ef6b950578664cbcd3bc12eaed0d7a387997db5e0ba29fb140";
             };
@@ -185,8 +238,16 @@ lib.runTests {
           foundation = {
             "0.0.26.1" = {
               revisions = {
-                default = "/nix/store/5vw12rxa3as8b82kz1arddwzs45fzj6q-foundation-0.0.26.1-r0-9a2f63a33dc6b3c1425c4755522b8e619d04fdfcfef72e358155b965b28745a8.nix";
-                r0 = "/nix/store/5vw12rxa3as8b82kz1arddwzs45fzj6q-foundation-0.0.26.1-r0-9a2f63a33dc6b3c1425c4755522b8e619d04fdfcfef72e358155b965b28745a8.nix";
+                default = {
+                  nix = "lambda";
+                  revNum = 0;
+                  sha256 = "9a2f63a33dc6b3c1425c4755522b8e619d04fdfcfef72e358155b965b28745a8";
+                };
+                r0 = {
+                  nix = "lambda";
+                  revNum = 0;
+                  sha256 = "9a2f63a33dc6b3c1425c4755522b8e619d04fdfcfef72e358155b965b28745a8";
+                };
               };
               sha256 = "3c588f6bcf875762ac18b03b17a7ee3c0c60c8e2c884c0192269b0a97e89d526";
             };
@@ -194,15 +255,31 @@ lib.runTests {
           network = {
             "3.1.2.1" = {
               revisions = {
-                default = "/nix/store/sfc02hqr02pa3rwhha1skvlkiwmgvsf7-network-3.1.2.1-r0-ed4b1bb733613df5a2ebecd5533d08f20bacb0dc59ed207fd4b4670fe718713f.nix";
-                r0 = "/nix/store/sfc02hqr02pa3rwhha1skvlkiwmgvsf7-network-3.1.2.1-r0-ed4b1bb733613df5a2ebecd5533d08f20bacb0dc59ed207fd4b4670fe718713f.nix";
+                default = {
+                  nix = "lambda";
+                  revNum = 0;
+                  sha256 = "ed4b1bb733613df5a2ebecd5533d08f20bacb0dc59ed207fd4b4670fe718713f";
+                };
+                r0 = {
+                  nix = "lambda";
+                  revNum = 0;
+                  sha256 = "ed4b1bb733613df5a2ebecd5533d08f20bacb0dc59ed207fd4b4670fe718713f";
+                };
               };
               sha256 = "21869fd942cb9996ba26ba9418cdd44ac869f81caba08e5a2b2cdfe792ae4518";
             };
             "3.1.2.5" = {
               revisions = {
-                default = "/nix/store/rrh5f3hb8g5bwgd6y7lwfky3nrgsg5b2-network-3.1.2.5-r0-433a5e076aaa8eb3e4158abae78fb409c6bd754e9af99bc2e87583d2bcd8404a.nix";
-                r0 = "/nix/store/rrh5f3hb8g5bwgd6y7lwfky3nrgsg5b2-network-3.1.2.5-r0-433a5e076aaa8eb3e4158abae78fb409c6bd754e9af99bc2e87583d2bcd8404a.nix";
+                default = {
+                  nix = "lambda";
+                  revNum = 0;
+                  sha256 = "433a5e076aaa8eb3e4158abae78fb409c6bd754e9af99bc2e87583d2bcd8404a";
+                };
+                r0 = {
+                  nix = "lambda";
+                  revNum = 0;
+                  sha256 = "433a5e076aaa8eb3e4158abae78fb409c6bd754e9af99bc2e87583d2bcd8404a";
+                };
               };
               sha256 = "ee914e9b43bfb0f415777eb0473236803b14a35d48f6172079260c92c6ceb335";
             };
@@ -210,8 +287,16 @@ lib.runTests {
           terminal-size = {
             "0.3.2.1" = {
               revisions = {
-                default = "/nix/store/k9gk020ygp6j94sa3xv46fkgrc8jl5zn-terminal-size-0.3.2.1-r0-7b2d8e0475a46961d07ddfb91dee618de70eff55d9ba0402ebeac1f9dcf9b18b.nix";
-                r0 = "/nix/store/k9gk020ygp6j94sa3xv46fkgrc8jl5zn-terminal-size-0.3.2.1-r0-7b2d8e0475a46961d07ddfb91dee618de70eff55d9ba0402ebeac1f9dcf9b18b.nix";
+                default = {
+                  nix = "lambda";
+                  revNum = 0;
+                  sha256 = "7b2d8e0475a46961d07ddfb91dee618de70eff55d9ba0402ebeac1f9dcf9b18b";
+                };
+                r0 = {
+                  nix = "lambda";
+                  revNum = 0;
+                  sha256 = "7b2d8e0475a46961d07ddfb91dee618de70eff55d9ba0402ebeac1f9dcf9b18b";
+                };
               };
               sha256 = "8e4fbfea182f3bf5769744196ca88bb2cb1c80caa617debe34336f90db27131e";
             };
@@ -219,8 +304,16 @@ lib.runTests {
           unix-compat = {
             "0.5.3" = {
               revisions = {
-                default = "/nix/store/mc1vh6wzg0vp1c1srxrqmpv9fsqay6dw-unix-compat-0.5.3-r0-9c6d68f9afb5baa6be55e8415dd401835ce0d4dfc2090f1c169fcd61c152ebac.nix";
-                r0 = "/nix/store/mc1vh6wzg0vp1c1srxrqmpv9fsqay6dw-unix-compat-0.5.3-r0-9c6d68f9afb5baa6be55e8415dd401835ce0d4dfc2090f1c169fcd61c152ebac.nix";
+                default = {
+                  nix = "lambda";
+                  revNum = 0;
+                  sha256 = "9c6d68f9afb5baa6be55e8415dd401835ce0d4dfc2090f1c169fcd61c152ebac";
+                };
+                r0 = {
+                  nix = "lambda";
+                  revNum = 0;
+                  sha256 = "9c6d68f9afb5baa6be55e8415dd401835ce0d4dfc2090f1c169fcd61c152ebac";
+                };
               };
               sha256 = "2fe56781422d5caf47dcbbe82c998bd33f429f8c7093483fad36cd2d31dbdceb";
             };


### PR DESCRIPTION
We have been using `readFile` and `fromJSON` to read a `.json` a 60MB .json file.  This change puts the information contained in the json file into `.nix` files that are imported when needed (rather than all at once).  This seems to save around 1s at eval time.

Tested with:
```
time nix-instantiate -E '(import ./. {}).pkgs-unstable.haskell-nix.tool "ghc8107" "hello" {}'
time nix-instantiate -E '(import ./. {}).pkgs-unstable.haskell-nix.tool "ghc8107" "haskell-language-server" {}'
```

See also https://github.com/input-output-hk/nix-tools/pull/118