### PR TITLE
Try to get version from `.name` if there is no `.version

### DIFF
--- a/overlays/cabal-pkg-config.nix
+++ b/overlays/cabal-pkg-config.nix
@@ -29,8 +29,17 @@ final: prev:
   # overrides here.
   allPkgConfigWrapper =
     let
+      # Try getting the `.version` attribute or failing that look in the
+      # `.name`.  Some packages like `icu` have the correct version in
+      # `.name` but no `.version`.
+      getVersion = p:
+        let versionInNameMatch = builtins.match ".*-([0-9.]*)" (p.name or "");
+        in p.version or (
+          if versionInNameMatch == null
+            then null
+            else __head versionInNameMatch);
       pkgconfigPkgs =
-        final.lib.filterAttrs (name: p: __length p > 0 && (__head p) ? version)
+        final.lib.filterAttrs (name: p: __length p > 0 && getVersion (__head p) != null)
           (import ../lib/pkgconf-nixpkgs-map.nix final);
     in prev.pkgconfig.overrideAttrs (attrs: {
       installPhase = attrs.installPhase + ''
@@ -53,7 +62,7 @@ final: prev:
           ERROR=\$(mktemp)
         cat <<EOF2
         ${final.pkgs.lib.concatStrings (map (p: ''
-          ${(builtins.head p).version}
+          ${getVersion (builtins.head p)}
         '') (__attrValues pkgconfigPkgs))
         }
         EOF2


### PR DESCRIPTION
Some packages like `icu` have the correct version in `.name` but no `.version`.

Fixes #1361