### PR TITLE
Add a custom `nix.conf` file for CI tests

### DIFF
--- a/test/nix.conf
+++ b/test/nix.conf
@@ -1,0 +1,10 @@
+allow-import-from-derivation = true
+allowed-users = *
+builders-use-substitutes = true
+experimental-features = nix-command flakes
+keep-derivations = true
+keep-outputs = true
+max-jobs = auto
+substituters = https://cache.iog.io https://cache.nixos.org https://cache.ngi0.nixos.org/ https://cache.nixos.org/
+system-features = nixos-test benchmark big-parallel kvm
+trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.ngi0.nixos.org-1:KqH5CBLNSyX184S9BKZJo1LxrxJ9ltnY2uAs5c/f1MA= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo=

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -20,6 +20,17 @@ printf "*** Cleaning package build directories..." >& 2
 rm -rvf */cabal.project.local */.ghc.environment* */dist */dist-newstyle */.stack-work
 echo >& 2
 
+# This was needed is first place to make hix template / flake devShell examples
+# not require interactive user confirmation. Because the IOG nix cache settings
+# are defined in the `nixConfig` flake attribute.
+if [ ! -z ${CI+x} ]; then
+  printf "*** Set custom nix.conf for CI ..." >& 2
+  export XDG_CONFIG_HOME=$HOME/.config
+  mkdir -p $XDG_CONFIG_HOME/nix
+  cp ./nix.conf $XDG_CONFIG_HOME/nix
+  echo >& 2
+fi
+
 printf "*** Running the nix-build tests...\n" >& 2
 nix build $NIX_BUILD_ARGS \
    -I . -I .. \


### PR DESCRIPTION
This should unstuck both #1579 and #1601 …

n.b. This is enabled only when `CI` env variable is set, to not bother
normal users in their interactive tests :wink: 