### PR TITLE
Discard string context when using antiquoted string as attrset key

### DIFF
--- a/lib/cabal-project-parser.nix
+++ b/lib/cabal-project-parser.nix
@@ -196,7 +196,10 @@ let
         '');
       # Directory to `lndir` when constructing a suitable $HOME/.cabal dir
       repo = {
-        ${name} = repoContents;
+        # Strings used as attrset keys can't have contet. This can cause problems if the cabal.project file has antiquoted strings
+        # in it. Discarding the context here works, and because 'name' is used elsewhere, we don't actually lose the string content,
+        # which can matter!
+        ${builtins.unsafeDiscardStringContext name} = repoContents;
       };
     };
 


### PR DESCRIPTION
This manifested in practice because I was trying to do something like
this:
```
repository cardano-haskell-packages:
  url: file:${CHaP}
  secure: True
```
which gave me errors about not being allowed to have string context. We
do actually need the string context (otherwise we end up not depending
on the repository, and the sandbox prevents us from looking at it!), so
we have to be careful about where to discard. The simplest thing is to
discard where it's needed: as we create the attrset key.
