### PR TITLE
Fix duplicate ${system} in flake tutorial

### DIFF
--- a/docs/tutorials/getting-started-flakes.md
+++ b/docs/tutorials/getting-started-flakes.md
@@ -97,7 +97,7 @@ Add `flake.nix`:
       };
     in flake // {
       # Built by `nix build .`
-      packages.${system}.default = flake.packages."hello:exe:hello";
+      packages.default = flake.packages."hello:exe:hello";
     });
 }
 ```


### PR DESCRIPTION
When I followed this tutorial, my default package ended up as `packages.aarch64-darwin.aarch64-darwin.default`. Removing this "extra" `${system}` solves the problem, but admittedly I'm not 100% sure what's going on here.