### PR TITLE
More use of 22.11 to avoid GHA issues

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -89,13 +89,7 @@ in rec {
       ];
     };
     check-materialization-concurrency = pkgs.buildPackages.callPackage ./scripts/check-materialization-concurrency/check.nix {};
-    # Forcing nixpkgs-unstable here because this test makes a script
-    # that when run will build `aeson` (used by `tests/cabal-simple`)
-    # and we currently do not build that on hydra for nixpkgs-2205 (used by `pkgs`).
-    # Using nixpkgs-unstable should allow buildkite to find what it needs
-    # in the hydra cache when it runs the script.
-    check-path-support = (import haskellNix.sources.nixpkgs-unstable nixpkgsArgs)
-        .buildPackages.callPackage ./scripts/check-path-support.nix {
+    check-path-support = pkgs.buildPackages.callPackage ./scripts/check-path-support.nix {
       inherit compiler-nix-name;
     };
   };

--- a/build.nix
+++ b/build.nix
@@ -6,11 +6,11 @@
 , nixpkgsArgs ? haskellNix.nixpkgsArgs
 , pkgs ? import nixpkgs nixpkgsArgs
 , evalPackages ? import nixpkgs nixpkgsArgs
-# This version is used to make our GHA runners happy
+# This version is used to make our GitHub Action runners happy
 # Using `nixpkgs-unstable` currently results in:
 #   version `GLIBCXX_3.4.30' not found
-, nixpkgsForGHA ? haskellNix.sources.nixpkgs-2211
-, pkgsForGHA ? import nixpkgsForGHA (nixpkgsArgs // { inherit (pkgs) system; })
+, nixpkgsForGitHubAction ? haskellNix.sources.nixpkgs-2211
+, pkgsForGitHubAction ? import nixpkgsForGitHubAction (nixpkgsArgs // { inherit (pkgs) system; })
 , ifdLevel ? 1000
 , compiler-nix-name ? throw "No `compiler-nix-name` passed to build.nix"
 , haskellNix ? (import ./default.nix {})
@@ -87,7 +87,7 @@ in rec {
       ];
     };
     check-materialization-concurrency = pkgs.buildPackages.callPackage ./scripts/check-materialization-concurrency/check.nix {};
-    check-path-support = pkgsForGHA.buildPackages.callPackage ./scripts/check-path-support.nix {
+    check-path-support = pkgsForGitHubAction.buildPackages.callPackage ./scripts/check-path-support.nix {
       inherit compiler-nix-name;
     };
   };

--- a/build.nix
+++ b/build.nix
@@ -6,7 +6,7 @@
 , nixpkgsArgs ? haskellNix.nixpkgsArgs
 , pkgs ? import nixpkgs nixpkgsArgs
 , evalPackages ? import nixpkgs nixpkgsArgs
-, nixpkgsForHydra ? haskellNix.sources.nixpkgs-2105
+, nixpkgsForHydra ? haskellNix.sources.nixpkgs-2211
 , pkgsForHydra ? import nixpkgsForHydra (nixpkgsArgs // { inherit (pkgs) system; })
 , ifdLevel ? 1000
 , compiler-nix-name ? throw "No `compiler-nix-name` passed to build.nix"
@@ -89,7 +89,7 @@ in rec {
       ];
     };
     check-materialization-concurrency = pkgs.buildPackages.callPackage ./scripts/check-materialization-concurrency/check.nix {};
-    check-path-support = pkgs.buildPackages.callPackage ./scripts/check-path-support.nix {
+    check-path-support = pkgsForHydra.buildPackages.callPackage ./scripts/check-path-support.nix {
       inherit compiler-nix-name;
     };
   };

--- a/nix-tools/.buildkite/nix-tools-build.sh
+++ b/nix-tools/.buildkite/nix-tools-build.sh
@@ -1,6 +1,10 @@
 #! /usr/bin/env nix-shell
 #! nix-shell -I "nixpkgs=channel:nixos-22.11" -i bash -p nixUnstable cabal-install ghc git nix-prefetch-git cacert
 
+# This file uses nixpkgs 22.11 to make our GHA runners happy
+# Using `nixpkgs-unstable` currently results in:
+#   version `GLIBCXX_3.4.30' not found
+
 # The `nix-shell` is set to run without `--pure`.
 # It is possible to use `--pure` if we need to, but it requires setting these.
 #  export LANG=en_US.UTF-8

--- a/nix-tools/.buildkite/nix-tools-build.sh
+++ b/nix-tools/.buildkite/nix-tools-build.sh
@@ -22,7 +22,7 @@ cabal new-update
 
 echo
 echo "+++ Run stable version of make-install-plan and plan-to-nix"
-nix build --impure --expr '(let haskellNix = import (builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz") {}; in (import haskellNix.sources.nixpkgs haskellNix.nixpkgsArgs).haskell-nix.nix-tools.ghc8107)' -o nt
+nix build --impure --expr '(let haskellNix = import (builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz") {}; in (import haskellNix.sources.nixpkgs-2211 haskellNix.nixpkgsArgs).haskell-nix.nix-tools.ghc8107)' -o nt
 ./nt/bin/make-install-plan
 rm -rf .buildkite/nix1
 ./nt/bin/plan-to-nix --output .buildkite/nix1 --plan-json dist-newstyle/cache/plan.json


### PR DESCRIPTION
We are not sure why, but it seems that using the latest `nixpkgs-unstable` for things results in `version `GLIBCXX_3.4.30' not found` errors on our GitHub Action runners.  This change uses our `nixpkgs-2211` pin to avoid these issues.

It also removes a similar old workarounds we had for building and testing hydra on buildkite.