### PR TITLE
Bump nixpkgs pin used in default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,17 +1,19 @@
 {...}@args:
 
 let
-  pin = (__fromJSON (__readFile ./flake.lock)).nodes.nixpkgs-2205.locked;
+  pins = (__fromJSON (__readFile ./flake.lock)).nodes;
+  nixpkgsPin = pins.nixpkgs-2205.locked;
+  flakeCompatPin = pins.flake-compat.locked;
   nixpkgsSrc =
     builtins.fetchTarball {
-      url = "https://github.com/NixOS/nixpkgs/archive/${pin.rev}.tar.gz";
-      sha256 = pin.narHash;
+      url = "https://github.com/NixOS/nixpkgs/archive/${nixpkgsPin.rev}.tar.gz";
+      sha256 = nixpkgsPin.narHash;
     };
   pkgs = args.pkgs or (import nixpkgsSrc {});
   flake-compat =
     pkgs.fetchzip {
-      url = "https://github.com/edolstra/flake-compat/archive/5523c47f13259b981c49b26e28499724a5125fd8.tar.gz";
-      sha256 = "sha256-7IySNHriQjzOZ88DDk6VDPf1GoUaOrOeUdukY62o52o=";
+      url = "https://github.com/edolstra/flake-compat/archive/{flakeCompatPin.rev}.tar.gz";
+      sha256 = flakeCompatPin.narHash;
     };
   self = import flake-compat {
     # We bypass flake-compat's rootSrc cleaning by evading its detection of this as a git

--- a/default.nix
+++ b/default.nix
@@ -3,8 +3,8 @@
 let
   nixpkgsSrc =
     builtins.fetchTarball {
-      url = "https://github.com/NixOS/nixpkgs/archive/110a2c9ebbf5d4a94486854f18a37a938cfacbbb.tar.gz";
-      sha256 = "sha256-leWXLchbAbqOlLT6tju631G40SzQWPqaAXQG3zH1Imw=";
+      url = "https://github.com/NixOS/nixpkgs/archive/549d82bdd40f760a438c3c3497c1c61160f3de55.tar.gz";
+      sha256 = "1rk9rh2ssp6zwqbnxa2cyncwjky9igkj90qdgbhzshwwxp89y6ai";
     };
   pkgs = args.pkgs or (import nixpkgsSrc {});
   flake-compat =

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,11 @@
 {...}@args:
 
 let
+  pin = (__fromJSON (__readFile ./flake.lock)).nodes.nixpkgs-2205.locked;
   nixpkgsSrc =
     builtins.fetchTarball {
-      url = "https://github.com/NixOS/nixpkgs/archive/549d82bdd40f760a438c3c3497c1c61160f3de55.tar.gz";
-      sha256 = "1rk9rh2ssp6zwqbnxa2cyncwjky9igkj90qdgbhzshwwxp89y6ai";
+      url = "https://github.com/NixOS/nixpkgs/archive/${pin.rev}.tar.gz";
+      sha256 = pin.narHash;
     };
   pkgs = args.pkgs or (import nixpkgsSrc {});
   flake-compat =

--- a/flake.lock
+++ b/flake.lock
@@ -83,6 +83,23 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1632802058,
+        "narHash": "sha256-7IySNHriQjzOZ88DDk6VDPf1GoUaOrOeUdukY62o52o=",
+        "owner": "hamishmack",
+        "repo": "flake-compat",
+        "rev": "5523c47f13259b981c49b26e28499724a5125fd8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hamishmack",
+        "ref": "hkm/pkgs-fetch",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1644229661,
@@ -356,6 +373,7 @@
         "cabal-34": "cabal-34",
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,7 @@
     nixpkgs-2111 = { url = "github:NixOS/nixpkgs/nixpkgs-21.11-darwin"; };
     nixpkgs-2205 = { url = "github:NixOS/nixpkgs/nixpkgs-22.05-darwin"; };
     nixpkgs-unstable = { url = "github:NixOS/nixpkgs/nixpkgs-unstable"; };
+    flake-compat = { url = "github:hamishmack/flake-compat/hkm/pkgs-fetch"; flake = false; };
     flake-utils = { url = "github:numtide/flake-utils"; };
     hydra.url = "hydra";
     hackage = {

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -39,6 +39,8 @@ fi
 
 if [ "$TESTS" == "unit-tests" ] || [ "$TESTS" == "all" ]; then
   printf "*** Running the unit tests... " >& 2
+  # Running nix build first avoids `error: path '/nix/store/X-hackage-to-nix-ghcjs-overlay.drv' is not valid`
+  nix-build ./default.nix --argstr compiler-nix-name $GHC -A unit.tests
   res=$(nix-instantiate --eval --json --strict ./default.nix --argstr compiler-nix-name $GHC -A unit.tests)
   num_failed=$(jq length <<< "$res")
   if [ $num_failed -eq 0 ]; then


### PR DESCRIPTION
Making it match the current 22.05 pin in flake.lock.

Was going to do this because of #1648, but might save some people a nixpkgs download so let's do it anyway.