### PR TITLE
Give a working evalPackages to package-set

### DIFF
--- a/modules/plan.nix
+++ b/modules/plan.nix
@@ -299,13 +299,6 @@ in {
       visible = false;
       internal = true;
     };
-
-    evalPackages = mkOption {
-      type = unspecified;
-      description = ''
-        The `evalPackages` that will be used when building `hoogle` and shell tools.
-      '';
-    };
   };
 
   config = let module = config.plan.pkg-def config.hackage.configs; in {

--- a/package-set.nix
+++ b/package-set.nix
@@ -101,6 +101,9 @@ in pkgs.lib.evalModules {
 
     # Configuration that applies to all plans
     ./modules/configuration-nix.nix
+
+    # Configuration that applies to all projects
+    ./modules/project-common.nix
   ];
 };
 in f


### PR DESCRIPTION
I only use things like plan-to-nix and I don't use the project
functions. Recently the introduction of evalPackages has broken my
workflow.

Trying to include tools via withHoogle = true; or tools.cabal =
"3.4.0.0"; would result in evalPackages being evaluated but being
undefined.

Because the evalPackages defined in plan.nix was just a stub. I tried
to expand it there but then it also needed evalSystem. Since
project-common.nix already has working definitions for these and
doesn't bring in too much else, I decided to just use that for
package-sets. Not great but seems work well.