### PR TITLE
Fix haskell-language-server tests

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -43,10 +43,10 @@ in rec {
     } // pkgs.lib.optionalAttrs (__compareVersions haskell.compiler.${compiler-nix-name}.version "9.4" < 0) {
       stack = tool compiler-nix-name "stack" { version = "2.9.3"; inherit evalPackages; };
     } // pkgs.lib.optionalAttrs (__compareVersions haskell.compiler.${compiler-nix-name}.version "9.6" < 0) {
-      hls-latest = tool compiler-nix-name "haskell-language-server" {
+      hls-latest = tool compiler-nix-name "haskell-language-server" rec {
         inherit evalPackages;
-        src = pkgs.lib.mkForce pkgs.haskell-nix.sources."hls-1.10";
-        cabalProject = __readFile (pkgs.haskell-nix.sources."hls-1.10" + "/cabal.project");
+        src = pkgs.haskell-nix.sources."hls-1.10";
+        cabalProject = __readFile (src + "/cabal.project");
         sha256map."https://github.com/pepeiborra/ekg-json"."7a0af7a8fd38045fd15fb13445bdcc7085325460" = "sha256-fVwKxGgM0S4Kv/4egVAAiAjV7QB5PBqMVMCfsv7otIQ=";
       };
     })

--- a/build.nix
+++ b/build.nix
@@ -42,12 +42,10 @@ in rec {
       };
     } // pkgs.lib.optionalAttrs (__compareVersions haskell.compiler.${compiler-nix-name}.version "9.4" < 0) {
       stack = tool compiler-nix-name "stack" { version = "2.9.3"; inherit evalPackages; };
+    } // pkgs.lib.optionalAttrs (__compareVersions haskell.compiler.${compiler-nix-name}.version "9.6" < 0) {
       hls-latest = tool compiler-nix-name "haskell-language-server" {
         inherit evalPackages;
-        version =
-          if __compareVersions haskell.compiler.${compiler-nix-name}.version "9.0" < 0
-            then "1.8.0.0"
-            else "latest";
+        version = "github-1.10";
       };
     })
   );

--- a/build.nix
+++ b/build.nix
@@ -45,7 +45,9 @@ in rec {
     } // pkgs.lib.optionalAttrs (__compareVersions haskell.compiler.${compiler-nix-name}.version "9.6" < 0) {
       hls-latest = tool compiler-nix-name "haskell-language-server" {
         inherit evalPackages;
-        version = "github-1.10";
+        src = pkgs.lib.mkForce pkgs.haskell-nix.sources."hls-1.10";
+        cabalProject = __readFile (pkgs.haskell-nix.sources."hls-1.10" + "/cabal.project");
+        sha256map."https://github.com/pepeiborra/ekg-json"."7a0af7a8fd38045fd15fb13445bdcc7085325460" = "sha256-fVwKxGgM0S4Kv/4egVAAiAjV7QB5PBqMVMCfsv7otIQ=";
       };
     })
   );

--- a/flake.lock
+++ b/flake.lock
@@ -283,6 +283,23 @@
         "type": "github"
       }
     },
+    "hls-1.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hpc-coveralls": {
       "flake": false,
       "locked": {
@@ -725,6 +742,7 @@
         "flake-utils": "flake-utils",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",
+        "hls-1.10": "hls-1.10",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,7 @@
     nixpkgs-unstable = { url = "github:NixOS/nixpkgs/nixpkgs-unstable"; };
     flake-compat = { url = "github:input-output-hk/flake-compat/hkm/gitlab-fix"; flake = false; };
     flake-utils = { url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs"; };
+    "hls-1.10" = { url = "github:haskell/haskell-language-server/1.10.0.0"; flake = false; };
     tullia = {
       url = "github:input-output-hk/tullia";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/modules/configuration-nix.nix
+++ b/modules/configuration-nix.nix
@@ -89,7 +89,7 @@ in {
       "ghc8101" "ghc8102" "ghc8103" "ghc8104" "ghc8105" "ghc8106" "ghc8107" "ghc810420210212"
     ]) [
       (fromUntil "1.7.0.0" "1.8.0.0" ../patches/ghcide-1.7-unboxed-tuple-fix-issue-1455.patch)
-      (fromUntil "1.8.0.0" "1.9.0.0" ../patches/ghcide-1.8-unboxed-tuple-fix-issue-1455.patch)
+      (fromUntil "1.8.0.0" "1.11.0.0" ../patches/ghcide-1.8-unboxed-tuple-fix-issue-1455.patch)
     ]
     # This is needed for a patch only applied to ghc810420210212
     ++ pkgs.lib.optional (__elem config.compiler.nix-name [

--- a/modules/hackage-project.nix
+++ b/modules/hackage-project.nix
@@ -43,7 +43,7 @@ in {
           inherit (rev) sha256;
         };
         revSuffix = lib.optionalString (rev.revNum > 0) "-r${toString rev.revNum}";
-      in config.evalPackages.runCommand "${name}-${version}${revSuffix}-src" {} (''
+      in lib.mkOverride 1100 (config.evalPackages.runCommand "${name}-${version}${revSuffix}-src" {} (''
           tmp=$(mktemp -d)
           cd $tmp
           tar xzf ${tarball}
@@ -56,6 +56,6 @@ in {
           # the same `alex`, `happy` and `hscolour` are used to build GHC.  It also means that
           # that `tools` in the shell will be built the same.
           filterPath = { path, ... }: path;
-        };
+        });
   };
 }

--- a/modules/hackage-quirks.nix
+++ b/modules/hackage-quirks.nix
@@ -43,24 +43,6 @@ in [
     }
   )
 
-  ({config, lib, pkgs, ...}:
-    { _file = "haskell.nix/overlays/hackage-quirks.nix#haskell-language-server"; } //
-    lib.mkIf (config.name == "haskell-language-server" && config.version == "github-1.10") {
-      configureArgs = "--disable-tests --disable-benchmarks";
-      src = lib.mkForce pkgs.haskell-nix.sources."hls-1.10";
-      cabalProjectLocal = ''
-        -- Plugins that are broken for some compilers
-        if impl(ghc ^>=9.4.1)
-          package haskell-language-server
-            flags: -floskell -stylishhaskell -rename
-        if impl(ghc ^>=8.10.1)
-          constraints: stm-hamt <1.2.0.10
-          package haskell-language-server
-            flags: -tactic
-      '';
-    }
-  )
-
   # The latest version of stack (2.9.1) in hackage fails to build because the
   # of version of rio-prettyprint (recently released 0.1.4.0) chosen by cabal.
   # https://github.com/commercialhaskell/stack/issues/5963

--- a/modules/hackage-quirks.nix
+++ b/modules/hackage-quirks.nix
@@ -45,25 +45,18 @@ in [
 
   ({config, lib, pkgs, ...}:
     { _file = "haskell.nix/overlays/hackage-quirks.nix#haskell-language-server"; } //
-    lib.mkIf (config.name == "haskell-language-server") {
-      # TODO remove this when `dependent-sum-0.7.1.0` constraint on `some` has been updated.
-      # See https://github.com/haskell/haskell-language-server/issues/2969
-      # and https://github.com/obsidiansystems/dependent-sum/issues/71
-      cabalProject = lib.mkDefault (''
-        packages: .
-        constraints: dependent-sum >=0.7.1.0
-      ''
-      # TODO remove once these the plugins have been updated in hackage
-      + lib.optionalString (config.version == "1.8.0.0") ''
-        package haskell-language-server
-          flags: -qualifyimportednames${
-            # Stylish haskell is broken for GHC 9.2
-            lib.optionalString (__elem config.compiler-nix-name ["ghc921" "ghc922" "ghc923" "ghc924" "ghc925" "ghc926" "ghc927"]) " -stylishhaskell"
-            # Hlint with this HLS only compiles for GHC 9.0
-            + lib.optionalString (!__elem config.compiler-nix-name ["ghc901" "ghc902"]) " -hlint"
-        }
-        constraints: hls-fourmolu-plugin <1.1.1.0, hls-rename-plugin <1.0.2.0, hls-stan-plugin <1.0.1.0
-      '');
+    lib.mkIf (config.name == "haskell-language-server" && config.version == "github-1.10") {
+      configureArgs = "--disable-tests --disable-benchmarks";
+      src = lib.mkForce pkgs.haskell-nix.sources."hls-1.10";
+      cabalProjectLocal = ''
+        -- Plugins that are broken for some compilers
+        if impl(ghc ^>=9.4.1)
+          package haskell-language-server
+            flags: -floskell -stylishhaskell -rename
+        if impl(ghc ^>=8.10.1)
+          package haskell-language-server
+            flags: -tactic
+      '';
     }
   )
 

--- a/modules/hackage-quirks.nix
+++ b/modules/hackage-quirks.nix
@@ -54,6 +54,7 @@ in [
           package haskell-language-server
             flags: -floskell -stylishhaskell -rename
         if impl(ghc ^>=8.10.1)
+          constraints: stm-hamt <1.2.0.10
           package haskell-language-server
             flags: -tactic
       '';

--- a/test/haskell-language-server/cabal.nix
+++ b/test/haskell-language-server/cabal.nix
@@ -1,8 +1,11 @@
 { stdenv, testSrc, haskell-nix, compiler-nix-name, evalPackages, recurseIntoAttrs }:
 let
-  inherit (haskell-nix.tool compiler-nix-name "haskell-language-server" {
-    version = "github-1.10";
-    inherit evalPackages; }) project;
+  project = haskell-nix.cabalProject' {
+    inherit compiler-nix-name evalPackages;
+    name = "haskell-language-server";
+    src = haskell-nix.sources."hls-1.10";
+    sha256map."https://github.com/pepeiborra/ekg-json"."7a0af7a8fd38045fd15fb13445bdcc7085325460" = "sha256-fVwKxGgM0S4Kv/4egVAAiAjV7QB5PBqMVMCfsv7otIQ=";
+  };
 in recurseIntoAttrs {
   ifdInputs = {
     inherit (project) plan-nix;

--- a/test/haskell-language-server/cabal.nix
+++ b/test/haskell-language-server/cabal.nix
@@ -1,10 +1,7 @@
 { stdenv, testSrc, haskell-nix, compiler-nix-name, evalPackages, recurseIntoAttrs }:
 let
   inherit (haskell-nix.tool compiler-nix-name "haskell-language-server" {
-    version =
-      if __compareVersions haskell-nix.compiler.${compiler-nix-name}.version "9.0" < 0
-        then "1.8.0.0"
-        else "latest";
+    version = "github-1.10";
     inherit evalPackages; }) project;
 in recurseIntoAttrs {
   ifdInputs = {

--- a/test/haskell-language-server/cabal.nix
+++ b/test/haskell-language-server/cabal.nix
@@ -10,5 +10,5 @@ in recurseIntoAttrs {
   build = project.getComponent "haskell-language-server:exe:haskell-language-server";
 
   # hls does not need to be cross compiled.
-  meta.disabled = stdenv.hostPlatform != stdenv.buildPlatform || __elem compiler-nix-name ["ghc941" "ghc942" "ghc943" "ghc944" "ghc96020230302" "ghc961"];
+  meta.disabled = stdenv.hostPlatform != stdenv.buildPlatform || __elem compiler-nix-name ["ghc961"];
 }


### PR DESCRIPTION
Rather than trying to get the hackage version working, this change makes it easy to use the tagged release from github.