### PR TITLE
Use ld.gold on musl

### DIFF
--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -66,8 +66,7 @@ let self =
 , useLdGold ? 
     # might be better check to see if cc is clang/llvm?
     # use gold as the linker on linux to improve link times
-    # do not use it on musl due to a ld.gold bug. See: <https://sourceware.org/bugzilla/show_bug.cgi?id=22266>.
-    (stdenv.targetPlatform.isLinux && !stdenv.targetPlatform.isAndroid && !stdenv.targetPlatform.isMusl) 
+    (stdenv.targetPlatform.isLinux && !stdenv.targetPlatform.isAndroid) 
 
 , ghc-version ? src-spec.version
 , ghc-version-date ? null


### PR DESCRIPTION
#1868 broke building with `pkgsCross.musl64` according to this comment: https://github.com/input-output-hk/haskell.nix/pull/1868#issuecomment-1478842067

The reason seems to be that it requires musl. This MR removes the special casing for musl, so it will now use ld.gold for x86_64-linux.

I tried to test this locally but couldn't get `pkgsCross.musl64.haskell-nix.compiler.ghc925` to build but I think that's independent of this. Hopefully someone else has better luck. I found that `targetPackages` was empty so nothing built. I think this must be something to do with how I was trying to build.