### PR TITLE
Default evalPackages to pkgsBuildBuild

### DIFF
--- a/modules/plan.nix
+++ b/modules/plan.nix
@@ -311,6 +311,7 @@ in {
     evalPackages = mkOption {
       type = unspecified;
       default = pkgs.pkgsBuildBuild;
+      defaultText = "pkgs.pkgsBuildBuild";
       description = ''
         The `evalPackages` that will be used when building `hoogle` and shell tools.
       '';

--- a/modules/plan.nix
+++ b/modules/plan.nix
@@ -310,6 +310,7 @@ in {
 
     evalPackages = mkOption {
       type = unspecified;
+      default = pkgs.pkgsBuildBuild;
       description = ''
         The `evalPackages` that will be used when building `hoogle` and shell tools.
       '';


### PR DESCRIPTION
In order to allow x86_64 machines to download aarch64 derivations from nix caches we started using `evalPackages` instead of `pkgs` to download hackage revision .cabal files.

https://github.com/input-output-hk/haskell.nix/pull/1911/files#diff-3f29943279540479b678e36737d12e3f9cf07ef52a2622d40a9e7a3cf6516264R48

This was fine for most new projects, but for older ones (including some of our older tests) it broke.  Unfortunately the test is one that uses the `master` branch of haskell.nix (so it did not break until after the PR was merged).

This change defaults `evalPackages` to `pkgsBuildBuild` in `plan.nix`.