### PR TITLE
Add exceptions and stm to nonReinstallablePkgs for ghc901

### DIFF
--- a/modules/component-driver.nix
+++ b/modules/component-driver.nix
@@ -61,8 +61,10 @@ in
     ]
     # TODO make this unconditional
     ++ lib.optionals (
-      __elem config.compiler.nix-name ["ghc901" "ghc902" "ghc921" "ghc922" "ghc923" "ghc924" "ghc925" "ghc926" "ghc927" "ghc941" "ghc942" "ghc943" "ghc944" "ghc945" "ghc961" "ghc96020230302"]) [
-      "ghc-bignum" ]
+      __elem config.compiler.nix-name ["ghc901" "ghc902" "ghc921" "ghc922" "ghc923" "ghc924" "ghc925" "ghc926" "ghc927" "ghc941" "ghc942" "ghc943" "ghc944" "ghc945" "ghc961" "ghc96020230302"])
+      (["ghc-bignum"]
+        # stm and exceptions are needed by the GHC package since 9.0.1
+        ++ lib.optionals (!config.reinstallableLibGhc) ["stm" "exceptions"])
     ++ lib.optionals (
       __elem config.compiler.nix-name ["ghc925" "ghc926" "ghc927" "ghc941" "ghc942" "ghc943" "ghc944" "ghc945" "ghc961" "ghc96020230302"]) [
       "system-cxx-std-lib" ]


### PR DESCRIPTION
We did not merge #1183 because we were concerned that it would change the  exceptions and stm used for users that did not want to build GHC. However `reinstallableLibGhc = true` is now the default and most projects should not be setting it to `false`.  That means this change will now only affect projects that likely want to use the built in `ghc` package.