### PR TITLE
Fix for haskell-language-server 1.8

### DIFF
--- a/modules/configuration-nix.nix
+++ b/modules/configuration-nix.nix
@@ -72,9 +72,12 @@ in {
   # This is a work around to make `ghcide` and `haskell-language-server` build with the unboxed tuple patch.
   packages.ghcide.patches =
     # Work out if we have applied the unboxed tupple patch in overlays/bootstrap.nix
-    pkgs.lib.optional (__elem config.compiler.nix-name [
+    pkgs.lib.optionals (__elem config.compiler.nix-name [
       "ghc8101" "ghc8102" "ghc8103" "ghc8104" "ghc8105" "ghc8106" "ghc8107" "ghc810420210212"
-    ]) (from "1.7.0.0" ../patches/ghcide-1.7-unboxed-tuple-fix-issue-1455.patch)
+    ]) [
+      (fromUntil "1.7.0.0" "1.8.0.0" ../patches/ghcide-1.7-unboxed-tuple-fix-issue-1455.patch)
+      (fromUntil "1.8.0.0" "1.9.0.0" ../patches/ghcide-1.8-unboxed-tuple-fix-issue-1455.patch)
+    ]
     # This is needed for a patch only applied to ghc810420210212
     ++ pkgs.lib.optional (__elem config.compiler.nix-name [
       "ghc810420210212"

--- a/modules/hackage-quirks.nix
+++ b/modules/hackage-quirks.nix
@@ -54,7 +54,7 @@ in [
       # TODO remove once these two plugins have been updated in hackage
       + lib.optionalString (config.version == "1.8.0.0") ''
         package haskell-language-server
-          flags: -qualifyimportednames -stylishhaskell
+          flags: -qualifyimportednames -stylishhaskell${lib.optionalString (config.compiler-nix-name != "ghc902") " -hlint"}
       ''
       # TODO Remove this flag once the hls-haddock-comments-plugin is updated in hackage to work with ghc 9.2
       + lib.optionalString (__elem config.compiler-nix-name ["ghc921" "ghc922" "ghc923" "ghc924"]) ''

--- a/modules/hackage-quirks.nix
+++ b/modules/hackage-quirks.nix
@@ -51,6 +51,11 @@ in [
         packages: .
         constraints: dependent-sum >=0.7.1.0
       ''
+      # TODO remove once these two plugins have been updated in hackage
+      + lib.optionalString (config.version == "1.8.0.0") ''
+        package haskell-language-server
+          flags: -qualifyimportednames -stylishhaskell
+      ''
       # TODO Remove this flag once the hls-haddock-comments-plugin is updated in hackage to work with ghc 9.2
       + lib.optionalString (__elem config.compiler-nix-name ["ghc921" "ghc922" "ghc923" "ghc924"]) ''
         package haskell-language-server

--- a/patches/ghcide-1.8-unboxed-tuple-fix-issue-1455.patch
+++ b/patches/ghcide-1.8-unboxed-tuple-fix-issue-1455.patch
@@ -1,0 +1,77 @@
+diff --git a/src/Development/IDE/Core/Compile.hs b/src/Development/IDE/Core/Compile.hs
+index e6094a47..c19b61f1 100644
+--- a/src/Development/IDE/Core/Compile.hs
++++ b/src/Development/IDE/Core/Compile.hs
+@@ -137,6 +137,15 @@ import           GHC.Hs                            (LEpaComment)
+ import qualified GHC.Types.Error                   as Error
+ #endif
+
++import StgSyn
++import FastString
++import Unique
++import CostCentre
++import Data.Either
++import CoreSyn
++import CoreToStg
++import SimplStg
++
+ -- | Given a string buffer, return the string (after preprocessing) and the 'ParsedModule'.
+ parseModule
+     :: IdeOptions
+@@ -272,9 +281,38 @@ captureSplicesAndDeps TypecheckHelpers{..} env k = do
+                        stg_expr
+                        [] Nothing
+ #else
++             {- Create a temporary binding and convert to STG -}
++           ; let bco_tmp_id = mkSysLocal (fsLit "BCO_toplevel")
++                                         (mkPseudoUniqueE 0)
++                                         (exprType prepd_expr)
++           ; (binds, _) <-
++               myCoreToStg hsc_env
++                           (icInteractiveModule (hsc_IC hsc_env))
++                           [NonRec bco_tmp_id prepd_expr]
++
++           ; let (_strings, lifted_binds) = partitionEithers $ do  -- list monad
++                  bnd <- binds
++                  case bnd of
++                    StgTopLifted (StgNonRec i expr) -> [Right (i, expr)]
++                    StgTopLifted (StgRec bnds)      -> map Right bnds
++                    StgTopStringLit b str           -> [Left (b, str)]
++
++           ; let stg_expr = case lifted_binds of
++                              [(_i, e)] -> e
++                              _        ->
++                                StgRhsClosure noExtFieldSilent
++                                              dontCareCCS
++                                              ReEntrant
++                                              []
++                                              (StgLet noExtFieldSilent
++                                                 (StgRec lifted_binds)
++                                                 (StgApp bco_tmp_id []))
++
+              {- Convert to BCOs -}
+            ; bcos <- coreExprToBCOs hsc_env
+-                       (icInteractiveModule (hsc_IC hsc_env)) prepd_expr
++                       (icInteractiveModule (hsc_IC hsc_env))
++                       bco_tmp_id
++                       stg_expr
+ #endif
+
+             -- Exclude wired-in names because we may not have read
+@@ -1705,3 +1743,16 @@ pathToModuleName = mkModuleName . map rep
+       rep c | isPathSeparator c = '_'
+       rep ':' = '_'
+       rep c = c
++
++myCoreToStg :: HscEnv -> Module -> CoreProgram
++            -> IO ( [StgTopBinding] -- output program
++                  , CollectedCCs )  -- CAF cost centre info (declared and used)
++myCoreToStg hsc_env this_mod prepd_binds = do
++    let (stg_binds, cost_centre_info)
++         = {-# SCC "Core2Stg" #-}
++           coreToStg (hsc_dflags hsc_env) this_mod prepd_binds
++    stg_binds2
++        <- {-# SCC "Stg2Stg" #-}
++           stg2stg hsc_env this_mod stg_binds
++
++    return (stg_binds2, cost_centre_info)


### PR DESCRIPTION
It looks like two of the plugins have not been updated in hackage yet (qualifyimportednames and stylishhaskell).