### PR TITLE
Fix implicit cabal project

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -1,5 +1,6 @@
 { pkgs, runCommand, cacert, index-state-hashes, haskellLib }@defaults:
 let readIfExists = src: fileName:
+      # Using origSrcSubDir bypasses any cleanSourceWith.
       let origSrcDir = src.origSrcSubDir or src;
       in
         if builtins.elem ((__readDir origSrcDir)."${fileName}" or "") ["regular" "symlink"]
@@ -122,24 +123,38 @@ let
       type == "directory" ||
       pkgs.lib.any (i: (pkgs.lib.hasSuffix i path)) [ ".cabal" "package.yaml" ]); };
 
-  # Using origSrcSubDir bypasses any cleanSourceWith so that it will work when
-  # access to the store is restricted.  If origSrc was already in the store
-  # you can pass the project in as a string.
-  rawCabalProject =
-    # Even if `cabal.project` doesn't exist, `cabal.project.local` is still used by cabal.
-    # We tested this: https://github.com/input-output-hk/haskell.nix/pull/1588
-    if cabalProject == null && cabalProjectLocal == null
-      then null
-      else (
-        # like fmap
-        let f = g: x: if x == null then "" else g x; in
-        f (x: x) cabalProject + f (x: "\n-- Added from cabalProjectLocal argument to cabalProject\n${x}") cabalProjectLocal
-      );
+  # When there is no `cabal.project` file `cabal-install` behaves as if there was
+  # one containing `packages: ./*.cabal`.  Even if there is a `cabal.project.local`
+  # containing some other `packages:`, it still includes `./*.cabal`.
+  #
+  # We could write to `cabal.project.local` instead of `cabal.project` when
+  # `cabalProject == null`.  However then `cabal-install` will look in parent
+  # directories for a `cabal.project` file. That would complicate reasoning about
+  # the relative directories of packages.
+  #
+  # Instead we treat `cabalProject == null` as if it was `packages: ./*.cabal`.
+  #
+  # See: https://github.com/input-output-hk/haskell.nix/pull/1588
+  #      https://github.com/input-output-hk/haskell.nix/pull/1639
+  #
+  rawCabalProject = ''
+    ${
+      if cabalProject == null
+        then ''
+          -- Included to match the implicit project used by `cabal-install`
+          packages: ./*.cabal
+        ''
+        else cabalProject
+    }
+    ${
+      pkgs.lib.optionalString (cabalProjectLocal != null) ''
+        -- Added from `cabalProjectLocal` argument to the `cabalProject` function
+        ${cabalProjectLocal}
+      ''
+    }
+  '';
 
-  cabalProjectIndexState =
-    if rawCabalProject != null
-    then pkgs.haskell-nix.haskellLib.parseIndexState rawCabalProject
-    else null;
+  cabalProjectIndexState = pkgs.haskell-nix.haskellLib.parseIndexState rawCabalProject;
 
   index-state-found =
     if index-state != null
@@ -292,10 +307,7 @@ let
           );
     };
 
-  fixedProject =
-    if rawCabalProject == null
-      then { sourceRepos = []; repos = {}; extra-hackages = []; makeFixedProjectFile = ""; replaceLocations = ""; }
-      else replaceSourceRepos rawCabalProject;
+  fixedProject = replaceSourceRepos rawCabalProject;
 
   # The use of the actual GHC can cause significant problems:
   # * For hydra to assemble a list of jobs from `components.tests` it must


### PR DESCRIPTION
#1588 does not provide an implicit project the way cabal does.  So for instance:

```
$ cabal unpack hello
$ cd hello-1.0.0.2
$ echo 'constraints: hello<0' >cabal.project.local
$ cabal build all
Resolving dependencies...
Error: cabal: Could not resolve dependencies:
[__0] next goal: hello (user goal)
[__0] rejecting: hello-1.0.0.2 (constraint from project config
/Users/hamish/iohk/hello-1.0.0.2/cabal.project.local requires <0)
[__0] rejecting: hello-1.0.0.1, hello-1.0 (constraint from user target
requires ==1.0.0.2)
[__0] fail (backjumping, conflict set: hello)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: hello
```

So even though there was no `packages:` it is looking for the package in the default location (the default is `packages: ./*.cabal` according to the cabal docs).

I also checked that including `packages:` in `.local` does not change the implicit `packages: ./*.cabal` with:
```
$ cabal unpack split
$ echo 'packages: ./split-0.2.3.5' > cabal.project.local
$ cabal build hello:exe:hello split:lib:split
```