### PR TITLE
Remove unused problematic input `nix-tools`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,6 @@
       url = "github:sevanspowell/hpc-coveralls";
       flake = false;
     };
-    nix-tools = { url = "path:./nix-tools"; };
     old-ghc-nix = {
       url = "github:angerman/old-ghc-nix/master";
       flake = false;


### PR DESCRIPTION
I think we added this when with the idea of sharing the `nix-tools` flake itself, but in the end we put the haskell.nix project settings in `nix-tools/nix/hix.nix` and shared them instead.