### PR TITLE
`index-state` was renamed `index-state-max`

### DIFF
--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -692,7 +692,7 @@ final: prev: {
                   inherit (pkg-set.config) hsPkgs;
                   inherit pkg-set;
                   plan-nix = callProjectResults.projectNix;
-                  inherit (callProjectResults) index-state;
+                  inherit (callProjectResults) index-state-max;
                   tool = final.buildPackages.haskell-nix.tool' evalPackages pkg-set.config.compiler.nix-name;
                   tools = final.buildPackages.haskell-nix.tools' evalPackages pkg-set.config.compiler.nix-name;
                   roots = final.haskell-nix.roots pkg-set.config.compiler.nix-name;


### PR DESCRIPTION
This was done as it no longer reflects the `index-state:` in the `cabal.project` it is the `index-state` passed into the project (if there was one) or the latest `hackage.nix` updates `index-state`.

Fixes #1904