### PR TITLE
Fix for tests broken by cabal update in hackage

### DIFF
--- a/builder/make-config-files.nix
+++ b/builder/make-config-files.nix
@@ -11,7 +11,9 @@ let
 
   flagsAndConfig = field: xs: lib.optionalString (xs != []) ''
     echo ${lib.concatStringsSep " " (map (x: "--${field}=${x}") xs)} >> $out/configure-flags
-    echo "${field}: ${lib.concatStringsSep " " xs}" >> $out/cabal.config
+    ${lib.concatStrings (map (x: ''
+      echo "${field}: ${x}" >> $out/cabal.config
+    '') xs)}
   '';
 
   target-pkg = "${ghc.targetPrefix}ghc-pkg";

--- a/builder/make-config-files.nix
+++ b/builder/make-config-files.nix
@@ -129,8 +129,11 @@ let
     done
 
     ${ # Note: we pass `clear` first to ensure that we never consult the implicit global package db.
-      flagsAndConfig "package-db" ["clear" "$out/${packageCfgDir}"]
+       # However in `cabal.config` `cabal` requires `global` to be first.
+      flagsAndConfig "package-db" ["clear"]
     }
+    echo "package-db: global" >> $out/cabal.config
+    ${ flagsAndConfig "package-db" ["$out/${packageCfgDir}"] }
 
     echo ${lib.concatStringsSep " " (lib.mapAttrsToList (fname: val: "--flags=${lib.optionalString (!val) "-" + fname}") flags)} >> $out/configure-flags
 

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 3
+, ifdLevel ? 1
 , checkMaterialization ? false }:
 
 let

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 3
+, ifdLevel ? 0
 , checkMaterialization ? false }:
 
 let

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 1
+, ifdLevel ? 2
 , checkMaterialization ? false }:
 
 let

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 2
+, ifdLevel ? 3
 , checkMaterialization ? false }:
 
 let

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 0
+, ifdLevel ? 1
 , checkMaterialization ? false }:
 
 let

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
-, ifdLevel ? 1
+, ifdLevel ? 0
 , checkMaterialization ? false }:
 
 let

--- a/test/cabal-simple/default.nix
+++ b/test/cabal-simple/default.nix
@@ -30,7 +30,7 @@ in recurseIntoAttrs {
   };
 
   # Used for testing externally with nix-shell (../tests.sh).
-  test-shell = project.shellFor { tools = { cabal = "3.6.2.0"; }; withHoogle = !__elem compiler-nix-name ["ghc901" "ghc902" "ghc921" "ghc922" "ghc923" "ghc924"]; };
+  test-shell = project.shellFor { tools = { cabal = "latest"; }; withHoogle = !__elem compiler-nix-name ["ghc901" "ghc902" "ghc921" "ghc922" "ghc923" "ghc924"]; };
 
   run = stdenv.mkDerivation {
     name = "cabal-simple-test";

--- a/test/shell-for/default.nix
+++ b/test/shell-for/default.nix
@@ -23,7 +23,7 @@ let
     packages = ps: with ps; [ pkga pkgb ];
     # This adds cabal-install to the shell, which helps tests because
     # they use a nix-shell --pure. Normally you would BYO cabal-install.
-    tools = { cabal = "3.2.0.0"; };
+    tools = { cabal = "latest"; };
     exactDeps = true;
     # Avoid duplicate package issues when runghc looks for packages
     packageSetupDeps = false;
@@ -34,7 +34,7 @@ let
     packages = ps: with ps; [ pkga ];
     # This adds cabal-install to the shell, which helps tests because
     # they use a nix-shell --pure. Normally you would BYO cabal-install.
-    tools = { cabal = "3.2.0.0"; };
+    tools = { cabal = "latest"; };
     exactDeps = true;
     # Avoid duplicate package issues when runghc looks for packages
     packageSetupDeps = false;
@@ -46,7 +46,7 @@ let
     #   packages = ps: with ps; [ pkga pkgb ];
     # This adds cabal-install to the shell, which helps tests because
     # they use a nix-shell --pure. Normally you would BYO cabal-install.
-    tools = { cabal = "3.2.0.0"; };
+    tools = { cabal = "latest"; };
     # Avoid duplicate package issues when runghc looks for packages
     packageSetupDeps = false;
   };


### PR DESCRIPTION
These tests pinned the `cabal-install` version, but not the hackage index state.  The recent addition of `Cabal` and `cabal-install` 3.8 to hackage has broken these tests.

This fix changes the tests to use the latest version of `cabal-install`.

We could probably fix them by pinning the hackage index state, but I think it is more useful to know if the latests version of `cabal-install` works with the latest hackage.  The `cabal-install` version used internally by haskell.nix is pinned along with the index state so we already test that pinned version. 