### PR TITLE
Fix `haskell.nix` evaluation with recent `nixpkgs`

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, buildPackages, evalPackages, stdenv, lib, haskellLib, ghc, compiler-nix-name, fetchurl, pkgconfig, nonReinstallablePkgs, hsPkgs, compiler, inputMap }:
+{ pkgs, buildPackages, evalPackages, stdenv, lib, haskellLib, ghc, compiler-nix-name, fetchurl, nonReinstallablePkgs, hsPkgs, compiler, inputMap }:
 
 let
   # Builds a single component of a package.

--- a/modules/project-common.nix
+++ b/modules/project-common.nix
@@ -15,7 +15,7 @@ with lib.types;
     };
     crossPlatforms = mkOption {
       type = unspecified;
-      default = p: [];
+      default = p: [ ];
     };
     # Default shell arguments
     shell = mkOption {
@@ -23,7 +23,7 @@ with lib.types;
         (import ./shell.nix { projectConfig = config; })
         { _module.args = { inherit (pkgs.haskell-nix) haskellLib; }; }
       ];
-      default = {};
+      default = { };
       description = ''
         Arguments to use for the default shell `p.shell` (these are passed to p.shellFor).
         For instance to include `cabal` and `ghcjs` support use
@@ -36,14 +36,14 @@ with lib.types;
         (import ./flake.nix { projectConfig = config; })
         { _module.args = { inherit (pkgs.haskell-nix) haskellLib; }; }
       ];
-      default = {};
+      default = { };
       description = ''
         Default arguments to use for the `p.flake`.
       '';
     };
     evalSystem = mkOption {
       type = str;
-      default = pkgs.pkgsBuildBuild.system;
+      default = pkgs.pkgsBuildBuild.stdenv.system;
       description = ''
         Specifies the system on which `cabal` and `nix-tools` should run.
         If not specified the `pkgsBuildBuild` system will be used.
@@ -55,8 +55,8 @@ with lib.types;
     evalPackages = mkOption {
       type = attrs;
       default =
-        if pkgs.pkgsBuildBuild.system == config.evalSystem
-          then pkgs.pkgsBuildBuild
+        if pkgs.pkgsBuildBuild.stdenv.system == config.evalSystem
+        then pkgs.pkgsBuildBuild
         else
           import pkgs.path {
             system = config.evalSystem;

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -34,11 +34,11 @@ let
     '';
     # For each architecture, what GHC version we should use for bootstrapping.
     buildBootstrapper =
-        if final.buildPlatform.isAarch64 && final.buildPlatform.isDarwin
+        if final.stdenv.buildPlatform.isAarch64 && final.stdenv.buildPlatform.isDarwin
         then {
             compilerNixName = "ghc8107";
         }
-        else if final.buildPlatform.isAarch64
+        else if final.stdenv.buildPlatform.isAarch64
         then {
             compilerNixName = "ghc883";
         }
@@ -48,13 +48,13 @@ let
     # AArch64 needs 8.8, but we prefer 8.6.5 for other 8.10 builds because of
     # * https://gitlab.haskell.org/ghc/ghc/-/issues/18143
     ghcForBuilding810
-      = if (final.buildPlatform.isAarch64 && final.buildPlatform.isDarwin)
+      = if (final.stdenv.buildPlatform.isAarch64 && final.stdenv.buildPlatform.isDarwin)
           then final.buildPackages.buildPackages.haskell-nix.bootstrap.compiler.ghc8107
-        else if (final.buildPlatform.isAarch64 || final.targetPlatform.isAarch64)
+        else if (final.stdenv.buildPlatform.isAarch64 || final.stdenv.targetPlatform.isAarch64)
           then final.buildPackages.buildPackages.haskell-nix.compiler.ghc884
         else final.buildPackages.buildPackages.haskell-nix.compiler.ghc865;
     ghcForBuilding90
-      = if (final.buildPlatform.isAarch64 && final.buildPlatform.isDarwin)
+      = if (final.stdenv.buildPlatform.isAarch64 && final.stdenv.buildPlatform.isDarwin)
           then final.buildPackages.buildPackages.haskell-nix.compiler.ghc8107
           else final.buildPackages.buildPackages.haskell-nix.compiler.ghc884;
     latestVer = {
@@ -71,9 +71,9 @@ let
         bootstrapGhc = final.buildPackages.haskell-nix.bootstrap.compiler."${buildBootstrapper.compilerNixName}";
       in
       if builtins.compareVersions x.src-spec.version bootstrapGhc.version < 0 then
-          throw "Desired GHC (${x.src-spec.version}) is older than the bootstrap GHC (${bootstrapGhc.version}) for this platform (${final.targetPlatform.config})."
+          throw "Desired GHC (${x.src-spec.version}) is older than the bootstrap GHC (${bootstrapGhc.version}) for this platform (${final.stdenv.targetPlatform.config})."
       # There is no binary for aarch64-linux ghc 8.8.4 so don't warn about 8.8.3 not being the latest version
-      else if x.src-spec.version == "8.8.3" && (final.targetPlatform.isAarch64 || final.buildPlatform.isAarch64)
+      else if x.src-spec.version == "8.8.3" && (final.stdenv.targetPlatform.isAarch64 || final.stdenv.buildPlatform.isAarch64)
         then x
       else if builtins.compareVersions x.src-spec.version latestVer.${v} < 0
         then __trace
@@ -195,8 +195,8 @@ in {
                 ++ fromUntil "8.10.2" "8.10.3" ./patches/ghc/MR3714-backported-to-8.10.2.patch
 
                 # See https://github.com/input-output-hk/haskell.nix/issues/1027
-                ++ final.lib.optional (versionAtLeast "8.10.3" && versionLessThan "9.2" && final.targetPlatform.isAarch64) ./patches/ghc/ghc-8.10-3434.patch
-                ++ final.lib.optional (versionAtLeast "9.2.1"  && versionLessThan "9.3" && final.targetPlatform.isAarch64) ./patches/ghc/ghc-9.2-3434.patch
+                ++ final.lib.optional (versionAtLeast "8.10.3" && versionLessThan "9.2" && final.stdenv.targetPlatform.isAarch64) ./patches/ghc/ghc-8.10-3434.patch
+                ++ final.lib.optional (versionAtLeast "9.2.1"  && versionLessThan "9.3" && final.stdenv.targetPlatform.isAarch64) ./patches/ghc/ghc-9.2-3434.patch
 
                 ++ fromUntil "8.10.1" "9.4"    ./patches/ghc/ghc-acrt-iob-func.patch
                 ++ fromUntil "8.10.1" "9.4"    ./patches/ghc/ghc-mprotect-nonzero-len.patch
@@ -208,14 +208,14 @@ in {
                 ++ fromUntil "9.2"    "9.3"    ./patches/ghc/ghc-9.2-Cabal-3886.patch
 
                 ++ fromUntil "8.10.3" "8.10.5" ./patches/ghc/ghc-8.10.3-rts-make-markLiveObject-thread-safe.patch
-                ++ final.lib.optionals final.targetPlatform.isWindows
+                ++ final.lib.optionals final.stdenv.targetPlatform.isWindows
                   (fromUntil "8.10.4" "9.3"    ./patches/ghc/ghc-8.10-z-drive-fix.patch)
                 ++ fromUntil "8.6.5"  "9.4"    ./patches/ghc/ghc-8.10-windows-add-dependent-file.patch
                 ++ fromUntil "8.10.1" "9.0"    ./patches/ghc/Cabal-unbreak-GHCJS.patch
                 ++ until              "8.10.5" ./patches/ghc/AC_PROG_CC_99.patch
                 ++ fromUntil "9.0.1"  "9.0.2"  ./patches/ghc/AC_PROG_CC_99.patch
                 ++ fromUntil "8.10.5" "8.10.6" ./patches/ghc/ghc-8.10.5-add-rts-exports.patch
-                ++ final.lib.optionals final.hostPlatform.isDarwin
+                ++ final.lib.optionals final.stdenv.hostPlatform.isDarwin
                   (fromUntil "8.10.5" "8.10.6" ./patches/ghc/ghc-8.10.5-darwin-allocateExec.patch)
                 ++ until              "8.10.6" ./patches/ghc/Sphinx_Unicode_Error.patch
                 ++ fromUntil "9.0.2"  "9.2.2"  ./patches/ghc/ghc-9.2.1-xattr-fix.patch      # Problem was backported to 9.0.2
@@ -227,18 +227,18 @@ in {
                 ++ fromUntil "8.10"   "9.1"    ./patches/ghc/issue-18708.patch              # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6554
                 ++ fromUntil "9.2.2"  "9.3"    ./patches/ghc/ghc-9.2.2-fix-warnings-building-with-self.patch # https://gitlab.haskell.org/ghc/ghc/-/commit/c41c478eb9003eaa9fc8081a0039652448124f5d
                 ++ fromUntil "8.6.5"  "9.5"    ./patches/ghc/ghc-hpc-response-files.patch   # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/8194
-                ++ final.lib.optionals (final.targetPlatform.isWindows) (fromUntil "9.4.1"  "9.5"    ./patches/ghc/ghc-9.4-hadrian-win-cross.patch)
+                ++ final.lib.optionals (final.stdenv.targetPlatform.isWindows) (fromUntil "9.4.1"  "9.5"    ./patches/ghc/ghc-9.4-hadrian-win-cross.patch)
 
                 # the following is a partial reversal of https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4391, to address haskell.nix#1227
-                ++ final.lib.optional (versionAtLeast "8.10.6" && versionLessThan "9.0" && final.targetPlatform.isAarch64) ./patches/ghc/mmap-next.patch
-                ++ final.lib.optional (versionAtLeast "8.10.6" && versionLessThan "9.0" && final.targetPlatform.isAarch64) ./patches/ghc/m32_alloc.patch
-                ++ final.lib.optional (versionAtLeast "8.10.6" && versionLessThan "9.0" && final.targetPlatform.isAndroid) ./patches/ghc/rts-android-jemalloc-qemu.patch
-                ++ final.lib.optional (versionAtLeast "8.10.6" && versionLessThan "9.0" && final.targetPlatform.isAndroid) ./patches/ghc/stack-protector-symbols.patch
-                ++ final.lib.optional (versionAtLeast "8.10.6" && versionLessThan "9.0" && final.targetPlatform.isAndroid) ./patches/ghc/libraries-prim-os-android.patch
-                ++ final.lib.optional (versionAtLeast "8.10.6" && versionLessThan "9.0" && final.targetPlatform.isAndroid) ./patches/ghc/ghc-rts-linker-condbr.patch
-                ++ final.lib.optional (versionAtLeast "8.10.6" && versionLessThan "9.0" && final.targetPlatform.isAndroid) ./patches/ghc/ghc-8.10.7-linker-weak-and-common.patch
-                ++ final.lib.optional (versionAtLeast "8.10.6" && versionLessThan "9.0" && final.targetPlatform.isAndroid) ./patches/ghc/libc-memory-symbols.patch
-                ++ final.lib.optional (versionAtLeast "8.10.6" && versionLessThan "9.0" && final.targetPlatform.isAndroid) ./patches/ghc/android-base-needs-iconv.patch
+                ++ final.lib.optional (versionAtLeast "8.10.6" && versionLessThan "9.0" && final.stdenv.targetPlatform.isAarch64) ./patches/ghc/mmap-next.patch
+                ++ final.lib.optional (versionAtLeast "8.10.6" && versionLessThan "9.0" && final.stdenv.targetPlatform.isAarch64) ./patches/ghc/m32_alloc.patch
+                ++ final.lib.optional (versionAtLeast "8.10.6" && versionLessThan "9.0" && final.stdenv.targetPlatform.isAndroid) ./patches/ghc/rts-android-jemalloc-qemu.patch
+                ++ final.lib.optional (versionAtLeast "8.10.6" && versionLessThan "9.0" && final.stdenv.targetPlatform.isAndroid) ./patches/ghc/stack-protector-symbols.patch
+                ++ final.lib.optional (versionAtLeast "8.10.6" && versionLessThan "9.0" && final.stdenv.targetPlatform.isAndroid) ./patches/ghc/libraries-prim-os-android.patch
+                ++ final.lib.optional (versionAtLeast "8.10.6" && versionLessThan "9.0" && final.stdenv.targetPlatform.isAndroid) ./patches/ghc/ghc-rts-linker-condbr.patch
+                ++ final.lib.optional (versionAtLeast "8.10.6" && versionLessThan "9.0" && final.stdenv.targetPlatform.isAndroid) ./patches/ghc/ghc-8.10.7-linker-weak-and-common.patch
+                ++ final.lib.optional (versionAtLeast "8.10.6" && versionLessThan "9.0" && final.stdenv.targetPlatform.isAndroid) ./patches/ghc/libc-memory-symbols.patch
+                ++ final.lib.optional (versionAtLeast "8.10.6" && versionLessThan "9.0" && final.stdenv.targetPlatform.isAndroid) ./patches/ghc/android-base-needs-iconv.patch
                 ;
         in ({
             ghc844 = final.callPackage ../compiler/ghc (traceWarnOld "8.4" {
@@ -418,7 +418,7 @@ in {
             ghc884 = final.callPackage ../compiler/ghc (traceWarnOld "8.8" {
                 extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc884; };
 
-                bootPkgs = bootPkgs // final.lib.optionalAttrs (!final.buildPlatform.isAarch64 && final.targetPlatform.isAarch64) {
+                bootPkgs = bootPkgs // final.lib.optionalAttrs (!final.stdenv.buildPlatform.isAarch64 && final.stdenv.targetPlatform.isAarch64) {
                   ghc = final.buildPackages.buildPackages.haskell-nix.compiler.ghc884;
                 };
                 inherit sphinx installDeps;
@@ -729,7 +729,7 @@ in {
                 extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc941; };
 
                 bootPkgs = bootPkgsGhc94 // {
-                  ghc = if final.buildPlatform != final.targetPlatform
+                  ghc = if final.stdenv.buildPlatform != final.stdenv.targetPlatform
                     then final.buildPackages.buildPackages.haskell-nix.compiler.ghc941
                     else final.buildPackages.buildPackages.haskell-nix.compiler.ghc902;
                 };
@@ -751,7 +751,7 @@ in {
                 extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc942; };
 
                 bootPkgs = bootPkgsGhc94 // {
-                  ghc = if final.buildPlatform != final.targetPlatform
+                  ghc = if final.stdenv.buildPlatform != final.stdenv.targetPlatform
                     then final.buildPackages.buildPackages.haskell-nix.compiler.ghc942
                     else final.buildPackages.buildPackages.haskell-nix.compiler.ghc902;
                 };
@@ -773,7 +773,7 @@ in {
                 extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc943; };
 
                 bootPkgs = bootPkgsGhc94 // {
-                  ghc = if final.buildPlatform != final.targetPlatform
+                  ghc = if final.stdenv.buildPlatform != final.stdenv.targetPlatform
                     then final.buildPackages.buildPackages.haskell-nix.compiler.ghc943
                     else final.buildPackages.buildPackages.haskell-nix.compiler.ghc902;
                 };
@@ -795,7 +795,7 @@ in {
                 extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc944; };
 
                 bootPkgs = bootPkgsGhc94 // {
-                  ghc = if final.buildPlatform != final.targetPlatform
+                  ghc = if final.stdenv.buildPlatform != final.stdenv.targetPlatform
                     then final.buildPackages.buildPackages.haskell-nix.compiler.ghc944
                     else final.buildPackages.buildPackages.haskell-nix.compiler.ghc902;
                 };
@@ -818,7 +818,7 @@ in {
                 extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc810420210212; };
 
                 bootPkgs = bootPkgs // {
-                  ghc = if (final.buildPlatform.isAarch64 || final.targetPlatform.isAarch64)
+                  ghc = if (final.stdenv.buildPlatform.isAarch64 || final.stdenv.targetPlatform.isAarch64)
                         then final.buildPackages.buildPackages.haskell-nix.compiler.ghc884
                         else final.buildPackages.buildPackages.haskell-nix.compiler.ghc865;
                 };
@@ -838,8 +838,8 @@ in {
                 # Avoid clashes with normal ghc8104
                 ghc-version = "8.10.4.20210212";
             };
-        } // final.lib.optionalAttrs (final.targetPlatform.isGhcjs or false) (
-         if final.hostPlatform.isGhcjs
+        } // final.lib.optionalAttrs (final.stdenv.targetPlatform.isGhcjs or false) (
+         if final.stdenv.hostPlatform.isGhcjs
            then throw "An attempt was made to build ghcjs with ghcjs (perhaps use `buildPackages` when refering to ghc)"
            else
                 # This will inject `exactDeps` and `envDeps`  into the ghcjs

--- a/overlays/cabal-pkg-config.nix
+++ b/overlays/cabal-pkg-config.nix
@@ -36,7 +36,7 @@ final: prev:
       pkgconfigPkgs =
         final.lib.filterAttrs (name: p: __length p > 0 && getVersion (__head p) != "")
           (import ../lib/pkgconf-nixpkgs-map.nix final);
-    in prev.pkgconfig.overrideAttrs (attrs:
+    in prev.pkg-config.overrideAttrs (attrs:
       let
         # These vars moved from attrs to attrs.env in nixpkgs adc8900df1758eda56abd68f7d781d1df74fa531
         # Support both for the time being.
@@ -87,7 +87,7 @@ final: prev:
   #
   # See https://github.com/input-output-hk/haskell.nix/issues/1642
   #
-  cabalPkgConfigWrapper = prev.pkgconfig.overrideAttrs (attrs: (
+  cabalPkgConfigWrapper = prev.pkg-config.overrideAttrs (attrs: (
   let
     # These vars moved from attrs to attrs.env in nixpkgs adc8900df1758eda56abd68f7d781d1df74fa531
     # Support both for the time being.

--- a/overlays/ghc-packages.nix
+++ b/overlays/ghc-packages.nix
@@ -44,9 +44,9 @@ let
           materialized = materialized-dir + "/ghc-boot-packages-nix/${ghcName +
               # The 3434.patch we apply to fix linking on arm systems changes ghc-prim.cabal
               # so it needs its own materialization.
-              final.lib.optionalString final.targetPlatform.isAarch64 "-aarch64"
+              final.lib.optionalString final.stdenv.targetPlatform.isAarch64 "-aarch64"
               # GHCJS bytestring and libiserv versions differs
-              + final.lib.optionalString final.hostPlatform.isGhcjs "-ghcjs"
+              + final.lib.optionalString final.stdenv.hostPlatform.isGhcjs "-ghcjs"
             }";
         } // final.lib.optionalAttrs unchecked {
           checkMaterialization = false;

--- a/overlays/ghcjs-asterius-triple.nix
+++ b/overlays/ghcjs-asterius-triple.nix
@@ -17,7 +17,7 @@ final: prev: prev.lib.recursiveUpdate prev {
             platform = {};
         };
     };
-    # gcc = if final.targetPlatform.isGhcjs then null else prev.gcc;
+    # gcc = if final.stdenv.targetPlatform.isGhcjs then null else prev.gcc;
     lib.systems.parse = with final.lib.systems.parse; {
         cpuTypes.js = cpuTypes.wasm32 // { name = "js"; family = "js"; };
         kernels.ghcjs = kernels.none // { name = "ghcjs"; };

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -181,7 +181,7 @@ final: prev: {
         snapshots = import ../snapshots.nix { inherit (final) lib ghc-boot-packages; inherit mkPkgSet stackage excludeBootPackages; };
         # Pick a recent LTS snapshot to be our "default" package set.
         haskellPackages =
-            if final.targetPlatform.isAarch64 && final.buildPlatform.isAarch64
+            if final.stdenv.targetPlatform.isAarch64 && final.stdenv.buildPlatform.isAarch64
             then snapshots."lts-15.13"
             else snapshots."lts-14.13";
 


### PR DESCRIPTION
Hi,

In our `haskell.nix` flake-based project, we're always careful to use the `haskell.nix`-provided `nixpkgs-unstable` pin to build our Haskell packages, because we want to take advantage of the IOG binary cache.

However, in the same flake, we also want to run some NixOS tests which use our Haskell packages. In recent months, `nixpkgs` has made this relatively easy to do (see https://nixos.org/manual/nixos/unstable/index.html#sec-call-nixos-test-outside-nixos). Until recently, we were able to make this work with `haskell.nix`'s `nixpkgs-unstable` pin with an ugly hack, but unfortunately, as of the most recent `nixpkgs-unstable` pin (`747927516efcb5e31ba03b7ff32f61f6d47e7d87`), our hack no longer works, for a few reasons:

* in `overlays/bootstrap.nix` (and elsewhere), `final.buildPlaform` and friends no longer exist.
* `pkgsBuildBuild.system` no longer exists.
* The `pkgconfig` alias has been removed (now only `pkg-config` exists).

I'm not suggesting that this PR is merged, as I confess that I don't really understand how `haskell.nix` works at this level of detail, and I was just blindly replacing various attributes with their obvious replacements, so it's possible that I've broken something else. But these changes do allow us now to use `nixos-lib.runTest`, and don't seem to adversely affect our ability to build our Haskell packages.

(I confess I'm a bit confused as to how `haskell.nix` builds at all with the `nixpkgs-unstable` pin. I suppose you all are careful not to use that pin to evaluate the project in your CI system?)
