### PR TITLE
Fix hls build for ghc 9.2

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -34,7 +34,6 @@ in rec {
             "ghc884" = "3.3.6";
           }.compiler-nix-name or "latest";
       };
-    } // pkgs.lib.optionalAttrs (!__elem compiler-nix-name ["ghc921" "ghc922" "ghc923" "ghc924"]) {
       hls-latest = tool compiler-nix-name "haskell-language-server" { inherit evalPackages; };
     })
   );

--- a/modules/hackage-quirks.nix
+++ b/modules/hackage-quirks.nix
@@ -5,8 +5,8 @@ let
   # Easier than importing nixpkgs just for this
   mapAttrsToList = f: attrs:
     map (name: f name attrs.${name}) (__attrNames attrs);
-in [(
-  {config, lib, pkgs, ...}:
+in [
+  ({config, lib, pkgs, ...}:
     { _file = "haskell.nix/overlays/hackage-quirks.nix#cabal-install"; } //
     # FIXME: this is required to build cabal-install 3.2 with ghc 8.6,
     # but also for
@@ -23,24 +23,33 @@ in [(
           packages.cabal-install.src = pkgs.buildPackages.haskell-nix.sources.cabal-32 + "/cabal-install";
         })
       ];
-    })]
+    }
+  )
+
+  # TODO remove this when `dependent-sum-0.7.1.0` constraint on `some` has been updated.
+  # See https://github.com/haskell/haskell-language-server/issues/2969
+  # and https://github.com/obsidiansystems/dependent-sum/issues/71
+  ({config, lib, pkgs, ...}:
+    { _file = "haskell.nix/overlays/hackage-quirks.nix#haskell-language-server"; } //
+    lib.mkIf (config.name == "haskell-language-server") {
+      cabalProject = lib.mkDefault (''
+        packages: .
+        constraints: dependent-sum >=0.7.1.0
+      ''
+      # TODO Remove this flag once the hls-haddock-comments-plugin is updated in hackage to work with ghc 9.2
+      + lib.optionalString (__elem config.compiler-nix-name ["ghc921" "ghc922" "ghc923" "ghc924"]) ''
+        package haskell-language-server
+          flags: -haddockcomments
+      '');
+    }
+  )
 
   # Map the following into modules that use `mkIf` to check the name of the
   # hackage package in a way that is lazy enought not to cause infinite recursion
   # issues.
-  ++ mapAttrsToList (n: v: {config, lib, ...}:
+  ] ++ mapAttrsToList (n: v: {config, lib, ...}:
     { _file = "haskell.nix/overlays/hackage-quirks.nix#${n}"; } //
     lib.mkIf (n == config.name) v) {
-
-    # TODO remove this when `dependent-sum-0.7.1.0` constraint on `some` has been updated.
-    # See https://github.com/haskell/haskell-language-server/issues/2969
-    # and https://github.com/obsidiansystems/dependent-sum/issues/71
-    haskell-language-server = {
-      cabalProject = ''
-        packages: .
-        constraints: dependent-sum >=0.7.1.0
-      '';
-    };
 
     lsp-test = {
       cabalProject = ''

--- a/test/haskell-language-server/cabal.nix
+++ b/test/haskell-language-server/cabal.nix
@@ -6,4 +6,7 @@ in recurseIntoAttrs {
     inherit (project) plan-nix;
   };
   build = project.getComponent "haskell-language-server:exe:haskell-language-server";
+
+  # hls does not need to be cross compiled.
+  meta.disabled = stdenv.hostPlatform != stdenv.buildPlatform;
 }

--- a/test/haskell-language-server/cabal.nix
+++ b/test/haskell-language-server/cabal.nix
@@ -6,7 +6,4 @@ in recurseIntoAttrs {
     inherit (project) plan-nix;
   };
   build = project.getComponent "haskell-language-server:exe:haskell-language-server";
-
-  # Haskell Language Server in hackage does not build for GHC 9.2 yet
-  meta.disabled = __elem compiler-nix-name ["ghc921" "ghc922" "ghc923" "ghc924"] || stdenv.hostPlatform != stdenv.buildPlatform;
 }


### PR DESCRIPTION
This adds `flags: -haddockcomments` to the default cabal.project of haskell-language-server to fix building on ghc 9.2