### PR TITLE
Fix building the stack tool

### DIFF
--- a/modules/hackage-quirks.nix
+++ b/modules/hackage-quirks.nix
@@ -105,4 +105,15 @@ in [
       })];
     };
 
+    stack = {
+      modules = [{
+        # Stack has a custom setup that expects both the library and stack executable
+        # to be configured at the same time.  Unfortunately this does mean that
+        # the library component is rebuilt unecessarily in the exe component derivation.
+        packages.stack.components.exes.stack.configureAllComponents = true;
+        # But we don't want to configure the tests as they have dependencies that
+        # are not included in the `exes` dependencies.
+        packages.stack.components.exes.stack.configureFlags = ["--disable-tests"];
+      }];
+    };
   }


### PR DESCRIPTION
Fixes #218

Tested with:

```
nix-build -E '((import ./. {}).pkgs-unstable.haskell-nix.tool "ghc924" "stack" "2.9.1")'
```