### PR TITLE
Fix #1557: add `haskell.nix` to https://github.com/NixOS/flake-registry

### DIFF
--- a/docs/tutorials/getting-started-hix.md
+++ b/docs/tutorials/getting-started-hix.md
@@ -4,7 +4,7 @@ Hix is a command line tool that provides an easy way to add haskell.nix
 support to existing haskell projects.
 
 You will need `nix` installed and in you `PATH` with nix in PATH with
-`experimental-features = [ "nix-command" "flakes" ];` configured.
+`experimental-features = nix-command flakes` configured.
 See https://nixos.wiki/wiki/Flakes for details.
 
 ## Using `hix init` and `nix`
@@ -17,7 +17,7 @@ For instance to run `cabal build` on the `hello` package from hackage:
 ```bash
 cabal unpack hello
 cd hello-1.0.0.2
-nix run "github:input-output-hk/haskell.nix#hix" -- init
+nix run haskell.nix#hix -- init
 nix develop
 cabal build
 ```


### PR DESCRIPTION
This depends on https://github.com/NixOS/flake-registry/pull/29

This would allow things like:

```
nix run haskell.nix#hix -- init
nix run haskell.nix#hix -- develop
nix run haskell.nix#hix-build
nix run haskell.nix#hix-shell
```

N.B. If `haskell.nix` isn't allowed, we will use `haskell-nix` instead.