### PR TITLE
fix stack-cache hash-mismatch by enabling submodules

### DIFF
--- a/lib/stack-cache-generator.nix
+++ b/lib/stack-cache-generator.nix
@@ -97,6 +97,7 @@ concatMap (dep:
                 }
                 else builtins.fetchGit ({
                   inherit (dep) url rev;
+                  submodules = true;
                 } // evalPackages.lib.optionalAttrs (branch != null) { ref = branch; });
         in map (subdir: {
                 name = cabalName "${pkgsrc}/${subdir}";


### PR DESCRIPTION
fixes #1720 

- the nix-tool stack-to-nix fetches the submodules so `fetchGit` probably should, too. 