### PR TITLE
Add the alternative nix profile install command.

### DIFF
--- a/docs/dev/installing-nix-tools.md
+++ b/docs/dev/installing-nix-tools.md
@@ -6,10 +6,12 @@ To build the latest `nix-tools` and store the result at `./nt`, run:
 nix build -f https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz pkgs.haskell-nix.nix-tools.ghc884 --out-link nt
 ```
 
-If you would like to then install `nix-tools` into your profile, run:
+If you would like to then install `nix-tools` into your profile, run an install
+command:
 
 ```shell
 nix-env -i ./nt
+nix profile install ./nt
 ```
 
 ## Optional: Installing via [Haskell.nix][] source


### PR DESCRIPTION
Following the docs can error:

```
> nix-env -i ./nt
error: profile '/nix/var/nix/profiles/per-user/.../profile'
  is incompatible with 'nix-env'; please use 'nix profile' instead
```