### PR TITLE
Remove input map from the builder

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -1,3 +1,18 @@
+# While creating the nix build plan, we take care to create package derivations
+# that do not include any reference to the plan itself or how it is created.
+#
+# This allows haskell.nix to share packages between plans (at least when they
+# have identical dependencies). If the package derivations included the hash of
+# the plan derivation, different plans would always produce different packages
+# and there could not be any sharing of packages between plans.
+#
+# Any wrangling of the project dependencies (e.g. fetching package indices,
+# source-repository-packages or any other asset required for building) *has* to
+# be performed during planning. The nix build plan will import any remote asset
+# through a fixed-output derivations (i.e. a call to a fetcher).
+#
+# tl;dr: the builder must not re-introduce any reference to the build plan.
+
 { pkgs, buildPackages, evalPackages, stdenv, lib, haskellLib, ghc, compiler-nix-name, fetchurl, nonReinstallablePkgs, hsPkgs, compiler }:
 
 let

--- a/builder/default.nix
+++ b/builder/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, buildPackages, evalPackages, stdenv, lib, haskellLib, ghc, compiler-nix-name, fetchurl, nonReinstallablePkgs, hsPkgs, compiler, inputMap }:
+{ pkgs, buildPackages, evalPackages, stdenv, lib, haskellLib, ghc, compiler-nix-name, fetchurl, nonReinstallablePkgs, hsPkgs, compiler }:
 
 let
   # Builds a single component of a package.
@@ -85,7 +85,7 @@ in {
   # Build a Haskell package from its config.
   # TODO: this pkgs is the adjusted pkgs, but pkgs.pkgs is unadjusted
   build-package = haskellLib.weakCallPackage pkgs ./hspkg-builder.nix {
-    inherit haskellLib ghc compiler-nix-name comp-builder setup-builder inputMap;
+    inherit haskellLib ghc compiler-nix-name comp-builder setup-builder;
   };
 
   inherit shellFor makeConfigFiles;

--- a/builder/hspkg-builder.nix
+++ b/builder/hspkg-builder.nix
@@ -1,4 +1,4 @@
-{ pkgs, buildPackages, stdenv, lib, haskellLib, ghc, compiler-nix-name, fetchurl, runCommand, comp-builder, setup-builder, inputMap }:
+{ pkgs, buildPackages, stdenv, lib, haskellLib, ghc, compiler-nix-name, fetchurl, runCommand, comp-builder, setup-builder }:
 
 config:
 { flags
@@ -24,24 +24,9 @@ let
       "ghc902/stm-2.5.0.0" = "/libraries/stm";
       "ghc902/filepath-1.4.2.1" = "/libraries/filepath";
     }."${compiler-nix-name}/${name}" or null;
-  baseUrlMatch =
-    let
-      # All the urls that should contain the source
-      srcUrls = lib.optional (pkg.src ? url) pkg.src.url ++ pkg.src.urls or [];
-    in __head (
-        # Look for one that matches the expected pattern
-        builtins.filter (x: x != null) (
-          map (__match "(.*)/package/([^/]*)") srcUrls)
-        # Return null if none do
-        ++ [null]);
   src =
     if bundledSrc != null
       then ghc.configured-src + bundledSrc
-    else if baseUrlMatch != null && inputMap ? ${__head baseUrlMatch}
-      then
-        # Use the copy of the package that is in the inputMap for this
-        # repository.
-        inputMap.${__head baseUrlMatch} + "/package/${__elemAt baseUrlMatch 1}"
     else pkg.src;
 
   cabalFile = if package-description-override == null || bundledSrc != null then null else package-description-override;

--- a/modules/cabal-project.nix
+++ b/modules/cabal-project.nix
@@ -111,6 +111,7 @@ in {
       description = ''
         Specifies the contents of urls in the cabal.project file.
         The `.rev` attribute is checked against the `tag` for `source-repository-packages`.
+        # FIXME is the following still relevant?
         For `revision` blocks the `inputMap.<url>` will be used and
         they `.tar.gz` for the `packages` used will also be looked up
         in the `inputMap`.

--- a/modules/component-driver.nix
+++ b/modules/component-driver.nix
@@ -4,7 +4,7 @@ let
     inherit haskellLib;
     ghc = config.ghc.package;
     compiler-nix-name = config.compiler.nix-name;
-    inherit (config) nonReinstallablePkgs hsPkgs compiler evalPackages inputMap;
+    inherit (config) nonReinstallablePkgs hsPkgs compiler evalPackages;
   };
 
 in
@@ -94,11 +94,6 @@ in
     ++ lib.optionals (
       __elem config.compiler.nix-name ["ghc941" "ghc942" "ghc943" "ghc944" "ghc961" "ghc96020230302"]) [
       "system-cxx-std-lib" ];
-
-  options.inputMap = lib.mkOption {
-    type = lib.types.attrsOf lib.types.unspecified;
-    default = {};
-  };
 
   options.hsPkgs = lib.mkOption {
     type = lib.types.unspecified;

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -650,7 +650,7 @@ final: prev: {
         # plan-nix without building the project.
         cabalProject' =
           projectModule: haskellLib.evalProjectModule ../modules/cabal-project.nix projectModule (
-            { src, compiler-nix-name, compilerSelection, evalPackages, inputMap, ... }@args:
+            { src, compiler-nix-name, compilerSelection, evalPackages, ... }@args:
             let
               callProjectResults = callCabalProjectToNix args;
               plan-pkgs = importAndFilterProject {
@@ -683,7 +683,6 @@ final: prev: {
                           final.lib.mkDefault (args.compilerSelection final.buildPackages).${compiler-nix-name};
                       compiler.nix-name = final.lib.mkForce args.compiler-nix-name;
                       evalPackages = final.lib.mkDefault evalPackages;
-                      inputMap = final.lib.mkDefault inputMap;
                     } ];
                   extra-hackages = args.extra-hackages or [] ++ callProjectResults.extra-hackages;
                 };


### PR DESCRIPTION
This is an attempt to fix #1906.

(Not so-) Brief summary:

We take care while planning to create package derivations that do not include any reference to the plan itself or how it is created. This allows haskell.nix to share packages between plans (at least when they have identical dependencies). If the derivation of the path iteself leaked into the package derivations in it, every plan would produce different package derivations and there coud be no sharing of packages between plans.

We end up breaking this separation when using non-Hackage repositories. Remeber than Hackage is wired directly into Haskell.nix through Hackage.nix, so a copy of its index is always available. For non-Hackage repositories instead, one has to pre-download the repo and make it available to an Haskell.nix project using the `inputMap` attribute.

E.g.
```nix
cabalProject {
  # ...
  inputMap = { "https://input-output-hk.github.io/cardano-haskell-packages" = CHaP; }; # CHaP is a store path
}
```

`lib/call-cabal-project-to-nix.nix` then uses this `inputMap` to pass both Hackage and the extra repositories to cabal so it can build a plan with all available packages. During this phase we make sure the package derivations do not include the store path of the repositories used to make the plan but refer to the package source _as they are available from the repository_. E.g. `cabal-files/cardano-prelude.nix` will have, not referring to the nix path `CHaP` above.

```
    src = (pkgs.lib).mkDefault (pkgs.fetchurl {
      url = "https://input-output-hk.github.io/cardano-haskell-packages/package/cardano-prelude-0.1.0.1.tar.gz";
      sha256 = "ff29d82288b4f3fbc2e3c9ea359b1c57d95a830f34537456f49e31021879228a";
      })
```

Now the plot twist :tornado: in the builder, we use again `inputMap` to replace the package sources with prefetched ones in the repo. If we have a copy of the repo in the store, we don't have to download those packages again right?

https://github.com/input-output-hk/haskell.nix/blob/58cbcc3fd5940366c190573a345d215e99a8db58/builder/hspkg-builder.nix#L37-L45

But in this way we have contaminated the package derivation with information about how we made the plan!

If you take the derivation use to build `cardano-prelude` above, it will now say:

```
❯ nix show-derivation /nix/store/vn7i39zr9lvwr98q1v4j2pf3z5nl4p2b-cardano-prelude-lib-cardano-prelude-0.1.0.1.drv
...
      "src": "/nix/store/jgwj5vpw3sd36m7qjb7vba3lmq28zvq4-source/package/cardano-prelude-0.1.0.1.tar.gz",
...
```

where `/nix/store/jgwj5vpw3sd36m7qjb7vba3lmq28zvq4-source` is exactly `CHaP`.

The consequence is what @michaelpj describes in #1906. Every time CHaP is changed all CHaP packages get rebuilt, even for an identical plan, because they now depend on the exact content of the repository. Even a small change in CHaP README will trigger a rebuild of all its packages. :sob: 

What I suggest here is to remove the use of inputMap in the builder. Currently it is only used for the lines above, but I am tempted to state that there should not be any use of inputMap in the builder *ever*. Any wrangling of the project dependencies should go thorugh the plan, which the builder blindly executes.

I have tested this against cardano-node and it seems to fix the immediate problem in #1906. I am testing whether this has an impact on project relying on srp's.


