### PR TITLE
Use ld.gold in dev shells

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -179,16 +179,7 @@ let
       [ "--with-gcc=${stdenv.cc.targetPrefix}cc"
       ] ++
       # BINTOOLS
-      (if stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid # might be better check to see if cc is clang/llvm?
-        # use gold as the linker on linux to improve link times
-        then [
-          "--with-ld=${stdenv.cc.bintools.targetPrefix}ld.gold"
-          "--ghc-option=-optl-fuse-ld=gold"
-          "--ld-option=-fuse-ld=gold"
-        ] else [
-          "--with-ld=${stdenv.cc.bintools.targetPrefix}ld"
-        ]
-      ) ++ [
+       [
         "--with-ar=${stdenv.cc.bintools.targetPrefix}ar"
         "--with-strip=${stdenv.cc.bintools.targetPrefix}strip"
       ]

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 2
+{ ifdLevel ? 3
 # Whether or not we are evaluating in restricted mode. This is true in Hydra, but not in Hercules.
 , restrictEval ? false
 , checkMaterialization ? false

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 3
+{ ifdLevel ? 1
 # Whether or not we are evaluating in restricted mode. This is true in Hydra, but not in Hercules.
 , restrictEval ? false
 , checkMaterialization ? false

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 1
+{ ifdLevel ? 2
 # Whether or not we are evaluating in restricted mode. This is true in Hydra, but not in Hercules.
 , restrictEval ? false
 , checkMaterialization ? false

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -299,6 +299,10 @@ stdenv.mkDerivation (rec {
         export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
         export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
         export STRIP="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}strip"
+    '' + lib.optionalString (targetPlatform == hostPlatform && useLdGold) 
+    # set LD explicitly if we want gold even if we aren't cross compiling
+    ''
+        export LD="ld.gold"
     '' + lib.optionalString (targetPlatform.isWindows) ''
         export DllWrap="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}dllwrap"
         export Windres="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}windres"

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -68,7 +68,7 @@ let self =
 , useLdGold ? 
     # might be better check to see if cc is clang/llvm?
     # use gold as the linker on linux to improve link times
-    # do not use it on musl due to a ld.gold bug.
+    # do not use it on musl due to a ld.gold bug. See: <https://sourceware.org/bugzilla/show_bug.cgi?id=22266>.
     (stdenv.targetPlatform.isLinux && !stdenv.targetPlatform.isAndroid && !stdenv.targetPlatform.isMusl) 
     || stdenv.targetPlatform.isAarch32
 

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -302,7 +302,7 @@ stdenv.mkDerivation (rec {
     '' + lib.optionalString (targetPlatform == hostPlatform && useLdGold) 
     # set LD explicitly if we want gold even if we aren't cross compiling
     ''
-        export LD="ld.gold"
+        export LD="${targetCC.bintools}/bin/ld.gold"
     '' + lib.optionalString (targetPlatform.isWindows) ''
         export DllWrap="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}dllwrap"
         export Windres="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}windres"

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -197,6 +197,7 @@ let
         "CFLAGS=-fuse-ld=gold"
         "CONF_GCC_LINKER_OPTS_STAGE1=-fuse-ld=gold"
         "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"
+        "CONF_LD_LINKER_OPTS_STAGE2=-fuse-ld=gold" # See: <https://gitlab.haskell.org/ghc/ghc/-/issues/22550#note_466656>
     ] ++ lib.optionals enableDWARF [
         "--enable-dwarf-unwind"
         "--with-libdw-includes=${lib.getDev elfutils}/include"

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -68,7 +68,8 @@ let self =
 , useLdGold ? 
     # might be better check to see if cc is clang/llvm?
     # use gold as the linker on linux to improve link times
-    (stdenv.targetPlatform.isLinux && !stdenv.targetPlatform.isAndroid) 
+    # do not use it on musl due to a ld.gold bug.
+    (stdenv.targetPlatform.isLinux && !stdenv.targetPlatform.isAndroid && !stdenv.targetPlatform.isMusl) 
     || stdenv.targetPlatform.isAarch32
 
 , ghc-version ? src-spec.version


### PR DESCRIPTION
Previously we built GHC with ld.gold for aarch32, and forced use of ld.gold in the component builder for non-android linux. Though this meant that ld.gold wasn't used in dev shells on non-android linux as that uses a different code-path.

This patch unifies all of this logic in one place: in the GHC build script.
If GHC is fed `LD` as being ld.gold then it will write that into its settings and try to use that at runtime.

So, we also build GHC with ld.gold on non-android linux, meaning that it uses that both in component builds and dev shells.

---

Unfortunately this will lead to mass rebuilds. I experimented with just duplicating the component logic in the ghcWrapper used in dev shells, but this led to mass rebuilds anyway, so, I think we might as well do the more principled thing.

---

Resolves #1866  