### PR TITLE
work-in-progress GHC 9.4.3 support

### DIFF
--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -259,7 +259,7 @@ stdenv.mkDerivation (rec {
     '' + lib.optionalString (ghc-version-date != null) ''
         substituteInPlace configure --replace 'RELEASE=YES' 'RELEASE=NO'
         echo '${ghc-version-date}' > VERSION_DATE
-    '' + lib.optionalString (builtins.compareVersions ghc-version "9.2.3" >= 0) ''
+    '' + lib.optionalString (builtins.compareVersions ghc-version "9.2.3" >= 0 && builtins.compareVersions ghc-version "9.4" < 0) ''
         ./boot
     '';
 


### PR DESCRIPTION
Closes #1595 

sha256 acquired with
```
nix-prefetch-url https://downloads.haskell.org/\~ghc/9.4.3/ghc-9.4.3-src.tar.xz
```

Alex >= 3.2.6 is required