### PR TITLE
remove references to `pmdk`

### DIFF
--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -4119,12 +4119,6 @@ pkgs:
     "ply-boot-client" = [ "plymouth" ];
     "ply-splash-core" = [ "plymouth" ];
     "ply-splash-graphics" = [ "plymouth" ];
-    "libpmem2" = [ "pmdk" ];
-    "libpmemblk" = [ "pmdk" ];
-    "libpmemlog" = [ "pmdk" ];
-    "libpmemobj" = [ "pmdk" ];
-    "libpmem" = [ "pmdk" ];
-    "libpmempool" = [ "pmdk" ];
     "pmix" = [ "pmix" ];
     "pm-utils" = [ "pmutils" ];
     "libpodofo" = [ "podofo" ];


### PR DESCRIPTION
In `nixpkgs`:
```
pmdk = throw "'pmdk' is discontinued, no further support or maintenance is planned by upstream"; 
# Added 2023-02-06
```
https://github.com/NixOS/nixpkgs/blob/9e56d6ec92c8fb4192f1392aa5c4101ad77f2070/pkgs/top-level/aliases.nix#L1230