### PR TITLE
Switch to enableNativeBignum = true when available

### DIFF
--- a/overlays/ghc.nix
+++ b/overlays/ghc.nix
@@ -5,7 +5,7 @@ final: prev: with prev;
     hasNativeBignum = name: !lib.hasPrefix "ghc8" name;
 
     ghcPkgOverrides = name: { enableIntegerSimple = false; } // lib.optionalAttrs (hasNativeBignum name) {
-      enableNativeBignum = false;
+      enableNativeBignum = true;
     };
 
     ghcDrvOverrides = drv: {


### PR DESCRIPTION
Per the discussion on #1254. CC @hamishmack 

AFAICT the current code is backwards -- it checks native bignum is possible, and if so it passes `enableNativeBignum = false`. This PR flips it the other way.

I've built my project's static executable with this and it seems to work fine. I'm not sure how to tell if a static executable is built using native bignum though.

EDIT: actually, I think it works! I tried building my executable with dynamic linking, both with and without this change. When I build with this change, the `libgmp` dependency disappears!