### PR TITLE
Update flake utils to include cross compilers

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1679009484,
-        "narHash": "sha256-DK/NWnmuhpPZ19pl+c3tfutDpXo6pMD2/zIIbk8Xpws=",
+        "lastModified": 1679360468,
+        "narHash": "sha256-LGnza3cfXF10Biw3ZTg0u9o9t7s680Ww200t5KkHTh8=",
         "owner": "hamishmack",
         "repo": "flake-utils",
-        "rev": "8a0234caf748d84b75c4db0f9c6a2423e8fe4ea8",
+        "rev": "e1ea268ff47ad475443dbabcd54744b4e5b9d4f5",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -187,15 +187,16 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
+        "lastModified": 1679009484,
+        "narHash": "sha256-DK/NWnmuhpPZ19pl+c3tfutDpXo6pMD2/zIIbk8Xpws=",
+        "owner": "hamishmack",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "8a0234caf748d84b75c4db0f9c6a2423e8fe4ea8",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
+        "owner": "hamishmack",
+        "ref": "hkm/nested-hydraJobs",
         "repo": "flake-utils",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     nixpkgs-2211 = { url = "github:NixOS/nixpkgs/nixpkgs-22.11-darwin"; };
     nixpkgs-unstable = { url = "github:NixOS/nixpkgs/nixpkgs-unstable"; };
     flake-compat = { url = "github:input-output-hk/flake-compat/hkm/gitlab-fix"; flake = false; };
-    flake-utils = { url = "github:numtide/flake-utils"; };
+    flake-utils = { url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs"; };
     tullia = {
       url = "github:input-output-hk/tullia";
       inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Currently they are excluded because of the way flake-utils treats hydraJobs.  This change also makes hydra-eval-jobs run around 4x faster (10m vs 40m).