### PR TITLE
Avoid cabalProject/sha256map for hls

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -43,11 +43,9 @@ in rec {
     } // pkgs.lib.optionalAttrs (__compareVersions haskell.compiler.${compiler-nix-name}.version "9.4" < 0) {
       stack = tool compiler-nix-name "stack" { version = "2.9.3"; inherit evalPackages; };
     } // pkgs.lib.optionalAttrs (__compareVersions haskell.compiler.${compiler-nix-name}.version "9.6" < 0) {
-      hls-latest = tool compiler-nix-name "haskell-language-server" rec {
+      hls-latest = tool compiler-nix-name "haskell-language-server" {
         inherit evalPackages;
         src = pkgs.haskell-nix.sources."hls-1.10";
-        cabalProject = __readFile (src + "/cabal.project");
-        sha256map."https://github.com/pepeiborra/ekg-json"."7a0af7a8fd38045fd15fb13445bdcc7085325460" = "sha256-fVwKxGgM0S4Kv/4egVAAiAjV7QB5PBqMVMCfsv7otIQ=";
       };
     })
   );

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -252,7 +252,13 @@ let
         packages.hadrian.postPatch = ''
           cd hadrian
         '';
-      }];        
+      }];
+      cabalProject = ''
+        packages:
+          .
+      '';
+      cabalProjectLocal = null;
+      cabalProjectFreeze = null;
       src = haskell-nix.haskellLib.cleanSourceWith {
         inherit src;
         subDir = "hadrian";

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -1,9 +1,11 @@
 { pkgs, runCommand, cacert, index-state-hashes, haskellLib }@defaults:
 let readIfExists = src: fileName:
       # Using origSrcSubDir bypasses any cleanSourceWith.
+      # `lookForCabalProject` allows us to avoid looking in source from hackage
+      # for cabal.project files.  It is set in `modules/hackage-project.nix`.
       let origSrcDir = src.origSrcSubDir or src;
       in
-        if builtins.elem ((__readDir origSrcDir)."${fileName}" or "") ["regular" "symlink"]
+        if (src.lookForCabalProject or true) && builtins.elem ((__readDir origSrcDir)."${fileName}" or "") ["regular" "symlink"]
           then __readFile (origSrcDir + "/${fileName}")
           else null;
 in

--- a/modules/cabal-project.nix
+++ b/modules/cabal-project.nix
@@ -96,7 +96,8 @@ in {
     };
     sha256map = mkOption {
       type = nullOr (attrsOf (either str (attrsOf str)));
-      default = null;
+      # Default needed for haskell-language-server 1.10
+      default."https://github.com/pepeiborra/ekg-json"."7a0af7a8fd38045fd15fb13445bdcc7085325460" = "sha256-fVwKxGgM0S4Kv/4egVAAiAjV7QB5PBqMVMCfsv7otIQ=";
       description = ''
         An alternative to adding `--sha256` comments into the
         cabal.project file:

--- a/modules/hackage-project.nix
+++ b/modules/hackage-project.nix
@@ -24,14 +24,6 @@ in {
     };
   };
   config = {
-    # Avoid readDir and readFile IFD functions looking for these files in the hackage source
-    # `mkOverride 1100` means this will be used in preference to the mkOption default,
-    # but a `mkDefault` can still override this.
-    cabalProject = lib.mkOverride 1100 ''
-      packages: .
-    '';
-    cabalProjectLocal = lib.mkOverride 1100 null;
-    cabalProjectFreeze = lib.mkOverride 1100 null;
     src =
       let
         tarball = config.evalPackages.fetchurl {
@@ -43,7 +35,10 @@ in {
           inherit (rev) sha256;
         };
         revSuffix = lib.optionalString (rev.revNum > 0) "-r${toString rev.revNum}";
-      in lib.mkOverride 1100 (config.evalPackages.runCommand "${name}-${version}${revSuffix}-src" {} (''
+      in lib.mkOverride 1100 (config.evalPackages.runCommand "${name}-${version}${revSuffix}-src" {
+          # Avoid readDir and readFile IFD functions looking for these project files in the hackage source
+          passthru.lookForCabalProject = false;
+        } (''
           tmp=$(mktemp -d)
           cd $tmp
           tar xzf ${tarball}

--- a/test/haskell-language-server/cabal.nix
+++ b/test/haskell-language-server/cabal.nix
@@ -4,7 +4,6 @@ let
     inherit compiler-nix-name evalPackages;
     name = "haskell-language-server";
     src = haskell-nix.sources."hls-1.10";
-    sha256map."https://github.com/pepeiborra/ekg-json"."7a0af7a8fd38045fd15fb13445bdcc7085325460" = "sha256-fVwKxGgM0S4Kv/4egVAAiAjV7QB5PBqMVMCfsv7otIQ=";
   };
 in recurseIntoAttrs {
   ifdInputs = {


### PR DESCRIPTION
This would allow:

```
tools.haskell-language-server.src = pkgs.haskell-nix.sources."hls-1.10";
```

Without the need to also pass `cabalProject` and `sha256map`.