### PR TITLE
Fix use of no longer supported GHC version.

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -110,7 +110,7 @@ in pkgs.haskell-nix.project {
     src = ./.;
   };
   # Specify the GHC version to use.
-  compiler-nix-name = "ghc8102"; # Not required for `stack.yaml` based projects.
+  compiler-nix-name = "ghc8107"; # Not required for `stack.yaml` based projects.
 }
 ```
 


### PR DESCRIPTION
The documentation is no longer valid.