### PR TITLE
Split checking hydra eval on buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -74,13 +74,39 @@ steps:
     agents:
       system: x86_64-linux
 
-  - label: 'Check that jobset will evaluate in Hydra'
+  - label: 'Check that jobset will evaluate in Hydra at ifdLevel 0 and 1'
     command:
       - nix-build build.nix -A maintainer-scripts.check-hydra -o check-hydra.sh
-      - ./check-hydra.sh 0
-      - ./check-hydra.sh 1
-      - ./check-hydra.sh 2
-      - ./check-hydra.sh 3
+      - ./check-hydra.sh --arg ifdLevel 0
+      - ./check-hydra.sh --arg ifdLevel 1
+    agents:
+      system: x86_64-linux
+
+  - label: 'Check that jobset will evaluate in Hydra at ifdLevel 2'
+    command:
+      - nix-build build.nix -A maintainer-scripts.check-hydra -o check-hydra.sh
+      - ./check-hydra.sh --arg ifdLevel 2
+    agents:
+      system: x86_64-linux
+
+  - label: 'Check that jobset will evaluate in Hydra at ifdLevel 3 and ghc 8.10'
+    command:
+      - nix-build build.nix -A maintainer-scripts.check-hydra -o check-hydra.sh
+      - "./check-hydra.sh --arg ifdLevel 3 --arg include 'x: __substring 0 6 x == \"ghc810\"'"
+    agents:
+      system: x86_64-linux
+
+  - label: 'Check that jobset will evaluate in Hydra at ifdLevel 3 and ghc 9.2'
+    command:
+      - nix-build build.nix -A maintainer-scripts.check-hydra -o check-hydra.sh
+      - "./check-hydra.sh --arg ifdLevel 3 --arg include 'x: __substring 0 5 x == \"ghc92\"'"
+    agents:
+      system: x86_64-linux
+
+  - label: 'Check that jobset will evaluate in Hydra at ifdLevel 3 and not (ghc 8.10 or ghc 9.2)'
+    command:
+      - nix-build build.nix -A maintainer-scripts.check-hydra -o check-hydra.sh
+      - "./check-hydra.sh --arg ifdLevel 3 --arg include 'x: !(__substring 0 6 x == \"ghc810\" || __substring 0 5 x == \"ghc92\")'"
     agents:
       system: x86_64-linux
 

--- a/scripts/check-hydra.nix
+++ b/scripts/check-hydra.nix
@@ -10,12 +10,12 @@ writeScript "check-hydra.sh" ''
   export PATH="${makeBinPath [ coreutils time gnutar gzip hydra-unstable jq gitMinimal ]}"
   export NIX_PATH=
 
-  echo '~~~ Evaluating release.nix with --arg ifdLevel '$1
+  echo '~~~ Evaluating release.nix with' "$@"
   command time --format '%e' -o eval-time.txt \
       hydra-eval-jobs \
       --option allowed-uris "https://github.com/NixOS https://github.com/input-output-hk" \
       --arg supportedSystems '[ builtins.currentSystem ]' \
-      --arg ifdLevel $1 \
+      "$@" \
       -I $(realpath .) release.nix > eval.json
   EVAL_EXIT_CODE="$?"
   if [ "$EVAL_EXIT_CODE" != 0 ]


### PR DESCRIPTION
Now that #1629 is done the slowest part of buildkite pipeline.yaml is checking the hydra eval.  It takes about 8 minutes.

This breaks it into 5 smaller jobs.