### PR TITLE
`shell.tools` mappings for `steeloverseer` and `implicit-hie`

### DIFF
--- a/overlays/tools.nix
+++ b/overlays/tools.nix
@@ -48,6 +48,8 @@ in { haskell-nix = prev.haskell-nix // {
   # Tools better known by their exe name.
   toolPackageName = {
     cabal = "cabal-install";
+    sos = "steeloverseer";
+    gen-hie = "implicit-hie";
   };
 
   # Packages that are better known by their package name.  We are not
@@ -55,6 +57,8 @@ in { haskell-nix = prev.haskell-nix // {
   # will have the same exe name.
   packageToolName = {
     cabal-install = "cabal";
+    steeloverseer = "sos";
+    implicit-hie = "gen-hie";
   };
 
   hackage-tool = projectModules:


### PR DESCRIPTION
Closes https://github.com/input-output-hk/haskell.nix/issues/1801

These two package names differ from their respective `exe` names.

`implicit-hie`: https://hackage.haskell.org/package/implicit-hie
The `exe` is `gen-hie`.

`steeloverseer`: https://hackage.haskell.org/package/steeloverseer
The `exe` name is `sos`.


This https://github.com/peterbecich/flake-example/blob/show-component-name-fix/nix/hix.nix is a test of this PR, showing that the mapping fixes the issue for `implicit-hie`.

`steeloverseer` is partially fixed; it fails to build for an unrelated reason.



This error
```
error: attribute '...' missing
``` 
is fixed for these two packages.