### PR TITLE
Remove nixpkgs 21.11 from CI and reduce tests

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -10,7 +10,6 @@
   inherit (import ./ci-lib.nix { inherit pkgs; }) dimension platformFilterGeneric filterAttrsOnlyRecursive;
   inherit (pkgs.haskell-nix) sources;
   nixpkgsVersions = {
-    "R2111" = "nixpkgs-2111";
     "R2205" = "nixpkgs-2205";
     "unstable" = "nixpkgs-unstable";
   };
@@ -30,17 +29,14 @@
     # cabal-install and nix-tools plans.  When removing a ghc version
     # from here (so that is no longer cached) also remove ./materialized/ghcXXX.
     # Update supported-ghc-versions.md to reflect any changes made here.
-    nixpkgs.lib.optionalAttrs (nixpkgsName == "R2111") {
+    nixpkgs.lib.optionalAttrs (nixpkgsName == "R2205") {
       ghc865 = false;
-      ghc8107 = true;
-    } // nixpkgs.lib.optionalAttrs (nixpkgsName == "R2205") {
-      ghc865 = false;
-      ghc8107 = true;
+      ghc8107 = false;
     } // nixpkgs.lib.optionalAttrs (nixpkgsName == "unstable") {
       ghc865 = false;
       ghc884 = false; # Native version is used to boot 9.0.1
       ghc8107 = true;
-      ghc902 = true;
+      ghc902 = false;
       ghc924 = true;
     });
   systems = nixpkgsName: nixpkgs: compiler-nix-name: nixpkgs.lib.genAttrs (

--- a/docs/reference/supported-ghc-versions.md
+++ b/docs/reference/supported-ghc-versions.md
@@ -21,12 +21,12 @@ really should use an instance of Nixpkgs provided by `haskell.nix` itself.
 
 | Nixpkgs version  | Nixpkgs pinning    | GHC version | `compiler-nix-name`   | Tested in CI? |
 |------------------|--------------------|-------------|-----------------------|---------------|
-| 21.11            | `nixpkgs-2111`     | 8.6.5       | `ghc865`              | No            |
-| 21.11            | `nixpkgs-2111`     | 8.10.7      | `ghc8107`             | Yes           |
+| 22.05            | `nixpkgs-2205`     | 8.6.5       | `ghc865`              | No            |
+| 22.05            | `nixpkgs-2205`     | 8.10.7      | `ghc8107`             | No            |
 | unstable         | `nixpkgs-unstable` | 8.6.5       | `ghc865`              | No            |
 | unstable         | `nixpkgs-unstable` | 8.8.4       | `ghc884`              | No            |
 | unstable         | `nixpkgs-unstable` | 8.10.7      | `ghc8107`             | Yes           |
-| unstable         | `nixpkgs-unstable` | 9.0.2       | `ghc902`              | Yes           |
+| unstable         | `nixpkgs-unstable` | 9.0.2       | `ghc902`              | No            |
 | unstable         | `nixpkgs-unstable` | 9.2.4       | `ghc924`              | Yes           |
 
 See [ci.nix](https://github.com/input-output-hk/haskell.nix/blob/master/ci.nix)

--- a/release.nix
+++ b/release.nix
@@ -21,8 +21,8 @@ let
     # added here will also included without aggregation, making it easier
     # to find a failing test.  Keep in mind though that adding too many
     # of these will slow down eval times.
-    x86_64-linux = allJobs.R2111.ghc8107.x86_64-linux.native or {};
-    x86_64-darwin = allJobs.R2111.ghc8107.x86_64-darwin.native or {};
+    x86_64-linux = allJobs.unstable.ghc8107.x86_64-linux.native or {};
+    x86_64-darwin = allJobs.unstable.ghc8107.x86_64-darwin.native or {};
   };
   names = x: lib.filter (n: n != "recurseForDerivations" && n != "meta")
     (builtins.attrNames x);


### PR DESCRIPTION
The time taken to run CI is getting very long.  Hopefully removing nixpkgs 21.11 and no longer runs full tests for GHC 9.0.2 well make room for GHC 9.4.1.