### PR TITLE
Fix #1558: add flake template for `nix flake init`

### DIFF
--- a/docs/tutorials/getting-started-flakes.md
+++ b/docs/tutorials/getting-started-flakes.md
@@ -12,6 +12,37 @@ project and its dependencies into Nix code.
 Assuming you have [Nix](https://nixos.org/download.html) installed, you can
 start setting up your project.
 
+## Using `flake init` and `nix`
+
+The `flake init` command create an example `hello` package from hackage
+containing an `flake.nix` and `nix/hix.nix` file. The project can be used with
+regular `nix` tools.
+
+```bash
+nix flake init --template haskell-nix#template --impure
+# `--impure` is required by `builtins.currentSystem`
+nix develop
+cabal build
+```
+
+To view the contents of the flake run:
+
+```
+nix flake show
+```
+
+To build a component with nix:
+
+```
+nix build .#hello:exe:hello
+```
+
+To build and run a component:
+
+```
+nix run .#hello:exe:hello
+```
+
 ## Setting up the binary cache
 
 IMPORTANT: you *must* do this or you *will* build several copies of GHC!

--- a/docs/tutorials/getting-started-flakes.md
+++ b/docs/tutorials/getting-started-flakes.md
@@ -19,7 +19,7 @@ containing an `flake.nix` and `nix/hix.nix` file. The project can be used with
 regular `nix` tools.
 
 ```bash
-nix flake init --template haskell-nix#template --impure
+nix flake init --template templates#haskell-nix --impure
 # `--impure` is required by `builtins.currentSystem`
 nix develop
 cabal build


### PR DESCRIPTION
This depends on https://github.com/NixOS/templates/pull/40

This issue makes both `nix run haskell-nix#hix -- init` and
`nix flake init --template templates#haskell-nix --impure` do the same
thing!