### PR TITLE
Add std++ to postgres as well as setting LC_CTYPE

### DIFF
--- a/overlays/musl.nix
+++ b/overlays/musl.nix
@@ -23,9 +23,14 @@ final: prev: prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl ({
   numactl = prev.numactl.overrideAttrs (_: { configureFlags = ["--enable-static"];});
 
   # See https://github.com/input-output-hk/haskell.nix/issues/948
-  postgresql = (prev.postgresql.overrideAttrs (old: { dontDisableStatic = true; }))
-    .override { enableSystemd = false; gssSupport = false; };
-  
+  postgresql = (prev.postgresql.overrideAttrs (old: {
+      dontDisableStatic = true;
+      # the following is needed becuase libicu links against stdc++
+      NIX_LDFLAGS = "--push-state --as-needed -lstdc++ --pop-state";
+      # without this collate.icu.utf8, and foreign_data will fail.
+      LC_CTYPE = "C";
+    })).override { enableSystemd = false; gssSupport = false; };
+
   openssl = prev.openssl.override { static = true; };
 
   icu = (prev.icu.overrideAttrs (old: { configureFlags = old.configureFlags ++ [ "--enable-static" "--disable-shared" ]; }));


### PR DESCRIPTION
The reason that necessitates setting LC_CTYPE is not fully clear to me, I've left some comments on the nixos/nixpkgs issue tracker. It appears as if we are pulling LC_CTYPE to be some UTC8 value if it's not set, instead of inheriting it from LC_ALL as it supposed to.

https://github.com/NixOS/nixpkgs/issues/150930#issuecomment-1553979592