### PR TITLE
Support subdir syntax in extra-deps.

### DIFF
--- a/nix-tools/lib/Stack2nix/Stack.hs
+++ b/nix-tools/lib/Stack2nix/Stack.hs
@@ -223,10 +223,15 @@ instance FromJSON Dependency where
               _ -> fail $ "invalid package index: " ++ show pi
           parseLocalPath = withText "Local Path" $
             return . LocalPath . dropTrailingSlash . T.unpack
+          parseSubdirs o = do
+            subdir' <- o .:? "subdir"
+            let subdir = fmap (\d -> [d]) subdir'
+            subdirs <- o .:? "subdirs"
+            return (subdir <|> subdirs)
           parseDVCS = withObject "DVCS" $ \o -> DVCS
             <$> (o .: "location" <|> parseJSON p)
             <*> o .:? "nix-sha256" .!= Nothing
-            <*> o .:? "subdirs" .!= ["."]
+            <*> parseSubdirs o .!= ["."]
 
           -- drop trailing slashes. Nix doesn't like them much;
           -- stack doesn't seem to care.


### PR DESCRIPTION
Stack supports the following syntax for extra-deps entries:
```
extra-deps:
  - git: <...>
    commit: <...>
    subdir: subdirectory
```

Which works exactly the way you expect. This PR adds support for parsing this.