### PR TITLE
Fixes re source-repository-package

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -129,6 +129,10 @@ steps:
     command:
       - nix-build build.nix -A maintainer-scripts.check-materialization-concurrency -o check-materialization-concurrency.sh
       - ./check-materialization-concurrency.sh
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 10
 
   - label: 'Make sure non store paths like can be used as src'
     command:

--- a/lib/cabal-project-parser.nix
+++ b/lib/cabal-project-parser.nix
@@ -77,7 +77,7 @@ let
   extractSourceRepoPackageData = cabalProjectFileName: sha256map: repo:
     let
       refOrRev =
-        if builtins.match "[0-9a-f](40)" repo.tag != null
+        if builtins.match "[0-9a-f]{40}" repo.tag != null
           then "rev"
           else "ref";
     in {

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -230,7 +230,11 @@ let
             else if repoData.sha256 != null
             then fetchgit { inherit (repoData) url sha256; rev = repoData.rev or repoData.ref; }
             else
-              let drv = builtins.fetchGit { inherit (repoData) url ; rev = repoData.rev or repoData.ref; ref = repoData.ref or null; };
+              let drv = builtins.fetchGit
+                { inherit (repoData) url ; ref = repoData.ref or null; }
+                # fetchGit does not accept "null" as rev, so when it's null
+                # we have to omit the argument completely.
+                // pkgs.lib.optionalAttrs (repoData ? rev) { inherit (repoData) rev; };
               in __trace "WARNING: No sha256 found for source-repository-package ${repoData.url} ref=${repoData.ref or "(unspecified)"} rev=${repoData.rev or "(unspecified)"} download may fail in restricted mode (hydra)"
                 (__trace "Consider adding `--sha256: ${hashPath drv}` to the ${cabalProjectFileName} file or passing in a sha256map argument"
                  drv);

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -220,8 +220,8 @@ let
       fetchPackageRepo = fetchgit: repoData:
         let
           fetched =
-            if inputMap ? "${repoData.url}/${repoData.ref}"
-              then inputMap."${repoData.url}/${repoData.ref}"
+            if inputMap ? "${repoData.url}/${repoData.rev or repoData.ref}"
+              then inputMap."${repoData.url}/${repoData.rev or repoData.ref}"
             else if inputMap ? ${repoData.url}
               then
                 (if inputMap.${repoData.url}.rev != repoData.ref

--- a/test/unit.nix
+++ b/test/unit.nix
@@ -29,7 +29,7 @@ let
 
   testRepoData = {
     url = "https://github.com/input-output-hk/haskell.nix.git";
-    ref = "487eea1c249537d34c27f6143dff2b9d5586c657";
+    rev = "487eea1c249537d34c27f6143dff2b9d5586c657";
     sha256 = "077j5j3j86qy1wnabjlrg4dmqy1fv037dyq3xb8ch4ickpxxs123";
   };
 in


### PR DESCRIPTION
It was not possible to use `source-repository-package` without `rev` and `sha256`. `rev` and no `sha256` still does not work due to `builtins.fetchGit` limitations.

Additionally, any case with `sha256` and private git repo over ssh does not work — `git` called by `pkgs.fetchgit` does not pull `openssh` dep and thus can't run `ssh` to clone the repo. This is however not haskell.nix's problem.