### PR TITLE
Avoid network-3.1.3.0 unknown symbol `socketpair'

### DIFF
--- a/test/th-dlls/cabal.project
+++ b/test/th-dlls/cabal.project
@@ -1,5 +1,9 @@
 packages: .
 
+-- network-3.1.3.0 results in: unknown symbol `socketpair'
+-- See https://github.com/haskell/network/issues/550
+constraints: network <3.1.3.0 || >3.1.3.0
+
 -- Needed for ghc 9.4.3 until hackage is updated
 source-repository-package
   type: git


### PR DESCRIPTION
When running template haskell code in wine we get this error (from https://ci.zw3rk.com/build/2305024/nixlog/1)

```
Building library for th-dlls-0.1.0.0..
[1 of 1] Compiling Lib              ( src/Lib.hs, dist/build/Lib.o )
---> Starting remote-iserv.exe on port 6413
---| remote-iserv.exe should have started on 6413
Could not find Wine Gecko. HTML rendering will be disabled.
wine: configuration in L"/build" has been updated.
Listening on port 6413
remote-iserv.exe:  | /nix/store/x1s18463jl5kzqdpv1xyy13pzj82dhjp-network-lib-network-x86_64-w64-mingw32-3.1.3.0/lib/x86_64-windows-ghc-8.10.7/network-3.1.3.0-91WeQjW06jRIKGtokERG5m/HSnetwork-3.1.3.0-91WeQjW06jRIKGtokERG5m.o: unknown symbol `socketpair'
remote-iserv.exe: Could not load Object Code /nix/store/x1s18463jl5kzqdpv1xyy13pzj82dhjp-network-lib-network-x86_64-w64-mingw32-3.1.3.0/lib/x86_64-windows-ghc-8.10.7/network-3.1.3.0-91WeQjW06jRIKGtokERG5m/HSnetwork-3.1.3.0-91WeQjW06jRIKGtokERG5m.o.

<no location info>: error:
    ghc: unable to load package `network-3.1.3.0'
```

See https://github.com/haskell/network/issues/550