### PR TITLE
Fix #1581 & #1586: flake output attribute `defaultPackage` and `devShell` are deprecated

### DIFF
--- a/docs/tutorials/getting-started-flakes.md
+++ b/docs/tutorials/getting-started-flakes.md
@@ -97,7 +97,7 @@ Add `flake.nix`:
       };
     in flake // {
       # Built by `nix build .`
-      defaultPackage = flake.packages."hello:exe:hello";
+      packages.${system}.default = flake.packages."hello:exe:hello";
     });
 }
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -137,7 +137,7 @@
 
       packages = ((self.internal.compat { inherit system; }).hix).apps;
 
-      devShell = with self.legacyPackages.${system};
+      devShells.${system}.default = with self.legacyPackages.${system};
         mkShell {
           buildInputs = [
             nixUnstable


### PR DESCRIPTION
Using `packages.<system>.default` and `devShells.<system>.default` instead