### PR TITLE
haskell-nix.extraPkgconfigMappings

### DIFF
--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -5583,7 +5583,7 @@ pkgs:
     "zzipfseeko" = [ "zziplib" ];
     "zziplib" = [ "zziplib" ];
     "zzipmmapped" = [ "zziplib" ];
-}) //
+} // pkgs.haskell-nix.extraPkgconfigMappings) //
   lookupAttrsIn pkgs.xorg {
     # Adding xlibsWrapper since it was used here beofre.
     # Putting libX11 first though so it can be used to get the version

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -11,6 +11,8 @@ final: prev: {
         # overlays.
         defaultModules = [];
 
+        # TODO: doc etc
+        extraPkgconfigMappings = {};
         # Nix Flake based source pins.
         # To update all inputs, get unstable Nix and then `nix flake update --recreate-lock-file`
         # Or `nix-shell -p nixUnstable --run "nix --experimental-features 'nix-command flakes' flake update --recreate-lock-file"`


### PR DESCRIPTION
Fixes https://github.com/input-output-hk/haskell.nix/issues/1664

You can try the `sdl-gpu-minimal` example here https://gitlab.com/macaroni.dev/macaroni.nix/-/merge_requests/12

It maps multiple new libraries and works on Linux and Windows (see https://github.com/input-output-hk/haskell.nix/issues/1666 for a change I had to make) currently.