### PR TITLE
Fix #1587: the option `shell.buildInputs` does not exist ...

### DIFF
--- a/builder/shell-for.nix
+++ b/builder/shell-for.nix
@@ -145,7 +145,7 @@ let
   mkDrvArgs = builtins.removeAttrs args ["packages" "components" "additional" "withHoogle" "tools"];
 in
   mkShell (mkDrvArgs // {
-    name = mkDrvArgs.name or name;
+    name = if (mkDrvArgs.name or null) == null then name else mkDrvArgs.name;
 
     buildInputs = systemInputs
       ++ mkDrvArgs.buildInputs or [];

--- a/modules/shell.nix
+++ b/modules/shell.nix
@@ -1,6 +1,10 @@
 { projectConfig }:
 { lib, config, pkgs, haskellLib, ... }: {
   options = {
+    name = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+    };
     packages = lib.mkOption {
       type = lib.types.unspecified;
       default = ps: builtins.attrValues (haskellLib.selectLocalPackages ps);
@@ -40,6 +44,30 @@
     crossPlatforms = lib.mkOption {
       type = lib.types.unspecified;
       default = projectConfig.crossPlatforms;
+    };
+
+    # mkShell args
+    inputsFrom = lib.mkOption {
+      type = lib.types.listOf lib.types.unspecified;
+      default = [];
+    };
+    shellHook = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+    };
+
+    # mkDerivation args
+    buildInputs = lib.mkOption {
+      type = lib.types.listOf lib.types.unspecified;
+      default = [];
+    };
+    nativeBuildInputs = lib.mkOption {
+      type = lib.types.listOf lib.types.unspecified;
+      default = [];
+    };
+    passthru = lib.mkOption {
+      type = lib.types.attrsOf lib.types.unspecified;
+      default = {};
     };
   };
 }


### PR DESCRIPTION
@hamishmack wrote:
> I think we need to add the following to the module in [shell.nix](https://github.com/input-output-hk/haskell.nix/blob/master/modules/shell.nix):
>  * From [`pkgs.mkShell`](https://nixos.org/manual/nixpkgs/stable/#sec-pkgs-mkShell)
>       - name
>       - inputsFrom
>       - shellHook
>  * From [`mkDerivation`](https://github.com/NixOS/nixpkgs/blob/c3b5e5344d08274212621f8931c7404d4745d3fc/pkgs/stdenv/generic/make-derivation.nix#L89-L156)
>       - buildInputs
>       - nativeBuildInputs
>       - passthru