### PR TITLE
Determine if the tag is a ref or a rev

### DIFF
--- a/lib/cabal-project-parser.nix
+++ b/lib/cabal-project-parser.nix
@@ -77,7 +77,7 @@ let
   extractSourceRepoPackageData = cabalProjectFileName: sha256map: repo:
     let
       refOrRev =
-        if builtins.match "[0-9a-f](40)" repo.tag
+        if builtins.match "[0-9a-f](40)" repo.tag != null
           then "rev"
           else "ref";
     in {

--- a/lib/cabal-project-parser.nix
+++ b/lib/cabal-project-parser.nix
@@ -74,9 +74,15 @@ let
   #   --shar256: 003lm3pm0000hbfmii7xcdd9v20000flxf7gdl2pyxia7p014i8z
   # will be trated like a field and returned here
   # (used in call-cabal-project-to-nix.nix to create a fixed-output derivation)
-  extractSourceRepoPackageData = cabalProjectFileName: sha256map: repo: {
+  extractSourceRepoPackageData = cabalProjectFileName: sha256map: repo:
+    let
+      refOrRev =
+        if builtins.match "[0-9a-f](40)" repo.tag
+          then "rev"
+          else "ref";
+    in {
     url = repo.location;
-    ref = repo.tag;
+    "${refOrRev}" = repo.tag;
     sha256 = repo."--sha256" or (
       if sha256map != null
         then sha256map."${repo.location}"."${repo.tag}"

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -228,10 +228,10 @@ let
                   then throw "${inputMap.${repoData.url}.rev} may not match ${repoData.ref} for ${repoData.url} use \"${repoData.url}/${repoData.ref}\" as the inputMap key if ${repoData.ref} is a branch or tag that points to ${inputMap.${repoData.url}.rev}."
                   else inputMap.${repoData.url})
             else if repoData.sha256 != null
-            then fetchgit { inherit (repoData) url sha256 rev; }
+            then fetchgit { inherit (repoData) url sha256; rev = repoData.rev or repoData.ref; }
             else
               let drv = builtins.fetchGit { inherit (repoData) url ; rev = repoData.rev or repoData.ref; ref = repoData.ref or null; };
-              in __trace "WARNING: No sha256 found for source-repository-package ${repoData.url} ${repoData.ref} download may fail in restricted mode (hydra)"
+              in __trace "WARNING: No sha256 found for source-repository-package ${repoData.url} ref=${repoData.ref or ""} rev=${repoData.rev or ""} download may fail in restricted mode (hydra)"
                 (__trace "Consider adding `--sha256: ${hashPath drv}` to the ${cabalProjectFileName} file or passing in a sha256map argument"
                  drv);
         in {

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -231,7 +231,7 @@ let
             then fetchgit { inherit (repoData) url sha256; rev = repoData.rev or repoData.ref; }
             else
               let drv = builtins.fetchGit { inherit (repoData) url ; rev = repoData.rev or repoData.ref; ref = repoData.ref or null; };
-              in __trace "WARNING: No sha256 found for source-repository-package ${repoData.url} ref=${repoData.ref or ""} rev=${repoData.rev or ""} download may fail in restricted mode (hydra)"
+              in __trace "WARNING: No sha256 found for source-repository-package ${repoData.url} ref=${repoData.ref or "(unspecified)"} rev=${repoData.rev or "(unspecified)"} download may fail in restricted mode (hydra)"
                 (__trace "Consider adding `--sha256: ${hashPath drv}` to the ${cabalProjectFileName} file or passing in a sha256map argument"
                  drv);
         in {

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -228,7 +228,7 @@ let
                   then throw "${inputMap.${repoData.url}.rev} may not match ${repoData.ref} for ${repoData.url} use \"${repoData.url}/${repoData.ref}\" as the inputMap key if ${repoData.ref} is a branch or tag that points to ${inputMap.${repoData.url}.rev}."
                   else inputMap.${repoData.url})
             else if repoData.sha256 != null
-              then fetchgit repoData
+            then fetchgit { inherit (repoData) url sha256 rev; }
             else
               let drv = builtins.fetchGit { inherit (repoData) url ref; };
               in __trace "WARNING: No sha256 found for source-repository-package ${repoData.url} ${repoData.ref} download may fail in restricted mode (hydra)"

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -230,7 +230,7 @@ let
             else if repoData.sha256 != null
             then fetchgit { inherit (repoData) url sha256 rev; }
             else
-              let drv = builtins.fetchGit { inherit (repoData) url ref; };
+              let drv = builtins.fetchGit { inherit (repoData) url ; rev = repoData.rev or repoData.ref; ref = repoData.ref or null; };
               in __trace "WARNING: No sha256 found for source-repository-package ${repoData.url} ${repoData.ref} download may fail in restricted mode (hydra)"
                 (__trace "Consider adding `--sha256: ${hashPath drv}` to the ${cabalProjectFileName} file or passing in a sha256map argument"
                  drv);

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -228,7 +228,7 @@ let
                   then throw "${inputMap.${repoData.url}.rev} may not match ${repoData.ref} for ${repoData.url} use \"${repoData.url}/${repoData.ref}\" as the inputMap key if ${repoData.ref} is a branch or tag that points to ${inputMap.${repoData.url}.rev}."
                   else inputMap.${repoData.url})
             else if repoData.sha256 != null
-              then fetchgit { inherit (repoData) url sha256; rev = repoData.ref; }
+              then fetchgit repoData
             else
               let drv = builtins.fetchGit { inherit (repoData) url ref; };
               in __trace "WARNING: No sha256 found for source-repository-package ${repoData.url} ${repoData.ref} download may fail in restricted mode (hydra)"


### PR DESCRIPTION
Test the `tag` attribute in the `cabal.project` file. If it looks like a git hash, then assign it to `rev`. Otherwise, assign it to `ref`.

This *should* fix the problem where `source-repo-override` cannot be used to set a `rev` or `ref`, which blocks #1663 from using `source-repo-override`.