### PR TITLE
Remove `configFiles` and `ghc` component outputs

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -54,6 +54,15 @@ let self =
 , doHoogle ? component.doHoogle # Also build a hoogle index
 , hyperlinkSource ? component.doHyperlinkSource # Link documentation to the source code
 , quickjump ? component.doQuickjump # Generate an index for interactive documentation navigation
+
+# Keep the configFiles as a derivation output (otherwise they are in a temp directory)
+# We need this for `cabal-doctest` to work, but it is also likely
+, keepConfigFiles ? component.keepConfigFiles || configureAllComponents
+
+# Keep the ghc wrapper as a `ghc` derivation output (otherwise it is in a temp directory)
+# This is used for the `ghc-paths` package in `modules/configuration.nix`
+, keepGhc ? component.keepGhc
+
 , keepSource ? component.keepSource || configureAllComponents # Build from `source` output in the store then delete `dist`
 , setupHaddockFlags ? component.setupHaddockFlags
 
@@ -397,6 +406,8 @@ let
       ++ executableToolDepends;
 
     outputs = ["out"]
+      ++ (lib.optional keepConfigFiles "configFiles")
+      ++ (lib.optional keepGhc "ghc")
       ++ (lib.optional enableSeparateDataOutput "data")
       ++ (lib.optional keepSource "source")
       ++ (lib.optional writeHieFiles "hie");
@@ -415,9 +426,22 @@ let
         chmod -R +w .
       '') + commonAttrs.prePatch;
 
-    configurePhase = ''
-      configFiles=$(mktemp -d)
-      ghc=$(mktemp -d)
+    configurePhase =
+      (
+        if keepConfigFiles then ''
+          mkdir -p $configFiles
+        ''
+        else ''
+          configFiles=$(mktemp -d)
+        ''
+      ) + (
+        if keepGhc then ''
+          mkdir -p $ghc
+        ''
+        else ''
+          ghc=$(mktemp -d)
+        ''
+      ) + ''
       wrappedGhc=$ghc
       ${configFiles.script}
       ${shellWrappers.script}

--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -396,7 +396,7 @@ let
       [ghc buildPackages.removeReferencesTo]
       ++ executableToolDepends;
 
-    outputs = ["out" "configFiles" "ghc"]
+    outputs = ["out"]
       ++ (lib.optional enableSeparateDataOutput "data")
       ++ (lib.optional keepSource "source")
       ++ (lib.optional writeHieFiles "hie");
@@ -416,8 +416,8 @@ let
       '') + commonAttrs.prePatch;
 
     configurePhase = ''
-      mkdir -p $configFiles
-      mkdir -p $ghc
+      configFiles=$(mktemp -d)
+      ghc=$(mktemp -d)
       wrappedGhc=$ghc
       ${configFiles.script}
       ${shellWrappers.script}

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 3
+{ ifdLevel ? 0
 # Whether or not we are evaluating in restricted mode. This is true in Hydra, but not in Hercules.
 , restrictEval ? false
 , checkMaterialization ? false

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 2
+{ ifdLevel ? 3
 # Whether or not we are evaluating in restricted mode. This is true in Hydra, but not in Hercules.
 , restrictEval ? false
 , checkMaterialization ? false

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 0
+{ ifdLevel ? 1
 # Whether or not we are evaluating in restricted mode. This is true in Hydra, but not in Hercules.
 , restrictEval ? false
 , checkMaterialization ? false

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 1
+{ ifdLevel ? 2
 # Whether or not we are evaluating in restricted mode. This is true in Hydra, but not in Hercules.
 , restrictEval ? false
 , checkMaterialization ? false

--- a/modules/configuration-nix.nix
+++ b/modules/configuration-nix.nix
@@ -157,4 +157,8 @@ in {
   packages.bitvec.patches = [
     (fromUntil "1.1.3.0" "1.1.3.0.1" ../patches/bitvec-gmp-fix.patch)
   ];
+
+  # ghc-paths stores the path of the GHC compiler used to build the component.
+  # we need to keep it in the store so that it will remain valid.
+  packages.ghc-paths.components.library.keepGhc = true;
 }

--- a/modules/package.nix
+++ b/modules/package.nix
@@ -355,11 +355,13 @@ in {
         # Exclude attributes that are likely to have conflicting definitions
         # (a common use case for `all` is in `shellFor` and it only has an
         # install phase).
-        builtins.removeAttrs c ["preCheck" "postCheck" "keepSource"]
+        builtins.removeAttrs c ["preCheck" "postCheck" "keepConfigFiles" "keepGhc" "keepSource"]
       ) (lib.filter (c: c.buildable && c.planned) allComps)
     ) // {
-      # If any one of the components needs us to keep the source
+      # If any one of the components needs us to keep one of these
       # then keep it for the `all` component
+      keepConfigFiles = lib.foldl' (x: comp: x || comp.keepConfigFiles) false allComps;
+      keepGhc = lib.foldl' (x: comp: x || comp.keepGhc) false allComps;
       keepSource = lib.foldl' (x: comp: x || comp.keepSource) false allComps;
     };
 }

--- a/modules/plan.nix
+++ b/modules/plan.nix
@@ -168,6 +168,18 @@ let
       default = (def.profilingDetail or "default");
     };
 
+    keepConfigFiles = mkOption {
+      type = bool;
+      default = (def.keepConfigFiles or false);
+      description = "Keep component configFiles in the store in a `configFiles` output";
+    };
+
+    keepGhc = mkOption {
+      type = bool;
+      default = (def.keepGhc or false);
+      description = "Keep component wrapped ghc in the store in a `ghc` output";
+    };
+
     keepSource = mkOption {
       type = bool;
       default = (def.keepSource or false);


### PR DESCRIPTION
These outputs were added when the derivations that used to provide them were removed (they instead the code that creates them is run in the `configurePhase`).

We think we might be better off without theses. They have two drawbacks:

* When running `genericBuild` inside a shell they must be created manually (with `export configFile=$(mktemp -d)` and `export ghc=$(mktemp -d)`).

* The stop `disallowedReferences` from working (see #1934).

* It is probably a non zero overhead to including them in the nix cache.