### PR TITLE
Make test logs more verbose using `bash -x` option

### DIFF
--- a/test/tests.sh
+++ b/test/tests.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p bash jq nix gnused
+#! nix-shell -i "bash -x" -p bash jq nix gnused
 
 set -euo pipefail
 


### PR DESCRIPTION
I believe that makes it way easier to get what command actually fail when reading test logs …