### PR TITLE
Add `shell.allDeps` as a fix for #1793

### DIFF
--- a/builder/shell-for.nix
+++ b/builder/shell-for.nix
@@ -15,6 +15,7 @@
 , withHoogle ? true
 , withHaddock ? withHoogle
 , exactDeps ? false
+, allToolDeps ? !exactDeps
 , tools ? {}
 , packageSetupDeps ? true
 , enableDWARF ? false
@@ -110,7 +111,7 @@ let
     (uniqueWithName (lib.concatMap (c: c.executableToolDepends)
       # When not using `exactDeps` cabal may try to build arbitrary dependencies
       # so in this case we need to provide the build tools for all of hsPkgs:
-      (if exactDeps then selectedComponents else allHsPkgsComponents)));
+      (if exactDeps || !allToolDeps then selectedComponents else allHsPkgsComponents)));
 
   # Set up a "dummy" component to use with ghcForComponent.
   component = {

--- a/builder/shell-for.nix
+++ b/builder/shell-for.nix
@@ -110,7 +110,10 @@ let
   nativeBuildInputs = removeSelectedInputs
     (uniqueWithName (lib.concatMap (c: c.executableToolDepends)
       # When not using `exactDeps` cabal may try to build arbitrary dependencies
-      # so in this case we need to provide the build tools for all of hsPkgs:
+      # so in this case we need to provide the build tools for all of `hsPkgs`.
+      # In some cases those tools may be unwanted or broken so the `allToolDeps`
+      # flag can be set to `false` to disable this (stack projects default `allToolDeps`
+      # to `false` as `hsPkgs` for them includes all of stackage):
       (if exactDeps || !allToolDeps then selectedComponents else allHsPkgsComponents)));
 
   # Set up a "dummy" component to use with ghcForComponent.

--- a/modules/shell.nix
+++ b/modules/shell.nix
@@ -35,7 +35,8 @@
       description = ''
         Indicates if the shell should include all the tool dependencies
         of in the haskell packages in the project.  Defaulted to `false` in
-        stack projects.
+        stack projects (to avoid trying to build the tools used by
+        every `stackage` package).
       '';
     };
     tools = lib.mkOption {

--- a/modules/shell.nix
+++ b/modules/shell.nix
@@ -29,6 +29,15 @@
       type = lib.types.bool;
       default = false;
     };
+    allToolDeps = lib.mkOption {
+      type = lib.types.bool;
+      default = !config.exactDeps;
+      description = ''
+        Indicates if the shell should include all the tool dependencies
+        of in the haskell packages in the project.  Defaulted to `false` in
+        stack projects.
+      '';
+    };
     tools = lib.mkOption {
       type = lib.types.attrsOf lib.types.unspecified;
       default = {};

--- a/modules/stack-project.nix
+++ b/modules/stack-project.nix
@@ -91,4 +91,9 @@ with types;
       description = "Deprecated in favour of `compiler-nix-name`";
     };
   };
+  config = {
+    # For stack projects we normally do not want to include the tool dependencies
+    # of all the hsPkgs (all of stackage).
+    shell.allToolDeps = mkDefault false;
+  };
 }


### PR DESCRIPTION
#1769 added all the tool dependencies of the hsPkgs in a project to the shell.  This is great for cabal projects where the set of packages will be limited to those in the plan.  It allows these packages to be rebuilt by cabal.

For stack projects however this set is much larger (all of stackage), likely to include unwanted tools and tools that may be broken.

This change adds `shell.allDeps` and defaults it to `false` for stack projects.

Fixes #1793