### PR TITLE
Choose proper `llvm` version for `llvm-hs` and make stack infra work like stack does

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -235,10 +235,16 @@ let
         "--ghc-options=-j1"
     );
 
+  # the build-tools version might be depending on the version of the package, similarly to patches
   executableToolDepends =
     (lib.concatMap (c: if c.isHaskell or false
       then builtins.attrValues (c.components.exes or {})
-      else [c]) build-tools) ++
+      else [c]) 
+      (builtins.filter (x: !(isNull x))
+      (map 
+        (p: if builtins.isFunction p
+          then p { inherit  (package.identifier) version; inherit revision; }
+          else p) build-tools))) ++
     lib.optional (pkgconfig != []) buildPackages.cabalPkgConfigWrapper;
 
   # Unfortunately, we need to wrap ghc commands for cabal builds to

--- a/lib/stack-cache-generator.nix
+++ b/lib/stack-cache-generator.nix
@@ -98,6 +98,7 @@ concatMap (dep:
                 else builtins.fetchGit ({
                   inherit (dep) url rev;
                   submodules = true;
+                  allRefs = true;
                 } // evalPackages.lib.optionalAttrs (branch != null) { ref = branch; });
         in map (subdir: {
                 name = cabalName "${pkgsrc}/${subdir}";

--- a/modules/configuration-nix.nix
+++ b/modules/configuration-nix.nix
@@ -91,7 +91,7 @@ in {
 
   packages.discount.components.library.libs = pkgs.lib.mkForce [ pkgs.discount ];
 
-  packages.llvm-hs.components.library.build-tools = pkgs.lib.mkForce [ pkgs.llvm ];
+  packages.llvm-hs.components.library.build-tools = pkgs.lib.mkForce [ pkgs.llvmPackages_12.llvm ];
 
   packages.BNFC.components.tests.doctests.build-tools = [
     config.hsPkgs.buildPackages.alex

--- a/modules/configuration-nix.nix
+++ b/modules/configuration-nix.nix
@@ -91,7 +91,18 @@ in {
 
   packages.discount.components.library.libs = pkgs.lib.mkForce [ pkgs.discount ];
 
-  packages.llvm-hs.components.library.build-tools = pkgs.lib.mkForce [ pkgs.llvmPackages_12.llvm ];
+  packages.llvm-hs.components.library.build-tools = pkgs.lib.mkForce [ 
+    (fromUntil "5.0.0" "6" pkgs.llvmPackages_5.llvm)
+    (fromUntil "6.0.0" "7" pkgs.llvmPackages_6.llvm)
+    (fromUntil "7.0.0" "8" pkgs.llvmPackages_7.llvm)
+    (fromUntil "8.0.0" "9" pkgs.llvmPackages_8.llvm)
+    (fromUntil "9.0.0" "12" pkgs.llvmPackages_9.llvm)
+    (fromUntil "12.0.0" "15" pkgs.llvmPackages_12.llvm)
+    # NOTE: we currently don't have a llvm versoin > 12 that has a tag 
+    #       in nixpkgs, so we probably can't build `llvm-hs > 12`, there 
+    #       is however a head version of llvm in nixpkgs, which we might 
+    #       be able to use if that case were to occur
+  ];
 
   packages.BNFC.components.tests.doctests.build-tools = [
     config.hsPkgs.buildPackages.alex


### PR DESCRIPTION
### `llvm-hs`

- the `llvm-hs` currently on hackage depends on llvm 9, however, `pkgs.llvm` is version 11, which should forbid it to work properly
- As a workaround, we pass the proper version to the `llvm-hs` package, similarly to how it's done with `patches`

### `stack` 

- stack is able to fetch a package from any rev, no matter which ref, as we can't specify the ref in the `stack.yaml` file, we probably want to pass `allRefs` to `fetchGit` to imitate stacks behaviour. 