### PR TITLE
Map opengl32 and glu32 to null on Windows

### DIFF
--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -121,6 +121,7 @@ in
      ole32 = null; rpcrt4 = null;
      winmm = null; userenv = null;
      kernel32 = null; ws2_32 = null;
+     opengl32 = null; glu32 = null;
      # this should be bundled with gcc.
      # if it's not we have more severe
      # issues anyway.


### PR DESCRIPTION
Helps fix https://github.com/input-output-hk/haskell.nix/issues/1091

I have that `gloss` project successfully x-compiling and running with `wine` here: https://github.com/BlackBlack667/TicTacToe/pull/2