### PR TITLE
Add cabal-issue-8352-workaround

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -49,7 +49,7 @@ in rec {
       # Update scripts use the internal nix-tools and cabal-install (compiled with a fixed GHC version)
       nix-tools = haskell.internal-nix-tools;
       cabal-install = haskell.internal-cabal-install;
-      inherit (haskell) update-index-state-hashes;
+      inherit (haskell) update-index-state-hashes cabal-issue-8352-workaround;
     };
     update-stackage = haskell.callPackage ./scripts/update-stackage.nix {
       inherit (pkgs) stdenv lib writeScript coreutils glibc git

--- a/build.nix
+++ b/build.nix
@@ -57,6 +57,7 @@ in rec {
       # Update scripts use the internal nix-tools and cabal-install (compiled with a fixed GHC version)
       nix-tools = haskell.internal-nix-tools;
       cabal-install = haskell.internal-cabal-install;
+      inherit (haskell) cabal-issue-8352-workaround;
     };
     update-pins = haskell.callPackage ./scripts/update-pins.nix {};
     update-docs = pkgs.buildPackages.callPackage ./scripts/update-docs.nix {

--- a/lib/cabal-project-parser.nix
+++ b/lib/cabal-project-parser.nix
@@ -145,7 +145,7 @@ let
       repoContents = if inputMap ? ${attrs.url}
         # If there is an input use it to make `file:` url and create a suitable `.cabal/packages/${name}` directory
         then evalPackages.runCommand name ({
-          nativeBuildInputs = [ cabal-install ];
+          nativeBuildInputs = [ cabal-install ] ++ evalPackages.haskell-nix.cabal-issue-8352-workaround;
           preferLocalBuild = true;
         }) ''
             HOME=$(mktemp -d)
@@ -162,7 +162,7 @@ let
             cp -r $HOME/.cabal/packages/${name} $out
         ''
         else evalPackages.runCommand name ({
-          nativeBuildInputs = [ cabal-install evalPackages.curl nix-tools ];
+          nativeBuildInputs = [ cabal-install evalPackages.curl nix-tools ] ++ evalPackages.haskell-nix.cabal-issue-8352-workaround;
           LOCALE_ARCHIVE = pkgs.lib.optionalString (evalPackages.stdenv.buildPlatform.libc == "glibc") "${evalPackages.glibcLocales}/lib/locale/locale-archive";
           LANG = "en_US.UTF-8";
           preferLocalBuild = true;

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -262,7 +262,7 @@ final: prev: {
               # dotCabalName anyway.
               dotCabalName = "dot-cabal-" + allNames;
               tarballRepoFor = name: index: final.runCommand "tarballRepo_${name}" {
-                nativeBuildInputs = [ cabal-install cabal-issue-8352-workaround ];
+                nativeBuildInputs = [ cabal-install ] ++ cabal-issue-8352-workaround;
               } ''
                 set -xe
 

--- a/scripts/update-external.nix
+++ b/scripts/update-external.nix
@@ -16,7 +16,7 @@ in
 
     set -euo pipefail
 
-    export PATH="${makeBinPath ([ coreutils curl findutils gawk bash git openssh nix-tools cabal-install cabal-issue-8352-workaround nixFlakes ] ++ optional stdenv.isLinux glibc)}"
+    export PATH="${makeBinPath ([ coreutils curl findutils gawk bash git openssh nix-tools cabal-install nixFlakes ] ++ cabal-issue-8352-workaround ++ optional stdenv.isLinux glibc)}"
 
     ${script}
 

--- a/scripts/update-external.nix
+++ b/scripts/update-external.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, writeScript, glibc, coreutils, git, openssh
 , nix-tools, cabal-install, nixFlakes
-, bash, curl, findutils, gawk }:
+, bash, curl, findutils, gawk, cabal-issue-8352-workaround }:
 
 { name, script }:
 
@@ -16,7 +16,7 @@ in
 
     set -euo pipefail
 
-    export PATH="${makeBinPath ([ coreutils curl findutils gawk bash git openssh nix-tools cabal-install nixFlakes ] ++ optional stdenv.isLinux glibc)}"
+    export PATH="${makeBinPath ([ coreutils curl findutils gawk bash git openssh nix-tools cabal-install cabal-issue-8352-workaround nixFlakes ] ++ optional stdenv.isLinux glibc)}"
 
     ${script}
 

--- a/scripts/update-hackage.nix
+++ b/scripts/update-hackage.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, writeScript, coreutils, glibc, git, openssh
 , nix-tools, cabal-install, nixFlakes
 , gawk, bash, curl, findutils
-, update-index-state-hashes }@args:
+, update-index-state-hashes, cabal-issue-8352-workaround }@args:
 
 import ./update-external.nix
 (removeAttrs args ["update-index-state-hashes"]) {

--- a/scripts/update-stackage.nix
+++ b/scripts/update-stackage.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, writeScript, coreutils, glibc, git, openssh
 , nix-tools, cabal-install, nixFlakes
-, gawk, bash, curl, findutils }@args:
+, gawk, bash, curl, findutils, cabal-issue-8352-workaround }@args:
 
 import ./update-external.nix args {
   name = "stackage";


### PR DESCRIPTION
I missed a couple of places where we call `cabal update` and now need the dummy ghc to prevent cabal from complaining.

See https://github.com/haskell/cabal/issues/8352