### PR TITLE
Add IOG nix cache in flake configuration

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -41,7 +41,7 @@ steps:
 
   - label: 'Check that the haskell.nix roots do not require IFDs'
     command:
-      - nix build .#roots.x86_64-linux --option allow-import-from-derivation false
+      - yes | nix build .#roots.x86_64-linux --option allow-import-from-derivation false
     agents:
       system: x86_64-linux
 

--- a/flake.nix
+++ b/flake.nix
@@ -147,4 +147,14 @@
           ];
         };
     });
+
+  # --- Flake Local Nix Configuration ----------------------------
+  nixConfig = {
+    # This sets the flake to use the IOG nix cache.
+    # Nix should ask for permission before using it,
+    # but remove it here if you do not want it to.
+    extra-substituters = ["https://cache.iog.io"];
+    extra-trusted-public-keys = ["hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="];
+    allow-import-from-derivation = "true";
+  };
 }


### PR DESCRIPTION
From https://nixos.org/manual/nix/unstable/command-ref/new-cli/nix3-flake.html#flake-format

> `nixConfig`: a set of `nix.conf` options to be set when evaluating any part of a flake. In the interests of security, only a small set of whitelisted options (currently `bash-prompt`, `bash-prompt-prefix`, `bash-prompt-suffix`, and `flake-registry`) are allowed to be set without confirmation so long as `accept-flake-config` is not set in the global configuration.