### PR TITLE
haskell-nix.extraPkgconfigMappings documentation

### DIFF
--- a/docs/tutorials/pkg-map.md
+++ b/docs/tutorials/pkg-map.md
@@ -29,6 +29,23 @@ nixpkgs.overlays = [
 ];
 ```
 
+The user can map package(s) in Nixpkgs to a `pkgconfig-depends` name by
+overlaying the `haskell-nix.extraPkgconfigMappings` attribute:
+
+```nix
+nixpkgs.overlays = [
+  (self: super: {
+    haskell-nix = super.haskell-nix // {
+      extraPkgconfigMappings = super.haskell-nix.extraPkgconfigMappings // {
+          # String pkgconfig-depends names are mapped to lists of Nixpkgs
+          # package names
+          "SDL_gpu" = [ "SDL_gpu" ];
+      };
+    };
+  })
+];
+```
+
 ### Replace libraries of components
 
 If a component is missing a dependency it can be added via modules. For example:
@@ -59,7 +76,7 @@ the Haskell.nix sources, so that it's solved for all users.
   — for `build-tool-depends`, `frameworks`, `extra-libraries`, etc.
 
   Each name can be mapped to:
-  1. A single package from nixkpgs.
+  1. A single package from nixpkgs.
   2. `null` — eliminates the dependency
   3. A list of packages — sometimes needed for dependencies such as `X11`.
 

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -11,7 +11,7 @@ final: prev: {
         # overlays.
         defaultModules = [];
 
-        # TODO: doc etc
+        # Additional user-provided mappings to augment ./../lib/pkgconf-nixpkgs-map.nix
         extraPkgconfigMappings = {};
         # Nix Flake based source pins.
         # To update all inputs, get unstable Nix and then `nix flake update --recreate-lock-file`


### PR DESCRIPTION
Following up on https://github.com/input-output-hk/haskell.nix/pull/1667

- Added an example of when and how to use this feature to `docs/tutorials/pkg-map.md`.
- Got rid of my `TODO` Nix comment and put a real one in.