### PR TITLE
Fix daily updates of hackage and stackage

### DIFF
--- a/scripts/update-external.nix
+++ b/scripts/update-external.nix
@@ -35,5 +35,5 @@ in
 
     cd ..
 
-    nix --experimental-features 'nix-command flakes' flake lock --update-input ${name}
+    yes | nix --experimental-features 'nix-command flakes' flake lock --update-input ${name}
   ''


### PR DESCRIPTION
These were broken by #1579 because `nix flake lock` now asks for confirmation that it is ok to use the nix configuration in the flake.