### PR TITLE
Split calls to `test/test.sh` into several buildkite jobs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,76 @@
 steps:
-  - label: 'Run tests with ghc8107'
-    command: "./test/tests.sh ghc8107"
+  - label: 'Run tests with ghc8107: Running the nix-build tests...'
+    command: "./test/tests.sh ghc8107 nix-build"
+    agents:
+      system: x86_64-linux
+
+  - label: 'Run tests with ghc8107: Running the unit tests...'
+    command: "./test/tests.sh ghc8107 unit-tests"
+    agents:
+      system: x86_64-linux
+
+  - label: 'Run tests with ghc8107: Checking that a nix-shell works for runghc...'
+    command: "./test/tests.sh ghc8107 runghc"
+    agents:
+      system: x86_64-linux
+
+  - label: 'Run tests with ghc8107: Checking that a nix-shell works for cabal...'
+    command: "./test/tests.sh ghc8107 cabal"
+    agents:
+      system: x86_64-linux
+
+  - label: 'Run tests with ghc8107: Checking that a nix-shell works for cabal (doExactConfig component)...'
+    command: "./test/tests.sh ghc8107 cabal-doExactConfig"
+    agents:
+      system: x86_64-linux
+
+  - label: 'Run tests with ghc8107: Checking that a nix-shell works for a project with test-suite build-tools and benchmarks...'
+    command: "./test/tests.sh ghc8107 tests-benchmarks"
+    agents:
+      system: x86_64-linux
+
+  - label: 'Run tests with ghc8107: Checking that a nix-shell works for a multi-target project...'
+    command: "./test/tests.sh ghc8107 multi-target"
+    agents:
+      system: x86_64-linux
+
+  - label: 'Run tests with ghc8107: Checking shellFor works for a cabal project, multiple packages...'
+    command: "./test/tests.sh ghc8107 shellFor-single-package"
+    agents:
+      system: x86_64-linux
+
+  - label: 'Run tests with ghc8107: Checking shellFor works for a cabal project, single package...y'
+    command: "./test/tests.sh ghc8107 shellFor-multiple-package"
+    agents:
+      system: x86_64-linux
+
+  - label: 'Run tests with ghc8107: Checking shellFor works for a cabal project, single package...'
+    command: "./test/tests.sh ghc8107 shellFor-hoogle"
+    agents:
+      system: x86_64-linux
+
+  - label: 'Run tests with ghc8107: Checking shellFor does not depend on given packages...y'
+    command: "./test/tests.sh ghc8107 shellFor-not-depends"
+    agents:
+      system: x86_64-linux
+
+  - label: 'Run tests with ghc8107: Checking the maintainer scripts...y'
+    command: "./test/tests.sh ghc8107 maintainer-scripts"
+    agents:
+      system: x86_64-linux
+
+  - label: 'Run tests with ghc8107: Checking that plan construction works with extra Hackages...'
+    command: "./test/tests.sh ghc8107 plan-extra-hackages"
+    agents:
+      system: x86_64-linux
+
+  - label: 'Run tests with ghc8107: Checking that package with extra Hackages can be build...'
+    command: "./test/tests.sh ghc8107 build-extra-hackages"
+    agents:
+      system: x86_64-linux
+
+  - label: 'Run tests with ghc8107: End-2-end test of hix project initialization and flakes development shell ...'
+    command: "./test/tests.sh ghc8107 hix"
     agents:
       system: x86_64-linux
 
@@ -56,3 +126,4 @@ steps:
       - "HIX_DIR=$(mktemp -d) nix run .#hix --accept-flake-config -- run github:haskell/cabal/3.8#cabal-install:exe:cabal --accept-flake-config --override-input haskellNix . -- --version"
     agents:
       system: x86_64-linux
+

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i "bash -x" -p bash jq nix gnused
+#! nix-shell -i bash -p bash jq nix gnused
 
 set -euo pipefail
 
@@ -9,9 +9,13 @@ NIX_BUILD_ARGS="${NIX_BUILD_ARGS:-}"
 
 cd $(dirname $0)
 
-if [ "$#" != "1" ]; then
+if   [ "$#" < "1" ]; then
   echo "Please pass a compiler-nix-name to use.  For example: ./test/tests.sh ghc884"
   exit 1
+elif [ "$#" > "1" ]; then
+  TESTS="$2"
+else
+  TESTS="all"
 fi
 
 GHC=$1
@@ -20,147 +24,177 @@ printf "*** Cleaning package build directories..." >& 2
 rm -rvf */cabal.project.local */.ghc.environment* */dist */dist-newstyle */.stack-work
 echo >& 2
 
-printf "*** Running the nix-build tests...\n" >& 2
-nix build $NIX_BUILD_ARGS \
-    --accept-flake-config \
-    -I . -I .. \
-    --option restrict-eval true \
-    --option allowed-uris "https://github.com/NixOS https://github.com/input-output-hk" \
-    --no-link --keep-going -f default.nix \
-    --argstr compiler-nix-name $GHC \
-    --arg CADerivationsEnabled $NIX_CA_DERIVATIONS
-echo >& 2
-
-printf "*** Running the unit tests... " >& 2
-res=$(nix-instantiate --eval --json --strict ./default.nix --argstr compiler-nix-name $GHC -A unit.tests)
-num_failed=$(jq length <<< "$res")
-if [ $num_failed -eq 0 ]; then
-  printf "PASSED\n" >& 2
-else
-  printf "$num_failed FAILED\n" >& 2
-  jq . <<< "$res"
-  exit 1
+if [ "$TESTS" == "nix-build" ] || [ "$TESTS" == "all" ]; then
+  printf "*** Running the nix-build tests...\n" >& 2
+  nix build $NIX_BUILD_ARGS \
+      --accept-flake-config \
+      -I . -I .. \
+      --option restrict-eval true \
+      --option allowed-uris "https://github.com/NixOS https://github.com/input-output-hk" \
+      --no-link --keep-going -f default.nix \
+      --argstr compiler-nix-name $GHC \
+      --arg CADerivationsEnabled $NIX_CA_DERIVATIONS
+  echo >& 2
 fi
 
-printf "*** Checking that a nix-shell works for runghc...\n" >& 2
-# This has to use ghc865 for now
-nix-shell $NIX_BUILD_ARGS \
-    --pure ./default.nix \
-    --argstr compiler-nix-name ghc865 \
-    -A with-packages.test-shell \
-    --run 'runghc with-packages/Point.hs'
-echo >& 2
-
-printf "*** Checking that a nix-shell works for cabal...\n" >& 2
-# This has to use ghc865 for now
-nix-shell $NIX_BUILD_ARGS \
-    --pure ./default.nix \
-    --argstr compiler-nix-name ghc865 \
-    -A with-packages.test-shell \
-    --run 'echo CABAL_CONFIG=$CABAL_CONFIG && type -p ghc && cd with-packages && cabal new-build'
-echo >& 2
-
-printf "*** Checking that a nix-shell works for cabal (doExactConfig component)...\n" >& 2
-# This has to use ghc865 for now
-nix-shell $NIX_BUILD_ARGS \
-    --pure ./default.nix \
-    --argstr compiler-nix-name ghc865 \
-    -A with-packages.test-shell-dec \
-    --run 'echo CABAL_CONFIG=$CABAL_CONFIG && echo GHC_ENVIRONMENT=$GHC_ENVIRONMENT && cd with-packages && cabal new-build'
-echo >& 2
-
-printf "*** Checking that a nix-shell works for a project with test-suite build-tools and benchmarks...\n" >& 2
-printf "!!! This is expected to fail until https://github.com/input-output-hk/haskell.nix/issues/231 is resolved! \n" >& 2
-nix-shell $NIX_BUILD_ARGS \
-    --pure ./default.nix \
-    --argstr compiler-nix-name $GHC \
-    -A cabal-22.shell \
-    --run 'cd cabal-22 && cabal new-build all --enable-tests --enable-benchmarks' \
-    || true
-echo >& 2
-
-printf "*** Checking that a nix-shell works for a multi-target project...\n" >& 2
-nix-shell $NIX_BUILD_ARGS \
-    --pure ./default.nix \
-    --argstr compiler-nix-name $GHC \
-    -A cabal-simple.test-shell \
-    --run 'cd cabal-simple && cabal new-build'
-echo >& 2
-
-printf "*** Checking shellFor works for a cabal project, multiple packages...\n" >& 2
-nix-shell $NIX_BUILD_ARGS \
-    --pure ./default.nix \
-    --argstr compiler-nix-name $GHC \
-    -A shell-for.env \
-    --run 'cd shell-for && cabal new-build all'
-echo >& 2
-
-printf "*** Checking shellFor works for a cabal project, single package...\n" >& 2
-nix-shell $NIX_BUILD_ARGS \
-    --pure ./default.nix \
-    --argstr compiler-nix-name $GHC \
-    -A shell-for.envPkga \
-    --run 'cd shell-for && cabal new-build --project=single.project all'
-echo >& 2
-
-printf "*** Checking shellFor has a working hoogle index...\n" >& 2
-nix-shell $NIX_BUILD_ARGS \
-    --pure ./default.nix \
-    --argstr compiler-nix-name $GHC \
-    -A shell-for.env \
-    --run 'hoogle ConduitT | grep Data.Conduit'
-echo >& 2
-
-printf "*** Checking shellFor does not depend on given packages...\n" >& 2
-drva=$(nix-instantiate ./default.nix --argstr compiler-nix-name $GHC -A shell-for.env)
-echo "-- hello" >> shell-for/pkga/PkgA.hs
-drvb=$(nix-instantiate ./default.nix --argstr compiler-nix-name $GHC -A shell-for.env)
-sed -i -e '/-- hello/d' shell-for/pkga/PkgA.hs
-if [ "$drva" != "$drvb" ]; then
-    printf "FAIL\nShell derivations\n$drva\n$drvb\n are not identical.\n" >& 2
+if [ "$TESTS" == "unit-tests" ] || [ "$TESTS" == "all" ]; then
+  printf "*** Running the unit tests... " >& 2
+  res=$(nix-instantiate --eval --json --strict ./default.nix --argstr compiler-nix-name $GHC -A unit.tests)
+  num_failed=$(jq length <<< "$res")
+  if [ $num_failed -eq 0 ]; then
+    printf "PASSED\n" >& 2
+  else
+    printf "$num_failed FAILED\n" >& 2
+    jq . <<< "$res"
     exit 1
-else
-    printf "PASS\n" >& 2
+  fi
 fi
 
-printf "*** Checking the maintainer scripts...\n" >& 2
-nix build $NIX_BUILD_ARGS \
-    --accept-flake-config \
-    --no-link \
-    --keep-going \
-    -f ../build.nix \
-    --argstr compiler-nix-name $GHC \
-        maintainer-scripts
-echo >& 2
+if [ "$TESTS" == "runghc" ] || [ "$TESTS" == "all" ]; then
+  printf "*** Checking that a nix-shell works for runghc...\n" >& 2
+  # This has to use ghc865 for now
+  nix-shell $NIX_BUILD_ARGS \
+      --pure ./default.nix \
+      --argstr compiler-nix-name ghc865 \
+      -A with-packages.test-shell \
+      --run 'runghc with-packages/Point.hs'
+  echo >& 2
+fi
 
-printf "*** Checking that plan construction works with extra Hackages...\n" >& 2
-nix build $NIX_BUILD_ARGS \
-    --accept-flake-config \
-    --no-link \
-    -f ./default.nix \
-    --argstr compiler-nix-name $GHC \
-    extra-hackage.run.project.plan-nix
-echo >& 2
+if [ "$TESTS" == "cabal" ] || [ "$TESTS" == "all" ]; then
+  printf "*** Checking that a nix-shell works for cabal...\n" >& 2
+  # This has to use ghc865 for now
+  nix-shell $NIX_BUILD_ARGS \
+      --pure ./default.nix \
+      --argstr compiler-nix-name ghc865 \
+      -A with-packages.test-shell \
+      --run 'echo CABAL_CONFIG=$CABAL_CONFIG && type -p ghc && cd with-packages && cabal new-build'
+  echo >& 2
+fi
 
-printf "*** Checking that package with extra Hackages can be build...\n" >& 2
-nix build $NIX_BUILD_ARGS \
-    --accept-flake-config \
-    --no-link \
-    -f ./default.nix \
-    --argstr compiler-nix-name $GHC \
-    extra-hackage.run.project.hsPkgs.external-package-user.components.exes.external-package-user
-echo >& 2
+if [ "$TESTS" == "cabal-doExactConfig" ] || [ "$TESTS" == "all" ]; then
+  printf "*** Checking that a nix-shell works for cabal (doExactConfig component)...\n" >& 2
+  # This has to use ghc865 for now
+  nix-shell $NIX_BUILD_ARGS \
+      --pure ./default.nix \
+      --argstr compiler-nix-name ghc865 \
+      -A with-packages.test-shell-dec \
+      --run 'echo CABAL_CONFIG=$CABAL_CONFIG && echo GHC_ENVIRONMENT=$GHC_ENVIRONMENT && cd with-packages && cabal new-build'
+  echo >& 2
+fi
 
-printf "*** End-2-end test of hix project initialization and flakes development shell ...\n" >& 2
-HASKELL_NIX=$(pwd)/..
-cd $(mktemp -d)
-nix-shell -p cabal-install --run "cabal update; cabal unpack hello"
-cd hello-*
-nix run $HASKELL_NIX#hix -- init
-nix develop \
-    --override-input haskellNix $HASKELL_NIX \
-    --accept-flake-config \
-    -c cabal build
-echo >& 2
+if [ "$TESTS" == "tests-benchmarks" ] || [ "$TESTS" == "all" ]; then
+  printf "*** Checking that a nix-shell works for a project with test-suite build-tools and benchmarks...\n" >& 2
+  printf "!!! This is expected to fail until https://github.com/input-output-hk/haskell.nix/issues/231 is resolved! \n" >& 2
+  nix-shell $NIX_BUILD_ARGS \
+      --pure ./default.nix \
+      --argstr compiler-nix-name $GHC \
+      -A cabal-22.shell \
+      --run 'cd cabal-22 && cabal new-build all --enable-tests --enable-benchmarks' \
+      || true
+  echo >& 2
+fi
+
+if [ "$TESTS" == "multi-target" ] || [ "$TESTS" == "all" ]; then
+  printf "*** Checking that a nix-shell works for a multi-target project...\n" >& 2
+  nix-shell $NIX_BUILD_ARGS \
+      --pure ./default.nix \
+      --argstr compiler-nix-name $GHC \
+      -A cabal-simple.test-shell \
+      --run 'cd cabal-simple && cabal new-build'
+  echo >& 2
+fi
+
+if [ "$TESTS" == "shellFor-single-package" ] || [ "$TESTS" == "all" ]; then
+  printf "*** Checking shellFor works for a cabal project, multiple packages...\n" >& 2
+  nix-shell $NIX_BUILD_ARGS \
+      --pure ./default.nix \
+      --argstr compiler-nix-name $GHC \
+      -A shell-for.env \
+      --run 'cd shell-for && cabal new-build all'
+  echo >& 2
+fi
+
+if [ "$TESTS" == "shellFor-multiple-package" ] || [ "$TESTS" == "all" ]; then
+  printf "*** Checking shellFor works for a cabal project, single package...\n" >& 2
+  nix-shell $NIX_BUILD_ARGS \
+      --pure ./default.nix \
+      --argstr compiler-nix-name $GHC \
+      -A shell-for.envPkga \
+      --run 'cd shell-for && cabal new-build --project=single.project all'
+  echo >& 2
+fi
+
+if [ "$TESTS" == "shellFor-hoogle" ] || [ "$TESTS" == "all" ]; then
+  printf "*** Checking shellFor has a working hoogle index...\n" >& 2
+  nix-shell $NIX_BUILD_ARGS \
+      --pure ./default.nix \
+      --argstr compiler-nix-name $GHC \
+      -A shell-for.env \
+      --run 'hoogle ConduitT | grep Data.Conduit'
+  echo >& 2
+fi
+
+if [ "$TESTS" == "shellFor-not-depends" ] || [ "$TESTS" == "all" ]; then
+  printf "*** Checking shellFor does not depend on given packages...\n" >& 2
+  drva=$(nix-instantiate ./default.nix --argstr compiler-nix-name $GHC -A shell-for.env)
+  echo "-- hello" >> shell-for/pkga/PkgA.hs
+  drvb=$(nix-instantiate ./default.nix --argstr compiler-nix-name $GHC -A shell-for.env)
+  sed -i -e '/-- hello/d' shell-for/pkga/PkgA.hs
+  if [ "$drva" != "$drvb" ]; then
+      printf "FAIL\nShell derivations\n$drva\n$drvb\n are not identical.\n" >& 2
+      exit 1
+  else
+      printf "PASS\n" >& 2
+  fi
+fi
+
+if [ "$TESTS" == "maintainer-scripts" ] || [ "$TESTS" == "all" ]; then
+  printf "*** Checking the maintainer scripts...\n" >& 2
+  nix build $NIX_BUILD_ARGS \
+      --accept-flake-config \
+      --no-link \
+      --keep-going \
+      -f ../build.nix \
+      --argstr compiler-nix-name $GHC \
+          maintainer-scripts
+  echo >& 2
+fi
+
+if [ "$TESTS" == "plan-extra-hackages" ] || [ "$TESTS" == "all" ]; then
+  printf "*** Checking that plan construction works with extra Hackages...\n" >& 2
+  nix build $NIX_BUILD_ARGS \
+      --accept-flake-config \
+      --no-link \
+      -f ./default.nix \
+      --argstr compiler-nix-name $GHC \
+      extra-hackage.run.project.plan-nix
+  echo >& 2
+fi
+
+if [ "$TESTS" == "build-extra-hackages" ] || [ "$TESTS" == "all" ]; then
+  printf "*** Checking that package with extra Hackages can be build...\n" >& 2
+  nix build $NIX_BUILD_ARGS \
+      --accept-flake-config \
+      --no-link \
+      -f ./default.nix \
+      --argstr compiler-nix-name $GHC \
+      extra-hackage.run.project.hsPkgs.external-package-user.components.exes.external-package-user
+  echo >& 2
+fi
+
+if [ "$TESTS" == "hix" ] || [ "$TESTS" == "all" ]; then
+  printf "*** End-2-end test of hix project initialization and flakes development shell ...\n" >& 2
+  HASKELL_NIX=$(pwd)/..
+  cd $(mktemp -d)
+  nix-shell -p cabal-install --run "cabal update; cabal unpack hello"
+  cd hello-*
+  nix run $HASKELL_NIX#hix -- init
+  nix develop \
+      --override-input haskellNix $HASKELL_NIX \
+      --accept-flake-config \
+      -c cabal build
+  echo >& 2
+fi
 
 printf "\n*** Finished successfully\n" >& 2


### PR DESCRIPTION
Motivations:

* Take advantage of parallel jobs execution ;
* Identify faster what is the test that is failing ;
* Don't have a failing test hidden behind a previous sequential test fail.