### PR TITLE
Update static overrides, to always use final

### DIFF
--- a/overlays/musl.nix
+++ b/overlays/musl.nix
@@ -1,38 +1,38 @@
 final: prev: prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl ({
   # Prevent pkgsMusl.pkgsStatic chain
-  busybox-sandbox-shell = prev.busybox-sandbox-shell.override { inherit (final) busybox; };
+  busybox-sandbox-shell = final.busybox-sandbox-shell.override { inherit (final) busybox; };
 
   # we don't want the static output to be split. That just
   # messes with the z -> libz mapping. We can't have a conditional
   # z -> libz / z -> libz.static mapping without threading the
   # package configuration in.  That seems a bit overkill.
-  zlib = prev.zlib.override { splitStaticOutput = false; };
+  zlib = final.zlib.override { splitStaticOutput = false; };
 
   # and a few more packages that need their static libs explicitly enabled
-  bzip2 = prev.bzip2.override { linkStatic = true; };
-  gmp = prev.gmp.override { withStatic = true; };
-  ncurses = prev.ncurses.override { enableStatic = true; };
-  libsodium = prev.libsodium.overrideAttrs (_: { dontDisableStatic = true; });
-  zstd = prev.zstd.override { static = true; };
-  xz = prev.xz.override { enableStatic = true; };
-  lzma = prev.lzma.override { enableStatic = true; };
-  pcre = prev.pcre.overrideAttrs (_: { dontDisableStatic = true; });
-  secp256k1 = prev.secp256k1.overrideAttrs ( oldAttrs: {
+  bzip2 = final.bzip2.override { linkStatic = true; };
+  gmp = final.gmp.override { withStatic = true; };
+  ncurses = final.ncurses.override { enableStatic = true; };
+  libsodium = final.libsodium.overrideAttrs (_: { dontDisableStatic = true; });
+  zstd = final.zstd.override { static = true; };
+  xz = final.xz.override { enableStatic = true; };
+  lzma = final.lzma.override { enableStatic = true; };
+  pcre = final.pcre.overrideAttrs (_: { dontDisableStatic = true; });
+  secp256k1 = final.secp256k1.overrideAttrs ( oldAttrs: {
     configureFlags = oldAttrs.configureFlags ++ ["--enable-static"];  });
 
-  numactl = prev.numactl.overrideAttrs (_: { configureFlags = ["--enable-static"];});
+  numactl = final.numactl.overrideAttrs (_: { configureFlags = ["--enable-static"];});
 
   # See https://github.com/input-output-hk/haskell.nix/issues/948
-  postgresql = (prev.postgresql.overrideAttrs (old: { dontDisableStatic = true; }))
+  postgresql = (final.postgresql.overrideAttrs (old: { dontDisableStatic = true; }))
     .override { enableSystemd = false; gssSupport = false; };
   
-  openssl = prev.openssl.override { static = true; };
+  openssl = final.openssl.override { static = true; };
 
-  icu = (prev.icu.overrideAttrs (old: { configureFlags = old.configureFlags ++ [ "--enable-static" "--disable-shared" ]; }));
+  icu = (final.icu.overrideAttrs (old: { configureFlags = old.configureFlags ++ [ "--enable-static" "--disable-shared" ]; }));
 
   # Fails on cross compile
-  nix = prev.nix.overrideAttrs (_: { doInstallCheck = false; });
+  nix = final.nix.overrideAttrs (_: { doInstallCheck = false; });
 } // prev.lib.optionalAttrs (prev.lib.versionAtLeast prev.lib.trivial.release "20.03") {
   # Fix infinite recursion between openssh and fetchcvs
-  openssh = prev.openssh.override { withFIDO = false; };
+  openssh = final.openssh.override { withFIDO = false; };
 })


### PR DESCRIPTION
We want to make sure that the static overrides happen last. That is if someone decided to swap out a library, we still want to apply the static logic at the final step.

This came up in https://github.com/input-output-hk/cardano-db-sync/pull/1403/commits/a7cd5db34782e70b0044ecb97c70654506690dc5, where we imported an overlay that modified the crypto libraries _after_ the haskell.nix overlays, and thus all of static cross broke, as the static changes got overridden by the later crypto-library changes. To fix this we had to introduce order in the sequence we apply overlays in. That however is highly error prone.