### PR TITLE
ghc-lib-parser-9.4: add global unique counters patch

### DIFF
--- a/modules/configuration-nix.nix
+++ b/modules/configuration-nix.nix
@@ -60,6 +60,7 @@ in {
   packages.ghc-lib-parser.patches = [
     (fromUntil "8.10.0.0" "9.2" ../overlays/patches/ghc-lib-parser-8.10-global-unique-counters-in-rts.patch)
     (fromUntil "9.2.0.0" "9.3" ../overlays/patches/ghc-lib-parser-9.2-global-unique-counters-in-rts.patch)
+    (fromUntil "9.4.0.0" "9.5" ../overlays/patches/ghc-lib-parser-9.4-global-unique-counters-in-rts.patch)
   ];
 
   # See https://github.com/haskell-nix/hnix/pull/1053

--- a/overlays/patches/ghc-lib-parser-9.4-global-unique-counters-in-rts.patch
+++ b/overlays/patches/ghc-lib-parser-9.4-global-unique-counters-in-rts.patch
@@ -1,0 +1,13 @@
+diff --git a/compiler/cbits/genSym.c b/compiler/cbits/genSym.c
+index 0897547..8627f5a 100644
+--- a/compiler/cbits/genSym.c
++++ b/compiler/cbits/genSym.c
+@@ -9,7 +9,7 @@
+ //
+ // The CPP is thus about the RTS version GHC is linked against, and not the
+ // version of the GHC being built.
+-#if !MIN_VERSION_GLASGOW_HASKELL(9,3,0,0)
++#if !MIN_VERSION_GLASGOW_HASKELL(9,2,0,0)
+ HsInt ghc_unique_counter = 0;
+ HsInt ghc_unique_inc     = 1;
+ #endif


### PR DESCRIPTION
Otherwise, linker errors like in #1488 show up