### PR TITLE
default.nix: Fix flake-compat URL

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,7 @@ let
   pkgs = args.pkgs or (import nixpkgsSrc {});
   flake-compat =
     pkgs.fetchzip {
-      url = "https://github.com/edolstra/flake-compat/archive/{flakeCompatPin.rev}.tar.gz";
+      url = "https://github.com/edolstra/flake-compat/archive/${flakeCompatPin.rev}.tar.gz";
       sha256 = flakeCompatPin.narHash;
     };
   self = import flake-compat {


### PR DESCRIPTION
A `$` for string interpolation was missed when changing the URL in the call to `fetchzip` for flake-compat to use the pin from `flake.lock` in c683efad28fbddf205554f15a39b0d8d7af53b62

@hamishmack, noticed a small typo introduced in `default.nix`.