### PR TITLE
First attempt at getting haskell.nix to work with nixpkgs provided compiler

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -82,7 +82,7 @@ let self =
 , enableTSanRTS ? false
 
 # LLVM
-, useLLVM ? false
+, useLLVM ? ghc.useLLVM
 , smallAddressSpace ? false
 
 }@drvArgs:

--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -82,7 +82,7 @@ let self =
 , enableTSanRTS ? false
 
 # LLVM
-, useLLVM ? ghc.useLLVM
+, useLLVM ? false
 , smallAddressSpace ? false
 
 }@drvArgs:

--- a/builder/hspkg-builder.nix
+++ b/builder/hspkg-builder.nix
@@ -18,10 +18,6 @@ config:
 , ...
 }@pkg:
 
-assert (if ghc.isHaskellNixCompiler or false then true
-  else throw ("It is likely you used `haskell.compiler.X` instead of `haskell-nix.compiler.X`"
-    + pkgs.lib.optionalString (name != null) (" for " + name)));
-
 let
   # Some packages bundled with GHC are not the same as they are in hackage.
   bundledSrc = {

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -107,9 +107,6 @@ let
               pkgs.haskell-nix.compiler."${compiler-nix-name}";
 
 in
-  assert (if ghc'.isHaskellNixCompiler or false then true
-    else throw ("It is likely you used `haskell.compiler.X` instead of `haskell-nix.compiler.X`"
-      + forName));
 
 let
   ghc = ghc';

--- a/overlays/ghc-packages.nix
+++ b/overlays/ghc-packages.nix
@@ -163,7 +163,7 @@ in rec {
               inherit subDir;
               includeSiblings = true;
             }
-            else "${ghc.passthru.configured-src}/${subDir}";
+            else "${ghc.configured-src}/${subDir}";
         nix = callCabal2Nix ghcName "${ghcName}-${pkgName}" src;
       }) (ghc-extra-pkgs ghc.version))
     final.buildPackages.haskell-nix.compiler;

--- a/overlays/ghc-packages.nix
+++ b/overlays/ghc-packages.nix
@@ -163,7 +163,7 @@ in rec {
               inherit subDir;
               includeSiblings = true;
             }
-            else "${ghc.configured-src}/${subDir}";
+            else "${ghc.passthru.configured-src}/${subDir}";
         nix = callCabal2Nix ghcName "${ghcName}-${pkgName}" src;
       }) (ghc-extra-pkgs ghc.version))
     final.buildPackages.haskell-nix.compiler;

--- a/test/with-nixpkgs-ghc/default.nix
+++ b/test/with-nixpkgs-ghc/default.nix
@@ -1,3 +1,4 @@
+{ with-nixpkgs ? true }:
 let
 
   haskell-nix = import ../../default.nix { };
@@ -17,14 +18,12 @@ let
   );
 
   pkgs = import nixpkgs {
-    system = __currentSystem;
     inherit (haskell-nix) config;
     overlays = [
-      # haskell-nix.overlays.haskell
-      # haskell-nix.overlays.tools
       haskell-nix.overlay
-      o2
-    ];
+    ]
+    ++
+    (if with-nixpkgs then [ o2 ] else [ ]);
   };
 
   prj = pkgs.haskell-nix.cabalProject {
@@ -35,4 +34,3 @@ let
 in
 
 prj.plan-nix
-

--- a/test/with-nixpkgs-ghc/default.nix
+++ b/test/with-nixpkgs-ghc/default.nix
@@ -4,14 +4,63 @@ let
   haskell-nix = import ../../default.nix { };
   nixpkgs = haskell-nix.inputs.nixpkgs.outPath;
 
+  fix = final: prev: compiler-nix-name:
+    let
+      haskell-nix-ghc = prev.haskell-nix.compiler.${compiler-nix-name};
+      nixpkgs-ghc = prev.haskell.compiler.${compiler-nix-name};
+
+      exactDepOut =
+        pkgs.runCommand "${nixpkgs-ghc.name}-exactDeps" { }
+          ''
+            mkdir -p $out
+            ${nixpkgs-ghc}/bin/ghc-pkg --version
+            for P in $(${nixpkgs-ghc}/bin/ghc-pkg list --simple-output | sed 's/-[0-9][0-9.]*//g'); do
+              mkdir -p $out/exactDeps/$P
+              touch $out/exactDeps/$P/configure-flags
+              touch $out/exactDeps/$P/cabal.config
+
+              if id=$(${nixpkgs-ghc}/bin/ghc-pkg field $P id --simple-output); then
+                echo "--dependency=$P=$id" >> $out/exactDeps/$P/configure-flags
+              elif id=$(${nixpkgs-ghc}/bin/ghc-pkg field "z-$P-z-*" id --simple-output); then
+                name=$(${nixpkgs-ghc}/bin/ghc-pkg field "z-$P-z-*" name --simple-output)
+                # so we are dealing with a sublib. As we build sublibs separately, the above
+                # query should be safe.
+                echo "--dependency=''${name#z-$P-z-}=$id" >> $out/exactDeps/$P/configure-flags
+              fi
+              if ver=$(${nixpkgs-ghc}/bin/ghc-pkg field $P version --simple-output); then
+                echo "constraint: $P == $ver" >> $out/exactDeps/$P/cabal.config
+                echo "constraint: $P installed" >> $out/exactDeps/$P/cabal.config
+              fi
+            done
+
+            mkdir -p $out/evalDeps
+            for P in $(${nixpkgs-ghc}/bin/ghc-pkg list --simple-output | sed 's/-[0-9][0-9.]*//g'); do
+              touch $out/evalDeps/$P
+              if id=$(${nixpkgs-ghc}/bin/ghc-pkg field $P id --simple-output); then
+                echo "package-id $id" >> $out/evalDeps/$P
+              fi
+            done
+          '';
+    in
+    pkgs.symlinkJoin {
+      paths = [ nixpkgs-ghc exactDepOut ];
+
+      name = "${nixpkgs-ghc.name}-with-evalDeps";
+      inherit (nixpkgs-ghc) version;
+
+      # BLAH
+      inherit (haskell-nix-ghc) passthru;
+      # enableShared = true;
+      # targetPrefix = "";
+      # passthru.configured-src = haskell-nix-ghc.passthru.configured-src;
+      # useLLVM = false;
+    };
+
   o2 = (
     final: prev: {
       haskell-nix = prev.haskell-nix // {
         compiler = prev.haskell-nix.compiler // {
-          ghc8107 = prev.haskell.compiler.ghc8107 // {
-            # Add stuff not in nixpkgs ghc
-            configured-src = prev.haskell-nix.compiler.ghc8107.configured-src; # Needed for reinstallableLibGhc to work
-          };
+          ghc8107 = fix final prev "ghc8107";
         };
       };
     }
@@ -23,7 +72,8 @@ let
       haskell-nix.overlay
     ]
     ++
-    (if with-nixpkgs then [ o2 ] else [ ]);
+    (if with-nixpkgs then [ o2 ] else [ ])
+    ;
   };
 
   prj = pkgs.haskell-nix.cabalProject {

--- a/test/with-nixpkgs-ghc/default.nix
+++ b/test/with-nixpkgs-ghc/default.nix
@@ -1,0 +1,38 @@
+let
+
+  haskell-nix = import ../../default.nix { };
+  nixpkgs = haskell-nix.inputs.nixpkgs.outPath;
+
+  o2 = (
+    final: prev: {
+      haskell-nix = prev.haskell-nix // {
+        compiler = prev.haskell-nix.compiler // {
+          ghc8107 = prev.haskell.compiler.ghc8107 // {
+            # Add stuff not in nixpkgs ghc
+            configured-src = prev.haskell-nix.compiler.ghc8107.configured-src; # Needed for reinstallableLibGhc to work
+          };
+        };
+      };
+    }
+  );
+
+  pkgs = import nixpkgs {
+    system = __currentSystem;
+    inherit (haskell-nix) config;
+    overlays = [
+      # haskell-nix.overlays.haskell
+      # haskell-nix.overlays.tools
+      haskell-nix.overlay
+      o2
+    ];
+  };
+
+  prj = pkgs.haskell-nix.cabalProject {
+    src = ./empty;
+    cabalProject = "extra-packages: lens";
+    compiler-nix-name = "ghc8107";
+  };
+in
+
+prj.plan-nix
+


### PR DESCRIPTION
Addresses #1565, #1531

Test with

```
$ nix build -f test/with-nixpkgs-ghc/default.nix
```

You can compare with haskell.nix provided ghc doing
```
$ nix build -f test/with-nixpkgs-ghc/default.nix --arg with-nixpkgs false
```

It doesn't work yet.

```
error: builder for '/nix/store/kc6s5i90sg8f9vcc84bmba724v98rhzc-Cabal-lib-Cabal-3.6.3.0.drv' failed with exit code 1;
       last 10 log lines:
       > filepath >=1.3.0.1 && <1.5,
       > mtl >=2.1 && <2.3,
       > parsec >=3.1.13.0 && <3.2,
       > pretty >=1.1.1 && <1.2,
       > process >=1.1.0.2 && <1.7,
       > text >=1.2.3.0 && <1.3 || ==2.0.*,
       > time >=1.4.0.1 && <1.13,
       > transformers ==0.3.* || >=0.4.1.0 && <0.6,
       > unix >=2.6.0.0 && <2.8
       >
       For full logs, run 'nix log /nix/store/kc6s5i90sg8f9vcc84bmba724v98rhzc-Cabal-lib-Cabal-3.6.3.0.drv'.
error: 1 dependencies of derivation '/nix/store/cyj07lpxk87ild1lzppg3861bk1my5kh-hpack-exe-hpack-0.35.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/0dfk0qj15vml9b8x07lw80a0lb1h4wb5-hpack-lib-hpack-0.35.0-config.drv' failed to build
error: 1 dependencies of derivation '/nix/store/sddb67idq4lhkkk51z5nagjz3wp8qqcd-hpack-lib-hpack-0.35.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/yq8vnjaw5lwqsgj16bpwrq63lrwzx4qk-nix-tools-lib-nix-tools-0.1.0.0-config.drv' failed to build
error: 1 dependencies of derivation '/nix/store/k0di5bkr6zk309r361zrfhvzzw9ffzpa-nix-tools-lib-nix-tools-0.1.0.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/zsxmd6rbh0jjfjxvnjy5p0r7nfwlz5j1-nix-tools.drv' failed to build
error: 1 dependencies of derivation '/nix/store/dk9842nlgawms6a57ydnsxfkq29zmb6v-haskell-project-plan-to-nix-pkgs.drv' failed to build
```

