### PR TITLE
Disable his -callhierachy for 8.10.7

### DIFF
--- a/modules/hackage-quirks.nix
+++ b/modules/hackage-quirks.nix
@@ -65,7 +65,7 @@ in [
         constraints: hls-fourmolu-plugin <1.1.1.0, hls-rename-plugin <1.0.2.0, hls-stan-plugin <1.0.1.0
       ''
       # TODO Remove this flag once the hls-call-hierarchy-plugin is updated in hackage to work with ghc 9.2
-      + lib.optionalString (__elem config.compiler-nix-name ["ghc921" "ghc922" "ghc923" "ghc924" "ghc925" "ghc926" "ghc927"]) ''
+      + lib.optionalString (__elem config.compiler-nix-name ["ghc8107" "ghc921" "ghc922" "ghc923" "ghc924" "ghc925" "ghc926" "ghc927"]) ''
         package haskell-language-server
           flags: -callhierarchy
       '');


### PR DESCRIPTION
It's broken
```
Using index-state 2023-03-21T00:00:00Z
Warning: The package list for 'hackage.haskell.org' is 19437 days old.
Run 'cabal update' to get the latest list of available packages.
Resolving dependencies...
make-install-plan: dieVerbatim: user error (Error: make-install-plan: Could not resolve dependencies:
[__0] trying: haskell-language-server-1.9.1.0 (user goal)
[__1] trying: haskell-language-server:+callhierarchy
[__2] next goal: hls-call-hierarchy-plugin (dependency of
haskell-language-server +callhierarchy)
[__2] rejecting: hls-call-hierarchy-plugin-1.2.0.0 (conflict:
haskell-language-server +callhierarchy => hls-call-hierarchy-plugin^>=1.1)
[__2] trying: hls-call-hierarchy-plugin-1.1.0.0
[__3] next goal: hls-plugin-api (dependency of haskell-language-server)
[__3] rejecting: hls-plugin-api-1.6.0.0 (conflict: hls-call-hierarchy-plugin
=> hls-plugin-api^>=1.5)
[__3] rejecting: hls-plugin-api-1.5.0.0 (conflict: haskell-language-server =>
hls-plugin-api^>=1.6)
[__3] skipping: hls-plugin-api-1.4.0.0, hls-plugin-api-1.3.0.0,
hls-plugin-api-1.2.0.2, hls-plugin-api-1.2.0.1, hls-plugin-api-1.2.0.0,
hls-plugin-api-1.1.0.2, hls-plugin-api-1.1.0.1, hls-plugin-api-1.1.0.0,
hls-plugin-api-1.0.0.0, hls-plugin-api-0.7.1.0, hls-plugin-api-0.7.0.0,
hls-plugin-api-0.6.0.0, hls-plugin-api-0.5.0.1, hls-plugin-api-0.5.0.0,
hls-plugin-api-0.4.1.0, hls-plugin-api-0.4.0.0 (has the same characteristics
that caused the previous version to fail: excluded by constraint '^>=1.6' from
'haskell-language-server')
[__3] fail (backjumping, conflict set: haskell-language-server,
hls-call-hierarchy-plugin, hls-plugin-api)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: haskell-language-server,
hls-plugin-api, hls-call-hierarchy-plugin,
haskell-language-server:callhierarchy
Try running with --minimize-conflict-set to improve the error message.
)
```