### PR TITLE
gold only on linux, !android, !musl

### DIFF
--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -70,7 +70,6 @@ let self =
     # use gold as the linker on linux to improve link times
     # do not use it on musl due to a ld.gold bug. See: <https://sourceware.org/bugzilla/show_bug.cgi?id=22266>.
     (stdenv.targetPlatform.isLinux && !stdenv.targetPlatform.isAndroid && !stdenv.targetPlatform.isMusl) 
-    || stdenv.targetPlatform.isAarch32
 
 , ghc-version ? src-spec.version
 , ghc-version-date ? null


### PR DESCRIPTION
We should not enable gold on aarch32 for every target platform. I believe the target platform gates are enough.

This fixes an oversight in #1868 