### PR TITLE
remove `digibyte` and `digibyted`

### DIFF
--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -1310,8 +1310,6 @@ pkgs:
     "ddcutil" = [ "ddcutil" ];
     "dee-1.0" = [ "dee" ];
     "dee-icu-1.0" = [ "dee" ];
-    "libdigibyteconsensus" = [ "digibyte" ];
-#    "libdigibyteconsensus" = [ "digibyted" ];
     "basicobjects" = [ "ding-libs" ];
     "collection" = [ "ding-libs" ];
     "dhash" = [ "ding-libs" ];


### PR DESCRIPTION
Corresponds to
```
digibyte = throw "digibyte has been removed since it's unnmaintained and will stop building with Qt > 5.14"; 
# Added 2022-11-24

digibyted = throw "digibyted has been removed since it's unnmaintained: https://github.com/digibyte/digibyte/graphs/code-frequency";
# Added 2022-11-24
```
https://github.com/NixOS/nixpkgs/blob/d45949a18b5fc951dbe1fb3881198b4f4d8df517/pkgs/top-level/aliases.nix#L139-L140

https://github.com/NixOS/nixpkgs/pull/202664/commits/333f2ef7636cd70b56e839587fdf4d56d6ccc132


I don't know what this will break, if anything