### PR TITLE
Fix issue with nixpkgs 21.05

### DIFF
--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -3182,7 +3182,7 @@ pkgs:
     "libtap" = [ "libtap" ];
     "libtasn1" = [ "libtasn1" ];
     "libtelnet" = [ "libtelnet" ];
-    "tensorflow" = [ "libtensorflow" ];
+    "tensorflow" = pkgs.lib.optional (builtins.compareVersions pkgs.lib.version "21.11" >= 0) "libtensorflow";
 #    "tensorflow" = [ "libtensorflow-bin" ];
     "termkey" = [ "libtermkey" ];
     "libthai" = [ "libthai" ];


### PR DESCRIPTION
This version of nixpkgs is still needed for old ghc cross compilation to windows.