### PR TITLE
Fix musl TH code using C++ & external interpreter

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -318,7 +318,7 @@ let
     }
     // lib.optionalAttrs stdenv.hostPlatform.isMusl {
       # This fixes musl compilation of TH code that depends on C++ (for instance TH code that uses the double-conversion package)
-      LD_LIBRARY_PATH="${pkgs.buildPackages.gcc-unwrapped.lib}/x86_64-unknown-linux-musl/lib"
+      LD_LIBRARY_PATH="${pkgs.buildPackages.gcc-unwrapped.lib}/x86_64-unknown-linux-musl/lib";
     };
 
   haddock = haddockBuilder {

--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -447,7 +447,9 @@ let
       '' else ''
         runHook preBuild
         # https://gitlab.haskell.org/ghc/ghc/issues/9221
-        $SETUP_HS build ${haskellLib.componentTarget componentId} -j$(($NIX_BUILD_CORES > 4 ? 4 : $NIX_BUILD_CORES)) ${lib.concatStringsSep " " setupBuildFlags}
+        ${ # This fixes musl compilation of TH code that depends on C++ (for instance TH code that uses the double-conversion package)
+           lib.optionalString stdenv.hostPlatform.isMusl "LD_LIBRARY_PATH=${pkgs.buildPackages.gcc-unwrapped.lib}/x86_64-unknown-linux-musl/lib "
+        }$SETUP_HS build ${haskellLib.componentTarget componentId} -j$(($NIX_BUILD_CORES > 4 ? 4 : $NIX_BUILD_CORES)) ${lib.concatStringsSep " " setupBuildFlags}
         runHook postBuild
       '');
 

--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -315,6 +315,10 @@ let
     }
     // lib.optionalAttrs (stdenv.buildPlatform.libc == "glibc") {
       LOCALE_ARCHIVE = "${buildPackages.glibcLocales}/lib/locale/locale-archive";
+    }
+    // lib.optionalAttrs stdenv.hostPlatform.isMusl {
+      # This fixes musl compilation of TH code that depends on C++ (for instance TH code that uses the double-conversion package)
+      LD_LIBRARY_PATH="${pkgs.buildPackages.gcc-unwrapped.lib}/x86_64-unknown-linux-musl/lib"
     };
 
   haddock = haddockBuilder {
@@ -447,9 +451,7 @@ let
       '' else ''
         runHook preBuild
         # https://gitlab.haskell.org/ghc/ghc/issues/9221
-        ${ # This fixes musl compilation of TH code that depends on C++ (for instance TH code that uses the double-conversion package)
-           lib.optionalString stdenv.hostPlatform.isMusl "LD_LIBRARY_PATH=${pkgs.buildPackages.gcc-unwrapped.lib}/x86_64-unknown-linux-musl/lib "
-        }$SETUP_HS build ${haskellLib.componentTarget componentId} -j$(($NIX_BUILD_CORES > 4 ? 4 : $NIX_BUILD_CORES)) ${lib.concatStringsSep " " setupBuildFlags}
+        $SETUP_HS build ${haskellLib.componentTarget componentId} -j$(($NIX_BUILD_CORES > 4 ? 4 : $NIX_BUILD_CORES)) ${lib.concatStringsSep " " setupBuildFlags}
         runHook postBuild
       '');
 

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 3
+{ ifdLevel ? 0
 # Whether or not we are evaluating in restricted mode. This is true in Hydra, but not in Hercules.
 , restrictEval ? false
 , checkMaterialization ? false

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 2
+{ ifdLevel ? 3
 # Whether or not we are evaluating in restricted mode. This is true in Hydra, but not in Hercules.
 , restrictEval ? false
 , checkMaterialization ? false

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 0
+{ ifdLevel ? 1
 # Whether or not we are evaluating in restricted mode. This is true in Hydra, but not in Hercules.
 , restrictEval ? false
 , checkMaterialization ? false

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 1
+{ ifdLevel ? 2
 # Whether or not we are evaluating in restricted mode. This is true in Hydra, but not in Hercules.
 , restrictEval ? false
 , checkMaterialization ? false

--- a/test/th-dlls/default.nix
+++ b/test/th-dlls/default.nix
@@ -4,12 +4,18 @@
 with lib;
 
 let
-  project = project' {
+  project = externalInterpreter: project' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "th-dlls";
+    modules = [({pkgs, ...}: lib.optionalAttrs externalInterpreter {
+      packages.th-dlls.components.library.ghcOptions = [ "-fexternal-interpreter" ];
+      # Static openssl seems to fail to load in iserv for musl
+      packages.HsOpenSSL.components.library.libs = lib.optional pkgs.stdenv.hostPlatform.isMusl (pkgs.openssl.override { static = false; });
+    })];
   };
 
-  packages = project.hsPkgs;
+  packages = (project false).hsPkgs;
+  packages-ei = (project true).hsPkgs;
 
 in recurseIntoAttrs {
   meta.disabled = stdenv.hostPlatform.isGhcjs ||
@@ -20,10 +26,13 @@ in recurseIntoAttrs {
     (stdenv.hostPlatform.isDarwin && __elem compiler-nix-name ["ghc941" "ghc942" "ghc943" "ghc944"]);
 
   ifdInputs = {
-    inherit (project) plan-nix;
+    inherit (project true) plan-nix;
   };
 
   build = packages.th-dlls.components.library;
   build-profiled = packages.th-dlls.components.library.profiled;
   just-template-haskell = packages.th-dlls.components.exes.just-template-haskell;
+  build-ei = packages-ei.th-dlls.components.library;
+  build-profiled-ei = packages-ei.th-dlls.components.library.profiled;
+  just-template-haskell-ei = packages-ei.th-dlls.components.exes.just-template-haskell;
 }


### PR DESCRIPTION
This makes the gcc_s.so library available to iserv.