### PR TITLE
shellFor: provide build tools for all packages when exactDeps = false. Fix #1753.

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -239,9 +239,12 @@ let
   executableToolDepends =
     (lib.concatMap (c: if c.isHaskell or false
       then builtins.attrValues (c.components.exes or {})
-      else [c]) 
-      (builtins.filter (x: !(isNull x))
-      (map 
+      else [c])
+      (builtins.filter (x: !(isNull x)
+        # We always exclude hsc2hs from build-tools because it is unecessary as it is provided by ghc
+        # and hsc2hs from ghc is first in PATH so the one from build-tools is never used.
+        && x.identifier.name or "" != "hsc2hs")
+      (map
         (p: if builtins.isFunction p
           then p { inherit  (package.identifier) version; inherit revision; }
           else p) build-tools))) ++
@@ -328,7 +331,7 @@ let
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
   };
-                    
+
   drv = stdenv.mkDerivation (commonAttrs // contentAddressedAttrs // {
     pname = nameOnly;
     inherit (package.identifier) version;


### PR DESCRIPTION
This fix #1753.

also only depends on `hsc2hs` from `ghcEnv` to avoid collisions when using devshell (`haskellLib.devshellFor`).