### PR TITLE
Fix aarch64-linker, take 2

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -220,6 +220,7 @@ in {
 
                 # the following is a partial reversal of https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4391, to address haskell.nix#1227
                 ++ final.lib.optional (versionAtLeast "8.10" && versionLessThan "9.0" && final.targetPlatform.isAarch64) ./patches/ghc/mmap-next.patch
+                ++ final.lib.optional (versionAtLeast "8.10" && versionLessThan "9.0" && final.targetPlatform.isAarch64) ./patches/ghc/m32_alloc.patch
                 ++ final.lib.optional (versionAtLeast "8.10" && versionLessThan "9.0" && final.targetPlatform.isAndroid) ./patches/ghc/rts-android-jemalloc-qemu.patch
                 ++ final.lib.optional (versionAtLeast "8.10" && versionLessThan "9.0" && final.targetPlatform.isAndroid) ./patches/ghc/stack-protector-symbols.patch
                 ++ final.lib.optional (versionAtLeast "8.10" && versionLessThan "9.0" && final.targetPlatform.isAndroid) ./patches/ghc/libraries-prim-os-android.patch

--- a/overlays/patches/ghc/m32_alloc.patch
+++ b/overlays/patches/ghc/m32_alloc.patch
@@ -1,0 +1,223 @@
+  diff --git a/rts/Linker.c b/rts/Linker.c
+index aaca823..f476702 100644
+--- a/rts/Linker.c
++++ b/rts/Linker.c
+@@ -1037,6 +1037,12 @@ typedef struct _info {
+ 
+ static info *infos = NULL;
+ 
++info *mkInfo(void *addr, size_t length);
++info *lookupInfo(void *addr, size_t length);
++info *lookupOrCreateInfo(void *addr, size_t length);
++void printInfo(info *cur);
++void printInfos(void);
++
+ info *mkInfo(void *addr, size_t length) {
+   info *i = NULL;
+   i = (info *)calloc(sizeof(info), 1);
+@@ -1083,7 +1089,7 @@ info *lookupOrCreateInfo(void *addr, size_t length) {
+ void printInfo(info *cur) {
+   printf("%p %8zu %p; n = %zu; total = %zu\n", cur->addr, cur->length, cur->next_addr, cur->count, cur->total_length);
+ }
+-void printInfos() {
++void printInfos(void) {
+   printf("Infos:\n");
+   for (info *cur = infos; cur != NULL; cur = cur->next) {
+     printInfo(cur);
+diff --git a/rts/linker/Elf.c b/rts/linker/Elf.c
+index 0bbbbf2..85054ea 100644
+--- a/rts/linker/Elf.c
++++ b/rts/linker/Elf.c
+@@ -739,7 +739,6 @@ ocGetNames_ELF ( ObjectCode* oc )
+           oc->sections[i].info->stubs = NULL;
+       } else if (kind != SECTIONKIND_OTHER && size > 0) {
+ 
+-#if defined(NEED_PLT)
+           /* To support stubs next to sections, we will use the following
+            * layout:
+            *
+@@ -758,26 +757,7 @@ ocGetNames_ELF ( ObjectCode* oc )
+           unsigned nstubs = numberOfStubsForSection(oc, i);
+           unsigned stub_space = STUB_SIZE * nstubs;
+ 
+-          void * mem = mmapAnonForLinker(size+stub_space, true, "anon:stub_space");
+-
+-          if( mem == NULL ) {
+-              barf("failed to mmap allocated memory to load section %d. "
+-                   "errno = %d", i, errno);
+-          }
+-
+-          /* copy only the image part over; we don't want to copy data
+-           * into the stub part.
+-           */
+-          memcpy( mem, oc->image + offset, size );
+-
+-          alloc = SECTION_MMAP;
+-
+-          mapped_offset = 0;
+-          mapped_size = roundUpToPage(size+stub_space);
+-          start = mem;
+-          mapped_start = mem;
+-#else
+-          if (USE_CONTIGUOUS_MMAP || RtsFlags.MiscFlags.linkerAlwaysPic) {
++          if (false) { //USE_CONTIGUOUS_MMAP || RtsFlags.MiscFlags.linkerAlwaysPic) {
+               // already mapped.
+               start = oc->image + offset;
+               alloc = SECTION_NOMEM;
+@@ -793,32 +773,46 @@ ocGetNames_ELF ( ObjectCode* oc )
+               // RODATA sections. Specifically .rodata.cst16. However we don't
+               // handle the cst part in any way what so ever, so 16 seems
+               // better than 8.
+-              start = m32_alloc(allocator, size, 16);
++              start = m32_alloc(allocator, size+stub_space, 16);
+               if (start == NULL) goto fail;
+               memcpy(start, oc->image + offset, size);
+               alloc = SECTION_M32;
+           } else {
+-              start = mapObjectFileSection(fd, offset, size,
++#if defined(NEED_PLT)
++            char buf[512];
++            sprintf(buf, "anon:%s, sec %d, kind %d, size %ld, stub %d, total %ld", oc->fileName, i, kind, size, stub_space, size + stub_space);
++
++            start = mmapAnonForLinker(size+stub_space, true, buf);
++
++            if( start == NULL ) {
++                barf("failed to mmap allocated memory to load section %d. "
++                    "errno = %d", i, errno);
++            }
++
++            /* copy only the image part over; we don't want to copy data
++            * into the stub part.
++            */
++            memcpy( start, oc->image + offset, size );
++
++            mapped_offset = 0;
++            mapped_size = roundUpToPage(size+stub_space);
++            mapped_start = start;
++
++#else
++              start = mapObjectFileSection(fd, offset, size+stub_space,
+                                            &mapped_start, &mapped_size,
+                                            &mapped_offset);
+               if (start == NULL) goto fail;
++#endif
+               alloc = SECTION_MMAP;
+           }
+-#endif
+           addSection(&sections[i], kind, alloc, start, size,
+                      mapped_offset, mapped_start, mapped_size);
+ 
+-#if defined(NEED_PLT)
+           oc->sections[i].info->nstubs = 0;
+-          oc->sections[i].info->stub_offset = (uint8_t*)mem + size;
++          oc->sections[i].info->stub_offset = (uint8_t*)start + size;
+           oc->sections[i].info->stub_size = stub_space;
+           oc->sections[i].info->stubs = NULL;
+-#else
+-          oc->sections[i].info->nstubs = 0;
+-          oc->sections[i].info->stub_offset = NULL;
+-          oc->sections[i].info->stub_size = 0;
+-          oc->sections[i].info->stubs = NULL;
+-#endif
+ 
+           addProddableBlock(oc, start, size);
+       } else {
+diff --git a/rts/linker/M32Alloc.c b/rts/linker/M32Alloc.c
+index 089fbeb..8d80b02 100644
+--- a/rts/linker/M32Alloc.c
++++ b/rts/linker/M32Alloc.c
+@@ -264,10 +264,10 @@ m32_alloc_page(void)
+      */
+     const size_t pgsz = getPageSize();
+     const size_t map_sz = pgsz * M32_MAP_PAGES;
+-    uint8_t *chunk = mmapAnonForLinker(map_sz, false, "anon:m32_alloc_page");
+-    if (chunk + map_sz > (uint8_t *) 0xffffffff) {
+-      barf("m32_alloc_page: failed to get allocation in lower 32-bits");
+-    }
++    uint8_t *chunk = mmapAnonForLinker(map_sz, true, "anon:m32_alloc_page");
++    // if (chunk + map_sz > (uint8_t *) 0xffffffff) {
++    //   barf("m32_alloc_page: failed to get allocation in lower 32-bits");
++    // }
+ 
+ #define GET_PAGE(i) ((struct m32_page_t *) (chunk + (i) * pgsz))
+     for (int i=0; i < M32_MAP_PAGES; i++) {
+@@ -467,6 +467,18 @@ m32_alloc(struct m32_allocator_t *alloc, size_t size, size_t alignment)
+        size+ROUND_UP(sizeof(struct m32_page_t),alignment);
+    return (char*)page + ROUND_UP(sizeof(struct m32_page_t),alignment);
+ }
++void
++m32_list(m32_allocator *alloc) {
++  for(struct m32_page_t *page = alloc->unprotected_list; page != NULL; page = m32_filled_page_get_next(page)) {
++      printf("%p (%d) %0x %0x %0x %0x\n", page, page->filled_page.size,
++      ((uint32_t*)page)[0],
++      ((uint32_t*)page)[1],
++      ((uint32_t*)page)[2],
++      ((uint32_t*)page)[3]
++      );
++  }
++}
++
+ 
+ #else
+ 
+@@ -499,4 +511,9 @@ m32_alloc(m32_allocator *alloc STG_UNUSED,
+     barf("%s: RTS_LINKER_USE_MMAP is %d", __func__, RTS_LINKER_USE_MMAP);
+ }
+ 
++void
++m32_list(m32_allocator *alloc STG_UNUSED) {
++    barf("%s: RTS_LINKER_USE_MMAP is %d", __func__, RTS_LINKER_USE_MMAP);
++}
++
+ #endif
+diff --git a/rts/linker/M32Alloc.h b/rts/linker/M32Alloc.h
+index 8a349a3..ab116eb 100644
+--- a/rts/linker/M32Alloc.h
++++ b/rts/linker/M32Alloc.h
+@@ -35,4 +35,6 @@ void m32_allocator_flush(m32_allocator *alloc) M32_NO_RETURN;
+ 
+ void * m32_alloc(m32_allocator *alloc, size_t size, size_t alignment) M32_NO_RETURN;
+ 
++void m32_list(m32_allocator *alloc);
++
+ #include "EndPrivate.h"
+diff --git a/rts/linker/elf_got.c b/rts/linker/elf_got.c
+index b55a443..c30ebef 100644
+--- a/rts/linker/elf_got.c
++++ b/rts/linker/elf_got.c
+@@ -110,8 +110,18 @@ fillGot(ObjectCode * oc) {
+ 
+                 if(0x0 == symbol->addr) {
+                     errorBelch(
+-                        "Something went wrong! Symbol %s has null address.\n",
+-                            symbol->name);
++                        "In oc: %s\n"
++                        "in symbtab: %d (%ld symbols total)\n"
++                        "Something went wrong! Symbol %ld: %s has null address.\n"
++                        "type: %d, bind: %d\n",
++
++                            oc->archiveMemberName ? oc->archiveMemberName : oc->fileName,
++                            symTab->index, symTab->n_symbols,
++                            i,
++                            symbol->name,
++                            ELF_ST_TYPE(symbol->elf_sym->st_info),
++                            ELF_ST_BIND(symbol->elf_sym->st_info)
++                            );
+                     return EXIT_FAILURE;
+                 }
+ 
+diff --git a/rts/linker/elf_plt.c b/rts/linker/elf_plt.c
+index 9cd42ef..913d788 100644
+--- a/rts/linker/elf_plt.c
++++ b/rts/linker/elf_plt.c
+@@ -56,8 +56,9 @@ makeStub(Section * section,
+     s->target = *addr;
+     s->flags  = flags;
+     s->next = NULL;
+-    s->addr = (uint8_t *)section->info->stub_offset + 8
++    s->addr = (uint8_t *)section->info->stub_offset
+             + STUB_SIZE * section->info->nstubs;
++    ASSERT(s->addr >= section->info->stub_offset && s->addr <= (void*)((uintptr_t)section->info->stub_offset + section->info->stub_size - STUB_SIZE));
+ 
+     if((*_makeStub)(s))
+         return EXIT_FAILURE;

--- a/overlays/patches/ghc/mmap-next.patch
+++ b/overlays/patches/ghc/mmap-next.patch
@@ -1,8 +1,8 @@
 diff --git a/rts/Linker.c b/rts/Linker.c
-index 55d1e3d186..26c224c76c 100644
+index 55d1e3d186..9b973eab53 100644
 --- a/rts/Linker.c
 +++ b/rts/Linker.c
-@@ -1037,6 +1037,109 @@ resolveSymbolAddr (pathchar* buffer, int size,
+@@ -1037,11 +1037,125 @@ resolveSymbolAddr (pathchar* buffer, int size,
  }
  
  #if RTS_LINKER_USE_MMAP
@@ -29,6 +29,11 @@ index 55d1e3d186..26c224c76c 100644
 +  void *addr;
 +  size_t length;
 +  void *next_addr;
++
++  // meta data
++  size_t count;
++  size_t total_length;
++
 +  struct _info *next;
 +} info;
 +
@@ -49,6 +54,10 @@ index 55d1e3d186..26c224c76c 100644
 +  i->addr = addr;
 +  i->length = length;
 +  i->next_addr = addr;
++
++  i->count = 0;
++  i->total_length = 0;
++
 +  i->next = NULL;
 +  return i;
 +}
@@ -74,7 +83,7 @@ index 55d1e3d186..26c224c76c 100644
 +}
 +
 +void printInfo(info *cur) {
-+  printf("%p %8zu %p\n", cur->addr, cur->length, cur->next_addr);
++  printf("%p %8zu %p; n = %zu; total = %zu\n", cur->addr, cur->length, cur->next_addr, cur->count, cur->total_length);
 +}
 +void printInfos() {
 +  printf("Infos:\n");
@@ -84,10 +93,10 @@ index 55d1e3d186..26c224c76c 100644
 +}
 +
 +void*
-+mmap_next(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
++mmap_next(void *addr, size_t length, int prot, int flags, int fd, off_t offset, char *name) {
 +  if(addr == NULL) return mmap(addr, length, prot, flags, fd, offset);
 +  size_t length_ = roundUpToPage(length);
-+  info *bucket = lookupOrCreateInfo(addr, length);
++  info *bucket = lookupOrCreateInfo(addr, length_);
 +  // we are going to look for up to pageSize * 1024 * 1024 (4GB) from the
 +  // address.
 +  size_t pageSize = getPageSize();
@@ -98,6 +107,8 @@ index 55d1e3d186..26c224c76c 100644
 +    if(mem == MAP_FAILED) { return mem; }
 +    if(mem == target) {
 +        bucket->next_addr = mem;
++        bucket->count += 1;
++        bucket->total_length += length;
 +        return mem;
 +    }
 +    munmap(mem, length);
@@ -112,26 +123,106 @@ index 55d1e3d186..26c224c76c 100644
  //
  // Returns NULL on failure.
  //
-@@ -1068,8 +1171,8 @@ mmap_again:
+ void *
+-mmapForLinker (size_t bytes, uint32_t prot, uint32_t flags, int fd, int offset)
++mmapForLinker (size_t bytes, uint32_t prot, uint32_t flags, int fd, int offset, bool near, char * name)
+ {
+    void *map_addr = NULL;
+    void *result;
+@@ -1068,8 +1182,12 @@ mmap_again:
              debugBelch("mmapForLinker: \tflags      %#0x\n",
                         MAP_PRIVATE | tryMap32Bit | fixed | flags));
  
 -   result = mmap(map_addr, size, prot,
 -                 MAP_PRIVATE|tryMap32Bit|fixed|flags, fd, offset);
-+   result = mmap_next(map_addr, size, prot,
-+                      MAP_PRIVATE|tryMap32Bit|fixed|flags, fd, offset);
++   if(near) {
++    result = mmap_next(map_addr, size, prot,
++                      MAP_PRIVATE|tryMap32Bit|fixed|flags, fd, offset, name);
++   } else {
++     result = mmap(map_addr, size, prot, MAP_PRIVATE|tryMap32Bit|fixed|flags, fd, offset);
++   }
  
     if (result == MAP_FAILED) {
         sysErrorBelch("mmap %" FMT_Word " bytes at %p",(W_)size,map_addr);
+@@ -1161,7 +1279,7 @@ mmap_again:
+ void *
+ mmapAnonForLinker (size_t bytes)
+ {
+-  return mmapForLinker (bytes, PROT_READ|PROT_WRITE, MAP_ANONYMOUS, -1, 0);
++  return mmapForLinker (bytes, PROT_READ|PROT_WRITE, MAP_ANONYMOUS, -1, 0, true, "mapAnonForLinker");
+ }
+ 
+ 
+@@ -1491,10 +1609,10 @@ preloadObjectFile (pathchar *path)
+     * See also the misalignment logic for darwin below.
+     */
+ #if defined(darwin_HOST_OS)
+-   image = mmapForLinker(fileSize, PROT_READ|PROT_WRITE, MAP_PRIVATE, fd, 0);
++   image = mmapForLinker(fileSize, PROT_READ|PROT_WRITE, MAP_PRIVATE, fd, 0, false, path);
+ #else
+    image = mmapForLinker(fileSize, PROT_READ|PROT_WRITE|PROT_EXEC,
+-                MAP_PRIVATE, fd, 0);
++                MAP_PRIVATE, fd, 0, false, path);
+ #endif
+ 
+    if (image == MAP_FAILED) {
 diff --git a/rts/LinkerInternals.h b/rts/LinkerInternals.h
-index f326a840b5..ef7918588d 100644
+index f326a840b5..a422bb0067 100644
 --- a/rts/LinkerInternals.h
 +++ b/rts/LinkerInternals.h
 @@ -14,6 +14,7 @@
  
  #if RTS_LINKER_USE_MMAP
  #include <sys/mman.h>
-+void* mmap_next(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
++void* mmap_next(void *addr, size_t length, int prot, int flags, int fd, off_t offset, char *name);
  #endif
  
  #include "BeginPrivate.h"
+@@ -314,7 +315,7 @@ void freeObjectCode (ObjectCode *oc);
+ SymbolAddr* loadSymbol(SymbolName *lbl, RtsSymbolInfo *pinfo);
+ 
+ void *mmapAnonForLinker (size_t bytes);
+-void *mmapForLinker (size_t bytes, uint32_t prot, uint32_t flags, int fd, int offset);
++void *mmapForLinker (size_t bytes, uint32_t prot, uint32_t flags, int fd, int offset, bool near, char * name));
+ void mmapForLinkerMarkExecutable (void *start, size_t len);
+ 
+ void addProddableBlock ( ObjectCode* oc, void* start, int size );
+diff --git a/rts/linker/Elf.c b/rts/linker/Elf.c
+index fdfe87a4e5..35e1f4f7cc 100644
+--- a/rts/linker/Elf.c
++++ b/rts/linker/Elf.c
+@@ -638,7 +638,7 @@ mapObjectFileSection (int fd, Elf_Word offset, Elf_Word size,
+ 
+     pageOffset = roundDownToPage(offset);
+     pageSize = roundUpToPage(offset-pageOffset+size);
+-    p = mmapForLinker(pageSize, PROT_READ | PROT_WRITE, 0, fd, pageOffset);
++    p = mmapForLinker(pageSize, PROT_READ | PROT_WRITE, 0, fd, pageOffset, true, "mapObjectFileSection");
+     if (p == NULL) return NULL;
+     *mapped_size = pageSize;
+     *mapped_offset = pageOffset;
+diff --git a/rts/linker/MachO.c b/rts/linker/MachO.c
+index 00b0dce04c..87c8b1c258 100644
+--- a/rts/linker/MachO.c
++++ b/rts/linker/MachO.c
+@@ -1200,7 +1200,7 @@ ocGetNames_MachO(ObjectCode* oc)
+                 unsigned nstubs = numberOfStubsForSection(oc, sec_idx);
+                 unsigned stub_space = STUB_SIZE * nstubs;
+ 
+-                void * mem = mmapForLinker(section->size+stub_space, PROT_READ | PROT_WRITE, MAP_ANON, -1, 0);
++                void * mem = mmapForLinker(section->size+stub_space, PROT_READ | PROT_WRITE, MAP_ANON, -1, 0, true, "PLT Stub");
+ 
+                 if( mem == MAP_FAILED ) {
+                     sysErrorBelch("failed to mmap allocated memory to load section %d. "
+diff --git a/rts/sm/Storage.c b/rts/sm/Storage.c
+index 72fabe309f..884a05f6a3 100644
+--- a/rts/sm/Storage.c
++++ b/rts/sm/Storage.c
+@@ -1776,7 +1776,7 @@ void freeExec (void *addr)
+ 
+ #if RTS_LINKER_USE_MMAP
+ AdjustorWritable allocateWrite(W_ bytes) {
+-    return mmapForLinker(bytes, PROT_READ | PROT_WRITE, MAP_ANONYMOUS, -1, 0);
++    return mmapForLinker(bytes, PROT_READ | PROT_WRITE, MAP_ANONYMOUS, -1, 0, true, "adjustor");
+ }
+ 
+ void markExec(W_ bytes, AdjustorWritable writ) {

--- a/overlays/patches/ghc/mmap-next.patch
+++ b/overlays/patches/ghc/mmap-next.patch
@@ -1,5 +1,5 @@
 diff --git a/rts/Linker.c b/rts/Linker.c
-index 55d1e3d186..9d43360713 100644
+index 55d1e3d186..d4afd44e46 100644
 --- a/rts/Linker.c
 +++ b/rts/Linker.c
 @@ -1037,11 +1037,125 @@ resolveSymbolAddr (pathchar* buffer, int size,
@@ -144,12 +144,15 @@ index 55d1e3d186..9d43360713 100644
  
     if (result == MAP_FAILED) {
         sysErrorBelch("mmap %" FMT_Word " bytes at %p",(W_)size,map_addr);
-@@ -1161,7 +1279,7 @@ mmap_again:
+@@ -1159,9 +1277,9 @@ mmap_again:
+  * Map read/write pages in low memory. Returns NULL on failure.
+  */
  void *
- mmapAnonForLinker (size_t bytes)
+-mmapAnonForLinker (size_t bytes)
++mmapAnonForLinker (size_t bytes, bool near)
  {
 -  return mmapForLinker (bytes, PROT_READ|PROT_WRITE, MAP_ANONYMOUS, -1, 0);
-+  return mmapForLinker (bytes, PROT_READ|PROT_WRITE, MAP_ANONYMOUS, -1, 0, true, "mapAnonForLinker");
++  return mmapForLinker (bytes, PROT_READ|PROT_WRITE, MAP_ANONYMOUS, -1, 0, near, "mapAnonForLinker");
  }
  
  
@@ -167,7 +170,7 @@ index 55d1e3d186..9d43360713 100644
  
     if (image == MAP_FAILED) {
 diff --git a/rts/LinkerInternals.h b/rts/LinkerInternals.h
-index f326a840b5..88d200d7c2 100644
+index f326a840b5..ec1c905d5c 100644
 --- a/rts/LinkerInternals.h
 +++ b/rts/LinkerInternals.h
 @@ -14,6 +14,7 @@
@@ -178,17 +181,19 @@ index f326a840b5..88d200d7c2 100644
  #endif
  
  #include "BeginPrivate.h"
-@@ -314,7 +315,7 @@ void freeObjectCode (ObjectCode *oc);
+@@ -313,8 +314,8 @@ void exitLinker( void );
+ void freeObjectCode (ObjectCode *oc);
  SymbolAddr* loadSymbol(SymbolName *lbl, RtsSymbolInfo *pinfo);
  
- void *mmapAnonForLinker (size_t bytes);
+-void *mmapAnonForLinker (size_t bytes);
 -void *mmapForLinker (size_t bytes, uint32_t prot, uint32_t flags, int fd, int offset);
++void *mmapAnonForLinker (size_t bytes, bool near);
 +void *mmapForLinker (size_t bytes, uint32_t prot, uint32_t flags, int fd, int offset, bool near, char * name);
  void mmapForLinkerMarkExecutable (void *start, size_t len);
  
  void addProddableBlock ( ObjectCode* oc, void* start, int size );
 diff --git a/rts/linker/Elf.c b/rts/linker/Elf.c
-index fdfe87a4e5..35e1f4f7cc 100644
+index fdfe87a4e5..6e9dc4e6c7 100644
 --- a/rts/linker/Elf.c
 +++ b/rts/linker/Elf.c
 @@ -638,7 +638,7 @@ mapObjectFileSection (int fd, Elf_Word offset, Elf_Word size,
@@ -200,10 +205,99 @@ index fdfe87a4e5..35e1f4f7cc 100644
      if (p == NULL) return NULL;
      *mapped_size = pageSize;
      *mapped_offset = pageOffset;
+@@ -711,7 +711,7 @@ ocGetNames_ELF ( ObjectCode* oc )
+                * address might be out of range for sections that are mmaped.
+                */
+               alloc = SECTION_MMAP;
+-              start = mmapAnonForLinker(size);
++              start = mmapAnonForLinker(size, true);
+               if (start == NULL) {
+                 barf("failed to mmap memory for bss. "
+                      "errno = %d", errno);
+@@ -758,7 +758,7 @@ ocGetNames_ELF ( ObjectCode* oc )
+           unsigned nstubs = numberOfStubsForSection(oc, i);
+           unsigned stub_space = STUB_SIZE * nstubs;
+ 
+-          void * mem = mmapAnonForLinker(size+stub_space);
++          void * mem = mmapAnonForLinker(size+stub_space, true);
+ 
+           if( mem == NULL ) {
+               barf("failed to mmap allocated memory to load section %d. "
+@@ -867,7 +867,7 @@ ocGetNames_ELF ( ObjectCode* oc )
+       }
+       void * common_mem = NULL;
+       if(common_size > 0) {
+-          common_mem = mmapAnonForLinker(common_size);
++          common_mem = mmapAnonForLinker(common_size, true);
+           if (common_mem == NULL) {
+             barf("ocGetNames_ELF: Failed to allocate memory for SHN_COMMONs");
+           }
+diff --git a/rts/linker/LoadArchive.c b/rts/linker/LoadArchive.c
+index 366b45d105..2391c58b1d 100644
+--- a/rts/linker/LoadArchive.c
++++ b/rts/linker/LoadArchive.c
+@@ -489,7 +489,7 @@ static HsInt loadArchive_ (pathchar *path)
+ 
+ #if defined(darwin_HOST_OS) || defined(ios_HOST_OS)
+             if (RTS_LINKER_USE_MMAP)
+-                image = mmapAnonForLinker(memberSize);
++                image = mmapAnonForLinker(memberSize, false);
+             else {
+                 /* See loadObj() */
+                 misalignment = machoGetMisalignment(f);
+@@ -548,7 +548,7 @@ while reading filename from `%" PATH_FMT "'", path);
+             }
+             DEBUG_LOG("Found GNU-variant file index\n");
+ #if RTS_LINKER_USE_MMAP
+-            gnuFileIndex = mmapAnonForLinker(memberSize + 1);
++            gnuFileIndex = mmapAnonForLinker(memberSize + 1, false);
+ #else
+             gnuFileIndex = stgMallocBytes(memberSize + 1, "loadArchive(image)");
+ #endif
+diff --git a/rts/linker/M32Alloc.c b/rts/linker/M32Alloc.c
+index d2b91140c0..45deca9a18 100644
+--- a/rts/linker/M32Alloc.c
++++ b/rts/linker/M32Alloc.c
+@@ -264,7 +264,7 @@ m32_alloc_page(void)
+      */
+     const size_t pgsz = getPageSize();
+     const size_t map_sz = pgsz * M32_MAP_PAGES;
+-    uint8_t *chunk = mmapAnonForLinker(map_sz);
++    uint8_t *chunk = mmapAnonForLinker(map_sz, false);
+     if (chunk + map_sz > (uint8_t *) 0xffffffff) {
+       barf("m32_alloc_page: failed to get allocation in lower 32-bits");
+     }
+@@ -408,7 +408,7 @@ m32_alloc(struct m32_allocator_t *alloc, size_t size, size_t alignment)
+    if (m32_is_large_object(size,alignment)) {
+       // large object
+       size_t alsize = ROUND_UP(sizeof(struct m32_page_t), alignment);
+-      struct m32_page_t *page = mmapAnonForLinker(alsize+size);
++      struct m32_page_t *page = mmapAnonForLinker(alsize+size, false);
+       if (page == NULL) {
+           sysErrorBelch("m32_alloc: Failed to map pages for %zd bytes", size);
+           return NULL;
 diff --git a/rts/linker/MachO.c b/rts/linker/MachO.c
-index 00b0dce04c..87c8b1c258 100644
+index 00b0dce04c..e0333c4c11 100644
 --- a/rts/linker/MachO.c
 +++ b/rts/linker/MachO.c
+@@ -445,7 +445,7 @@ makeGot(ObjectCode * oc) {
+ 
+     if(got_slots > 0) {
+         oc->info->got_size =  got_slots * sizeof(void*);
+-        oc->info->got_start = mmapAnonForLinker(oc->info->got_size);
++        oc->info->got_start = mmapAnonForLinker(oc->info->got_size, true);
+         if( oc->info->got_start == NULL ) {
+             barf("MAP_FAILED. errno=%d", errno );
+             return EXIT_FAILURE;
+@@ -1050,7 +1050,7 @@ ocBuildSegments_MachO(ObjectCode *oc)
+         return 1;
+     }
+ 
+-    mem = mmapAnonForLinker(size_compound);
++    mem = mmapAnonForLinker(size_compound, true);
+     if (NULL == mem) return 0;
+ 
+     IF_DEBUG(linker, debugBelch("ocBuildSegments: allocating %d segments\n", n_activeSegments));
 @@ -1200,7 +1200,7 @@ ocGetNames_MachO(ObjectCode* oc)
                  unsigned nstubs = numberOfStubsForSection(oc, sec_idx);
                  unsigned stub_space = STUB_SIZE * nstubs;
@@ -213,6 +307,32 @@ index 00b0dce04c..87c8b1c258 100644
  
                  if( mem == MAP_FAILED ) {
                      sysErrorBelch("failed to mmap allocated memory to load section %d. "
+diff --git a/rts/linker/SymbolExtras.c b/rts/linker/SymbolExtras.c
+index 9d4eb89400..1b0283527f 100644
+--- a/rts/linker/SymbolExtras.c
++++ b/rts/linker/SymbolExtras.c
+@@ -81,7 +81,7 @@ int ocAllocateExtras(ObjectCode* oc, int count, int first, int bssSize)
+       // symbol_extras is aligned to a page boundary so it can be mprotect'd.
+       bssSize = roundUpToPage(bssSize);
+       size_t allocated_size = n + bssSize + extras_size;
+-      void *new = mmapAnonForLinker(allocated_size);
++      void *new = mmapAnonForLinker(allocated_size, true);
+       if (new) {
+           memcpy(new, oc->image, oc->fileSize);
+           if (oc->imageMapped) {
+diff --git a/rts/linker/elf_got.c b/rts/linker/elf_got.c
+index 25f5a91d5a..613575ef07 100644
+--- a/rts/linker/elf_got.c
++++ b/rts/linker/elf_got.c
+@@ -52,7 +52,7 @@ makeGot(ObjectCode * oc) {
+     }
+     if(got_slots > 0) {
+         oc->info->got_size = got_slots * sizeof(void *);
+-        void * mem = mmapAnonForLinker(oc->info->got_size);
++        void * mem = mmapAnonForLinker(oc->info->got_size, true);
+         if (mem == NULL) {
+             errorBelch("MAP_FAILED. errno=%d", errno);
+             return EXIT_FAILURE;
 diff --git a/rts/sm/Storage.c b/rts/sm/Storage.c
 index 72fabe309f..884a05f6a3 100644
 --- a/rts/sm/Storage.c

--- a/overlays/patches/ghc/mmap-next.patch
+++ b/overlays/patches/ghc/mmap-next.patch
@@ -1,5 +1,5 @@
 diff --git a/rts/Linker.c b/rts/Linker.c
-index 55d1e3d186..9b973eab53 100644
+index 55d1e3d186..9d43360713 100644
 --- a/rts/Linker.c
 +++ b/rts/Linker.c
 @@ -1037,11 +1037,125 @@ resolveSymbolAddr (pathchar* buffer, int size,
@@ -116,7 +116,7 @@ index 55d1e3d186..9b973eab53 100644
 +      debugBelch("mmap_next failed to find suitable space in %p - %p\n", addr, target));
 +  }
 +  printInfos();
-+  barf("Failed to mmap_next for %p and size %zu\n", addr, length);
++  barf("Failed to mmap_next for %p and size %zu for %s\n", addr, length, name);
 +  return NULL;
 +}
 +

--- a/overlays/patches/ghc/mmap-next.patch
+++ b/overlays/patches/ghc/mmap-next.patch
@@ -167,7 +167,7 @@ index 55d1e3d186..9d43360713 100644
  
     if (image == MAP_FAILED) {
 diff --git a/rts/LinkerInternals.h b/rts/LinkerInternals.h
-index f326a840b5..a422bb0067 100644
+index f326a840b5..88d200d7c2 100644
 --- a/rts/LinkerInternals.h
 +++ b/rts/LinkerInternals.h
 @@ -14,6 +14,7 @@
@@ -183,7 +183,7 @@ index f326a840b5..a422bb0067 100644
  
  void *mmapAnonForLinker (size_t bytes);
 -void *mmapForLinker (size_t bytes, uint32_t prot, uint32_t flags, int fd, int offset);
-+void *mmapForLinker (size_t bytes, uint32_t prot, uint32_t flags, int fd, int offset, bool near, char * name));
++void *mmapForLinker (size_t bytes, uint32_t prot, uint32_t flags, int fd, int offset, bool near, char * name);
  void mmapForLinkerMarkExecutable (void *start, size_t len);
  
  void addProddableBlock ( ObjectCode* oc, void* start, int size );

--- a/overlays/patches/ghc/mmap-next.patch
+++ b/overlays/patches/ghc/mmap-next.patch
@@ -1,5 +1,5 @@
 diff --git a/rts/Linker.c b/rts/Linker.c
-index 55d1e3d186..d4afd44e46 100644
+index 55d1e3d186..9c5d02c56b 100644
 --- a/rts/Linker.c
 +++ b/rts/Linker.c
 @@ -1037,11 +1037,125 @@ resolveSymbolAddr (pathchar* buffer, int size,
@@ -100,7 +100,7 @@ index 55d1e3d186..d4afd44e46 100644
 +  // we are going to look for up to pageSize * 1024 * 1024 (4GB) from the
 +  // address.
 +  size_t pageSize = getPageSize();
-+  for(int i = (uintptr_t)addr & (pageSize-1) ? 1 : 0; i < 1024*1024; i++) {
++  for(int i = (uintptr_t)addr & (pageSize-1) ? 1 : 0; i < 16*1024*1024; i++) {
 +
 +    void *target = (void*)(((uintptr_t)(bucket->next_addr) & ~(pageSize-1))+(i*pageSize));
 +    void *mem = mmap(target, length, prot, flags, fd, offset);
@@ -149,10 +149,10 @@ index 55d1e3d186..d4afd44e46 100644
   */
  void *
 -mmapAnonForLinker (size_t bytes)
-+mmapAnonForLinker (size_t bytes, bool near)
++mmapAnonForLinker (size_t bytes, bool near, char *name)
  {
 -  return mmapForLinker (bytes, PROT_READ|PROT_WRITE, MAP_ANONYMOUS, -1, 0);
-+  return mmapForLinker (bytes, PROT_READ|PROT_WRITE, MAP_ANONYMOUS, -1, 0, near, "mapAnonForLinker");
++  return mmapForLinker (bytes, PROT_READ|PROT_WRITE, MAP_ANONYMOUS, -1, 0, near, name);
  }
  
  
@@ -170,7 +170,7 @@ index 55d1e3d186..d4afd44e46 100644
  
     if (image == MAP_FAILED) {
 diff --git a/rts/LinkerInternals.h b/rts/LinkerInternals.h
-index f326a840b5..ec1c905d5c 100644
+index f326a840b5..f058d8d7a6 100644
 --- a/rts/LinkerInternals.h
 +++ b/rts/LinkerInternals.h
 @@ -14,6 +14,7 @@
@@ -187,13 +187,13 @@ index f326a840b5..ec1c905d5c 100644
  
 -void *mmapAnonForLinker (size_t bytes);
 -void *mmapForLinker (size_t bytes, uint32_t prot, uint32_t flags, int fd, int offset);
-+void *mmapAnonForLinker (size_t bytes, bool near);
++void *mmapAnonForLinker (size_t bytes, bool near, char *name);
 +void *mmapForLinker (size_t bytes, uint32_t prot, uint32_t flags, int fd, int offset, bool near, char * name);
  void mmapForLinkerMarkExecutable (void *start, size_t len);
  
  void addProddableBlock ( ObjectCode* oc, void* start, int size );
 diff --git a/rts/linker/Elf.c b/rts/linker/Elf.c
-index fdfe87a4e5..6e9dc4e6c7 100644
+index fdfe87a4e5..0bbbbf2cc0 100644
 --- a/rts/linker/Elf.c
 +++ b/rts/linker/Elf.c
 @@ -638,7 +638,7 @@ mapObjectFileSection (int fd, Elf_Word offset, Elf_Word size,
@@ -210,7 +210,7 @@ index fdfe87a4e5..6e9dc4e6c7 100644
                 */
                alloc = SECTION_MMAP;
 -              start = mmapAnonForLinker(size);
-+              start = mmapAnonForLinker(size, true);
++              start = mmapAnonForLinker(size, true, "anon:SECTION_MAP");
                if (start == NULL) {
                  barf("failed to mmap memory for bss. "
                       "errno = %d", errno);
@@ -219,7 +219,7 @@ index fdfe87a4e5..6e9dc4e6c7 100644
            unsigned stub_space = STUB_SIZE * nstubs;
  
 -          void * mem = mmapAnonForLinker(size+stub_space);
-+          void * mem = mmapAnonForLinker(size+stub_space, true);
++          void * mem = mmapAnonForLinker(size+stub_space, true, "anon:stub_space");
  
            if( mem == NULL ) {
                barf("failed to mmap allocated memory to load section %d. "
@@ -228,12 +228,12 @@ index fdfe87a4e5..6e9dc4e6c7 100644
        void * common_mem = NULL;
        if(common_size > 0) {
 -          common_mem = mmapAnonForLinker(common_size);
-+          common_mem = mmapAnonForLinker(common_size, true);
++          common_mem = mmapAnonForLinker(common_size, true, "anon:common_mem");
            if (common_mem == NULL) {
              barf("ocGetNames_ELF: Failed to allocate memory for SHN_COMMONs");
            }
 diff --git a/rts/linker/LoadArchive.c b/rts/linker/LoadArchive.c
-index 366b45d105..2391c58b1d 100644
+index 366b45d105..0920340831 100644
 --- a/rts/linker/LoadArchive.c
 +++ b/rts/linker/LoadArchive.c
 @@ -489,7 +489,7 @@ static HsInt loadArchive_ (pathchar *path)
@@ -241,7 +241,7 @@ index 366b45d105..2391c58b1d 100644
  #if defined(darwin_HOST_OS) || defined(ios_HOST_OS)
              if (RTS_LINKER_USE_MMAP)
 -                image = mmapAnonForLinker(memberSize);
-+                image = mmapAnonForLinker(memberSize, false);
++                image = mmapAnonForLinker(memberSize, false, "anon:image");
              else {
                  /* See loadObj() */
                  misalignment = machoGetMisalignment(f);
@@ -250,12 +250,12 @@ index 366b45d105..2391c58b1d 100644
              DEBUG_LOG("Found GNU-variant file index\n");
  #if RTS_LINKER_USE_MMAP
 -            gnuFileIndex = mmapAnonForLinker(memberSize + 1);
-+            gnuFileIndex = mmapAnonForLinker(memberSize + 1, false);
++            gnuFileIndex = mmapAnonForLinker(memberSize + 1, false, "anon:loadArchive(image)");
  #else
              gnuFileIndex = stgMallocBytes(memberSize + 1, "loadArchive(image)");
  #endif
 diff --git a/rts/linker/M32Alloc.c b/rts/linker/M32Alloc.c
-index d2b91140c0..45deca9a18 100644
+index d2b91140c0..089fbeb717 100644
 --- a/rts/linker/M32Alloc.c
 +++ b/rts/linker/M32Alloc.c
 @@ -264,7 +264,7 @@ m32_alloc_page(void)
@@ -263,7 +263,7 @@ index d2b91140c0..45deca9a18 100644
      const size_t pgsz = getPageSize();
      const size_t map_sz = pgsz * M32_MAP_PAGES;
 -    uint8_t *chunk = mmapAnonForLinker(map_sz);
-+    uint8_t *chunk = mmapAnonForLinker(map_sz, false);
++    uint8_t *chunk = mmapAnonForLinker(map_sz, false, "anon:m32_alloc_page");
      if (chunk + map_sz > (uint8_t *) 0xffffffff) {
        barf("m32_alloc_page: failed to get allocation in lower 32-bits");
      }
@@ -272,12 +272,12 @@ index d2b91140c0..45deca9a18 100644
        // large object
        size_t alsize = ROUND_UP(sizeof(struct m32_page_t), alignment);
 -      struct m32_page_t *page = mmapAnonForLinker(alsize+size);
-+      struct m32_page_t *page = mmapAnonForLinker(alsize+size, false);
++      struct m32_page_t *page = mmapAnonForLinker(alsize+size, false, "anon:m32_alloc");
        if (page == NULL) {
            sysErrorBelch("m32_alloc: Failed to map pages for %zd bytes", size);
            return NULL;
 diff --git a/rts/linker/MachO.c b/rts/linker/MachO.c
-index 00b0dce04c..e0333c4c11 100644
+index 00b0dce04c..d4cd4d48b1 100644
 --- a/rts/linker/MachO.c
 +++ b/rts/linker/MachO.c
 @@ -445,7 +445,7 @@ makeGot(ObjectCode * oc) {
@@ -285,7 +285,7 @@ index 00b0dce04c..e0333c4c11 100644
      if(got_slots > 0) {
          oc->info->got_size =  got_slots * sizeof(void*);
 -        oc->info->got_start = mmapAnonForLinker(oc->info->got_size);
-+        oc->info->got_start = mmapAnonForLinker(oc->info->got_size, true);
++        oc->info->got_start = mmapAnonForLinker(oc->info->got_size, true, "anon:makeGot");
          if( oc->info->got_start == NULL ) {
              barf("MAP_FAILED. errno=%d", errno );
              return EXIT_FAILURE;
@@ -294,7 +294,7 @@ index 00b0dce04c..e0333c4c11 100644
      }
  
 -    mem = mmapAnonForLinker(size_compound);
-+    mem = mmapAnonForLinker(size_compound, true);
++    mem = mmapAnonForLinker(size_compound, true, "anon:BuildSegment");
      if (NULL == mem) return 0;
  
      IF_DEBUG(linker, debugBelch("ocBuildSegments: allocating %d segments\n", n_activeSegments));
@@ -308,7 +308,7 @@ index 00b0dce04c..e0333c4c11 100644
                  if( mem == MAP_FAILED ) {
                      sysErrorBelch("failed to mmap allocated memory to load section %d. "
 diff --git a/rts/linker/SymbolExtras.c b/rts/linker/SymbolExtras.c
-index 9d4eb89400..1b0283527f 100644
+index 9d4eb89400..5e1071eb72 100644
 --- a/rts/linker/SymbolExtras.c
 +++ b/rts/linker/SymbolExtras.c
 @@ -81,7 +81,7 @@ int ocAllocateExtras(ObjectCode* oc, int count, int first, int bssSize)
@@ -316,12 +316,12 @@ index 9d4eb89400..1b0283527f 100644
        bssSize = roundUpToPage(bssSize);
        size_t allocated_size = n + bssSize + extras_size;
 -      void *new = mmapAnonForLinker(allocated_size);
-+      void *new = mmapAnonForLinker(allocated_size, true);
++      void *new = mmapAnonForLinker(allocated_size, true, "anon:allocateExtras");
        if (new) {
            memcpy(new, oc->image, oc->fileSize);
            if (oc->imageMapped) {
 diff --git a/rts/linker/elf_got.c b/rts/linker/elf_got.c
-index 25f5a91d5a..613575ef07 100644
+index 25f5a91d5a..b55a44320c 100644
 --- a/rts/linker/elf_got.c
 +++ b/rts/linker/elf_got.c
 @@ -52,7 +52,7 @@ makeGot(ObjectCode * oc) {
@@ -329,7 +329,7 @@ index 25f5a91d5a..613575ef07 100644
      if(got_slots > 0) {
          oc->info->got_size = got_slots * sizeof(void *);
 -        void * mem = mmapAnonForLinker(oc->info->got_size);
-+        void * mem = mmapAnonForLinker(oc->info->got_size, true);
++        void * mem = mmapAnonForLinker(oc->info->got_size, true, "anon:oc->info->got_size");
          if (mem == NULL) {
              errorBelch("MAP_FAILED. errno=%d", errno);
              return EXIT_FAILURE;


### PR DESCRIPTION
This one moves most of the allocation logic into the m32 allocator, while also completely ignoring the _lower_ requirement. This of course is not ideal, however we've been mapping pages at the oder of 100x (4096 vs 40) the required space, and thus often ran out of memory due to sections per function.

This is now much improved. It also revealed at least _one_ out-of-bounds memory write issue.