### PR TITLE
Remove outdated comment on `tarballRepoFor`

### DIFF
--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -258,7 +258,6 @@ final: prev: {
                   exit 0
                 '';
               };
-              # This is very big, and cheap to build: prefer building it locally
               tarballRepoFor = name: index: final.runCommand "tarballRepo_${name}" {
                 nativeBuildInputs = [ cabal-install dummy-ghc dummy-ghc-pkg ];
               } ''


### PR DESCRIPTION
The reason this behaviour was changed, is that it's _not_ fast. It can take 10 seconds.