### PR TITLE
Fix hix support for github

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,3 +50,9 @@ steps:
       - nix-instantiate release.nix -A required-unstable-ghc8107-x86_64-darwin-native --show-trace --builders ''
     agents:
       system: x86_64-linux
+
+  - label: 'Check hix -- run github:haskell/cabal/3.8#cabal-install:exe:cabal -- --version'
+    command:
+      - "HIX_DIR=$(mktemp -d) nix run .#hix --accept-flake-config -- run github:haskell/cabal/3.8#cabal-install:exe:cabal --accept-flake-config --override-input haskellNix . -- --version"
+    agents:
+      system: x86_64-linux

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -801,11 +801,10 @@ final: prev: {
 
         # `project'` and `project` automatically select between `cabalProject`
         # and `stackProject` (when possible) by looking for `stack.yaml` or
-        # `cabal.project` files.  If both exist we can pass in one of:
+        # `cabal.project` files.  If both exist it uses the `cabal.project` file.
+        # To override this pass in:
         #     `projectFileName = "stack.yaml;"`
-        #     `projectFileName = "cabal.project";`
-        # to let it know which to choose (or pick another name).  If the
-        # selected file ends in a `.yaml` it is assumed to be for `stackProject`.
+        # If the selected file ends in a `.yaml` it is assumed to be for `stackProject`.
         # If neither `stack.yaml` nor `cabal.project` exist `cabalProject` is
         # used (as it will use a default `cabal.project`).
         project' = projectModule:
@@ -829,8 +828,8 @@ final: prev: {
                 then projectFileName  # Prefer the user selected project file name
                 else
                   if stackYamlExists && cabalProjectExists
-                    then throw ("haskell-nix.project : both `stack.yaml` and `cabal.project` files exist "
-                      + "set `projectFileName = \"stack.yaml\";` or `projectFileName = \"cabal.project\";`")
+                    then __trace ("haskell-nix.project : both `stack.yaml` and `cabal.project` files exist.  Using `cabal.project`. "
+                      + "set `projectFileName = \"stack.yaml\";` to override this.`") "cabal.project"
                     else
                       if stackYamlExists
                         then "stack.yaml"      # stack needs a stack.yaml


### PR DESCRIPTION
With this change we can build and run the latest `cabal` from github using haskell.nix with:

```
hix run github:haskell/cabal#cabal-install:exe:cabal -- --version
```

You can install it in your profile with:

```
hix profile install github:haskell/cabal#cabal-install:exe:cabal
```

Because the `flake.nix` file is stored in `$HOME/.hix/github:haskell/cabal` we can lock it with:

```
hix flake lock github:haskell/cabal
```