### PR TITLE
Add support to define materialized directory for compiler materialization

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -9,6 +9,7 @@ let readIfExists = src: fileName:
 in
 { name          ? src.name or null # optional name for better error messages
 , src
+, materialized-dir ? ../materialized
 , compiler-nix-name    # The name of the ghc compiler to use eg. "ghc884"
 , index-state   ? null # Hackage index-state, eg. "2019-10-10T00:00:00Z"
 , index-sha256  ? null # The hash of the truncated hackage index-state
@@ -335,7 +336,7 @@ let
   # when `checkMaterialization` is set.
   dummy-ghc-data =
     let
-      materialized = ../materialized/dummy-ghc + "/${ghc.targetPrefix}${ghc.name}-${pkgs.stdenv.buildPlatform.system}"
+      materialized = materialized-dir + "/dummy-ghc/${ghc.targetPrefix}${ghc.name}-${pkgs.stdenv.buildPlatform.system}"
         + pkgs.lib.optionalString (builtins.compareVersions ghc.version "8.10" < 0 && ghc.targetPrefix == "" && builtins.compareVersions pkgs.lib.version "22.05" < 0) "-old";
     in pkgs.haskell-nix.materialize ({
       sha256 = null;

--- a/lib/ghcjs-project.nix
+++ b/lib/ghcjs-project.nix
@@ -19,7 +19,7 @@
 # needed for configuring the source and booting the compiler
 # once it is built.  These are added to the `hsPkgs.shellFor`
 # of the project.
-{ pkgs }:
+{ pkgs, materialized-dir }:
 { src
 , compiler-nix-name
 , ghc ? pkgs.buildPackages.haskell-nix.compiler.${compiler-nix-name}
@@ -28,19 +28,19 @@
 , happy ? pkgs.haskell-nix.tool compiler-nix-name "happy" {
     index-state = pkgs.haskell-nix.internalHackageIndexState;
     version = "1.19.12";
-    materialized = ../materialized/ghcjs/happy + "/${compiler-nix-name}";
+    materialized = materialized-dir +"/ghcjs/happy/${compiler-nix-name}";
   }
 , alex ? pkgs.haskell-nix.tool compiler-nix-name "alex" {
     index-state = pkgs.haskell-nix.internalHackageIndexState;
     version = "3.2.5";
-    materialized = ../materialized/ghcjs/alex + "/${compiler-nix-name}";
+    materialized = materialized-dir + "/ghcjs/alex/${compiler-nix-name}";
   }
 , cabal-install ?
   if (builtins.compareVersions ghcjsVersion "8.10.0.0" >= 0)
   then pkgs.haskell-nix.tool compiler-nix-name "cabal" {
     index-state = pkgs.haskell-nix.internalHackageIndexState;
     version = "3.8.1.0";
-    materialized = ../materialized/ghcjs/cabal + "/${compiler-nix-name}";
+    materialized = materialized-dir + "/ghcjs/cabal/${compiler-nix-name}";
   }
   else pkgs.haskell-nix.tool compiler-nix-name "cabal" {
     index-state = pkgs.haskell-nix.internalHackageIndexState;
@@ -53,7 +53,7 @@
       packages: .
       constraints: Cabal <3.2.1.0, Cabal-syntax <0
     '';
-    materialized = ../materialized/ghcjs/cabal + "/${compiler-nix-name}";
+    materialized = materialized-dir + "/ghcjs/cabal/${compiler-nix-name}";
   }
 , ...
 }@args:
@@ -153,7 +153,7 @@ let
         pkg-def-extras = pkgs.lib.optional (!isGhcjs88) (hackage: {
           packages.happy.revision = hackage.happy."1.19.9".revisions.default;
         });
-        materialized = ../materialized + "/ghcjs/${compiler-nix-name}";
+        materialized = materialized-dir + "/ghcjs/${compiler-nix-name}";
         modules = [
             {
                 # we need ghc-boot in here for ghcjs.

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -872,7 +872,7 @@ final: prev: {
         # Like `cabalProject'`, but for building the GHCJS compiler.
         # This is exposed to allow GHCJS developers to work on the GHCJS
         # code in a nix-shell with `shellFor`.
-        ghcjsProject = import ../lib/ghcjs-project.nix { pkgs = final; };
+        ghcjsProject = import ../lib/ghcjs-project.nix { pkgs = final; materialized-dir = ./materialized; };
 
         # The functions that return a plan-nix often have a lot of dependencies
         # that could be GCed and also will not make it into hydra cache.


### PR DESCRIPTION
This allows outward facing users to define their own haskell.nix compilers and materialize them locally within their external project repo instead of modifying haskell.nix to include their own custom compilers.

