### PR TITLE
hix: use project' for lazier flake and no hardcoding evalSystem

### DIFF
--- a/hix/init/flake.nix
+++ b/hix/init/flake.nix
@@ -19,7 +19,8 @@
             hixProject =
               final.haskell-nix.hix.project {
                 src = ./.;
-                evalSystem = "EVAL_SYSTEM";
+                # uncomment with your current system for `nix flake show` to work:
+                #evalSystem = "EVAL_SYSTEM";
               };
           })
         ];

--- a/nix-tools/flake.nix
+++ b/nix-tools/flake.nix
@@ -17,7 +17,6 @@
             hixProject =
               final.haskell-nix.hix.project {
                 src = ./.;
-                evalSystem = "x86_64-darwin";
                 compiler-nix-name = __head compilers;
               };
           })

--- a/overlays/hix.nix
+++ b/overlays/hix.nix
@@ -35,7 +35,7 @@ final: prev: { haskell-nix = prev.haskell-nix // { hix = {
           then {}
           else import src;
       projectDefaults = importDefaults (toString (src.origSrcSubDir or src) + "/nix/hix.nix");
-    in final.haskell-nix.project [
+    in final.haskell-nix.project' [
             (import ../modules/hix-project.nix)
             projectDefaults
             commandArgs'


### PR DESCRIPTION
 hard-coding a particular `evalSystem` is not portable,
 and removing `evalSystem` forced users to have builders for each supported system.

 (with this commit `evalSystem` is now only necessary for `nix flake show`).

Current workaround until this is merged: https://github.com/input-output-hk/cardano-automation/commit/628f135d243d4a9e388c187e4c6179246038ee72