### PR TITLE
ghc-lib-parser-9.6: add global unique counters patch

### DIFF
--- a/modules/configuration-nix.nix
+++ b/modules/configuration-nix.nix
@@ -72,7 +72,7 @@ in {
   packages.ghc-lib-parser.patches = [
     (fromUntil "8.10.0.0" "9.2" ../overlays/patches/ghc-lib-parser-8.10-global-unique-counters-in-rts.patch)
     (fromUntil "9.2.0.0" "9.3" ../overlays/patches/ghc-lib-parser-9.2-global-unique-counters-in-rts.patch)
-    (fromUntil "9.4.0.0" "9.5" ../overlays/patches/ghc-lib-parser-9.4-global-unique-counters-in-rts.patch)
+    (fromUntil "9.4.0.0" "9.7" ../overlays/patches/ghc-lib-parser-9.4-global-unique-counters-in-rts.patch)
   ];
 
   # See https://github.com/haskell-nix/hnix/pull/1053


### PR DESCRIPTION
ghc-lib-parser-9.6 compiles with GHC 9.2, so extending #1580 is necessary.