### PR TITLE
Add Haskell Language Server Fixes

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -46,9 +46,9 @@ in rec {
       };
     } // pkgs.lib.optionalAttrs (__compareVersions haskell.compiler.${compiler-nix-name}.version "9.4" < 0) {
       stack = tool compiler-nix-name "stack" { version = "2.9.3"; inherit evalPackages; };
-      "hls-1.9.0.0" = tool compiler-nix-name "haskell-language-server" {
+      "hls-1.9.1.0" = tool compiler-nix-name "haskell-language-server" {
         inherit evalPackages;
-        version = "1.9.0.0";
+        version = "1.9.1.0";
       };
     } // pkgs.lib.optionalAttrs (__compareVersions haskell.compiler.${compiler-nix-name}.version "9.0" < 0) {
       "hls-1.8.0.0" = tool compiler-nix-name "haskell-language-server" {

--- a/build.nix
+++ b/build.nix
@@ -44,7 +44,7 @@ in rec {
         inherit evalPackages;
         version = "latest";
       };
-    } // pkgs.lib.optionalAttrs (__compareVersions haskell.compiler.${compiler-nix-name}.version "9.4" < 0) {
+    } // pkgs.lib.optionalAttrs (__compareVersions haskell.compiler.${compiler-nix-name}.version "9.6" < 0) {
       stack = tool compiler-nix-name "stack" { version = "2.9.3"; inherit evalPackages; };
       "hls-1.9.1.0" = tool compiler-nix-name "haskell-language-server" {
         inherit evalPackages;

--- a/build.nix
+++ b/build.nix
@@ -40,14 +40,20 @@ in rec {
             "ghc8107" = "3.4.1";
           }.${compiler-nix-name} or "latest";
       };
-    } // pkgs.lib.optionalAttrs (__compareVersions haskell.compiler.${compiler-nix-name}.version "9.4" < 0) {
-      stack = tool compiler-nix-name "stack" { version = "2.9.3"; inherit evalPackages; };
       hls-latest = tool compiler-nix-name "haskell-language-server" {
         inherit evalPackages;
-        version =
-          if __compareVersions haskell.compiler.${compiler-nix-name}.version "9.0" < 0
-            then "1.8.0.0"
-            else "latest";
+        version = "latest";
+      };
+    } // pkgs.lib.optionalAttrs (__compareVersions haskell.compiler.${compiler-nix-name}.version "9.4" < 0) {
+      stack = tool compiler-nix-name "stack" { version = "2.9.3"; inherit evalPackages; };
+      "hls-1.9.0.0" = tool compiler-nix-name "haskell-language-server" {
+        inherit evalPackages;
+        version = "1.9.0.0";
+      };
+    } // pkgs.lib.optionalAttrs (__compareVersions haskell.compiler.${compiler-nix-name}.version "9.0" < 0) {
+      "hls-1.8.0.0" = tool compiler-nix-name "haskell-language-server" {
+        inherit evalPackages;
+        version = "1.8.0.0";
       };
     })
   );

--- a/modules/configuration-nix.nix
+++ b/modules/configuration-nix.nix
@@ -89,7 +89,7 @@ in {
       "ghc8101" "ghc8102" "ghc8103" "ghc8104" "ghc8105" "ghc8106" "ghc8107" "ghc810420210212"
     ]) [
       (fromUntil "1.7.0.0" "1.8.0.0" ../patches/ghcide-1.7-unboxed-tuple-fix-issue-1455.patch)
-      (fromUntil "1.8.0.0" "1.9.0.0" ../patches/ghcide-1.8-unboxed-tuple-fix-issue-1455.patch)
+      (fromUntil "1.8.0.0" "1.11.0.0" ../patches/ghcide-1.8-unboxed-tuple-fix-issue-1455.patch)
     ]
     # This is needed for a patch only applied to ghc810420210212
     ++ pkgs.lib.optional (__elem config.compiler.nix-name [

--- a/modules/hackage-quirks.nix
+++ b/modules/hackage-quirks.nix
@@ -164,6 +164,9 @@ in [
         constraints:
           -- for ghc 8.10, stm-hamt 1.2.0.10 doesn't build
           stm-hamt < 1.2.0.10
+      '' + lib.optionalString (config.version == "1.10.0.0" && __elem config.compiler-nix-name ["ghc944"]) ''
+        package haskell-language-server
+          flags: -floskell -stylishhaskell -rename
       '' + lib.optionalString (config.version == "1.10.0.0" && __elem config.compiler-nix-name ["ghc8107"]) ''
         package haskell-language-server
           flags: -tactic

--- a/modules/hackage-quirks.nix
+++ b/modules/hackage-quirks.nix
@@ -59,9 +59,51 @@ in [
             + lib.optionalString (!__elem config.compiler-nix-name ["ghc901" "ghc902"]) " -hlint"
         }
         constraints: hls-fourmolu-plugin <1.1.1.0, hls-rename-plugin <1.0.2.0, hls-stan-plugin <1.0.1.0
+      '' + lib.optionalString (config.version == "1.9.1.0") ''
+        -- These have been copied from:
+        -- https://github.com/haskell/haskell-language-server/blob/1.9.1.0/cabal.project
+        constraints:
+          -- For GHC 9.4, older versions of entropy fail to build on Windows
+          entropy >= 0.4.1.10,
+          -- For GHC 9.4
+          basement >= 0.0.15,
+          -- For GHC 9.4
+          hw-prim >= 0.6.3.2,
+          hyphenation +embed,
+          -- remove this when hlint sets ghc-lib to true by default
+          -- https://github.com/ndmitchell/hlint/issues/1376
+          hlint +ghc-lib,
+          ghc-check -ghc-check-use-package-abis,
+          ghc-lib-parser-ex -auto,
+          stylish-haskell +ghc-lib,
+          fourmolu -fixity-th
+
+        allow-newer:
+          -- ghc-9.4
+          Chart-diagrams:lens,
+          Chart:lens,
+          co-log-core:base,
+          constraints-extras:base,
+          constraints-extras:template-haskell,
+          dependent-sum:some,
+          diagrams-contrib:base,
+          diagrams-contrib:lens,
+          diagrams-postscript:base,
+          diagrams-postscript:lens,
+          diagrams-svg:base,
+          diagrams-svg:lens,
+          ekg-json:base,
+          ghc-paths:Cabal,
+          haddock-library:base,
+          monoid-extras:base,
+          monoid-subclasses:vector,
+          svg-builder:base,
+          uuid:time,
+          vector-space:base,
+          ekg-wai:time,
       '' + lib.optionalString (config.version == "1.10.0.0") ''
         -- These have been copied from:
-        -- https://github.com/haskell/haskell-language-server/blob/1d07fbec5ad67242e4417232333a7af66776cf5a/cabal.project#L60-L79
+        -- https://github.com/haskell/haskell-language-server/blob/1d07fbec5ad67242e4417232333a7af66776cf5a/cabal.project
         constraints:
           -- For GHC 9.4, older versions of entropy fail to build on Windows
           entropy >= 0.4.1.10,
@@ -80,6 +122,44 @@ in [
           setup.happy == 1.20.1.1,
           happy == 1.20.1.1,
           filepath installed
+
+        allow-newer:
+          -- ghc-9.4
+          Chart-diagrams:lens,
+          Chart:lens,
+          co-log-core:base,
+          constraints-extras:base,
+          constraints-extras:template-haskell,
+          dependent-sum:some,
+          diagrams-contrib:base,
+          diagrams-contrib:lens,
+          diagrams-postscript:base,
+          diagrams-postscript:lens,
+          diagrams-svg:base,
+          diagrams-svg:lens,
+          ekg-json:base,
+          ghc-paths:Cabal,
+          haddock-library:base,
+          monoid-extras:base,
+          monoid-subclasses:vector,
+          svg-builder:base,
+          uuid:time,
+          vector-space:base,
+          ekg-wai:time,
+
+        if impl(ghc >= 9.5)
+          allow-newer:
+            -- ghc-9.6
+            algebraic-graphs:transformers,
+            cryptohash-md5:base,
+            cryptohash-sha1:base,
+            ekg-core:ghc-prim,
+            focus:transformers,
+            ghc-trace-events:base,
+            implicit-hie-cradle:transformers,
+            semigroupoids:base,
+            stm-hamt:transformers,
+            entropy:Cabal,
       '' + lib.optionalString (__elem config.compiler-nix-name ["ghc8107"]) ''
         constraints:
           -- for ghc 8.10, stm-hamt 1.2.0.10 doesn't build

--- a/test/haskell-language-server/cabal.nix
+++ b/test/haskell-language-server/cabal.nix
@@ -1,10 +1,7 @@
 { stdenv, testSrc, haskell-nix, compiler-nix-name, evalPackages, recurseIntoAttrs }:
 let
   inherit (haskell-nix.tool compiler-nix-name "haskell-language-server" {
-    version =
-      if __compareVersions haskell-nix.compiler.${compiler-nix-name}.version "9.0" < 0
-        then "1.8.0.0"
-        else "latest";
+    version = "latest";
     inherit evalPackages; }) project;
 in recurseIntoAttrs {
   ifdInputs = {
@@ -13,5 +10,5 @@ in recurseIntoAttrs {
   build = project.getComponent "haskell-language-server:exe:haskell-language-server";
 
   # hls does not need to be cross compiled.
-  meta.disabled = stdenv.hostPlatform != stdenv.buildPlatform || __elem compiler-nix-name ["ghc941" "ghc942" "ghc943" "ghc944" "ghc96020230302" "ghc961"];
+  meta.disabled = stdenv.hostPlatform != stdenv.buildPlatform;
 }


### PR DESCRIPTION
This removes the old dependent-sum fix, but adds new fixes needed by hls 1.10.

See https://github.com/haskell/haskell-language-server/blob/1d07fbec5ad67242e4417232333a7af66776cf5a/cabal.project#L60-L79

This fix will be used to get HLS 1.10 support working in https://github.com/input-output-hk/devx.