### PR TITLE
Remove webkitgtk24x-gtk3 mapping

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -32,6 +32,13 @@ in rec {
             "ghc882" = "3.3.6";
             "ghc883" = "3.3.6";
             "ghc884" = "3.3.6";
+            "ghc8101" = "3.4.1";
+            "ghc8102" = "3.4.1";
+            "ghc8103" = "3.4.1";
+            "ghc8104" = "3.4.1";
+            "ghc8105" = "3.4.1";
+            "ghc8106" = "3.4.1";
+            "ghc8107" = "3.4.1";
           }.compiler-nix-name or "latest";
       };
       hls-latest = tool compiler-nix-name "haskell-language-server" { inherit evalPackages; };

--- a/build.nix
+++ b/build.nix
@@ -39,7 +39,7 @@ in rec {
             "ghc8105" = "3.4.1";
             "ghc8106" = "3.4.1";
             "ghc8107" = "3.4.1";
-          }.compiler-nix-name or "latest";
+          }.${compiler-nix-name} or "latest";
       };
       hls-latest = tool compiler-nix-name "haskell-language-server" { inherit evalPackages; };
     })

--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -51,7 +51,6 @@ pkgs:
     "idn"                                = [ "libidn" ];
     "Imlib2"                             = [ "imlib2" ];
     "iw"                                 = [ "wirelesstools" ];
-    "javascriptcoregtk-3.0"              = [ "webkitgtk24x-gtk3" ]; # These are the old APIs, of which 2.4 is the last provider, so map directly to that.
     "jpeg"                               = [ "libjpeg" ];
     "jvm"                                = [ "jdk" ];
     "liboath"                            = [ "liboauth" ];
@@ -83,7 +82,6 @@ pkgs:
     "systemd-journal"                    = [ "systemd" ];
     "tag_c"                              = [ "taglib" ];
     "webkit2gtk"                         = [ "webkitgtk" ];
-    "webkitgtk-3.0"                      = [ "webkitgtk24x-gtk3" ]; # These are the old APIs, of which 2.4 is the last provider, so map directly to that
     "xml2"                               = [ "libxml2" ];
     "yaml"                               = [ "libyaml" ];
     "z"                                  = [ "zlib" ];


### PR DESCRIPTION
Even just looking for `pkgs.webkitgtk24x-gtk3.version` crashes nix eval with:

```
error: webkitgtk24x-gtk3 has been removed because it's insecure. Please use webkitgtk.
```