### PR TITLE
Revert default value for sha256map

### DIFF
--- a/modules/cabal-project.nix
+++ b/modules/cabal-project.nix
@@ -96,8 +96,7 @@ in {
     };
     sha256map = mkOption {
       type = nullOr (attrsOf (either str (attrsOf str)));
-      # Default needed for haskell-language-server 1.10
-      default."https://github.com/pepeiborra/ekg-json"."7a0af7a8fd38045fd15fb13445bdcc7085325460" = "sha256-fVwKxGgM0S4Kv/4egVAAiAjV7QB5PBqMVMCfsv7otIQ=";
+      default = null;
       description = ''
         An alternative to adding `--sha256` comments into the
         cabal.project file:

--- a/modules/hackage-quirks.nix
+++ b/modules/hackage-quirks.nix
@@ -43,6 +43,14 @@ in [
     }
   )
 
+  ({config, lib, pkgs, ...}:
+    { _file = "haskell.nix/overlays/hackage-quirks.nix#haskell-language-server"; } //
+    lib.mkIf (config.name == "haskell-language-server") {
+      # Default needed for haskell-language-server 1.10
+      sha256map."https://github.com/pepeiborra/ekg-json"."7a0af7a8fd38045fd15fb13445bdcc7085325460" = "sha256-fVwKxGgM0S4Kv/4egVAAiAjV7QB5PBqMVMCfsv7otIQ=";
+    }
+  )
+
   # The latest version of stack (2.9.1) in hackage fails to build because the
   # of version of rio-prettyprint (recently released 0.1.4.0) chosen by cabal.
   # https://github.com/commercialhaskell/stack/issues/5963


### PR DESCRIPTION
This breaks the behaviour when a `sha256map` is not provided, since the logic that uses it in `cabal-project-parser` treats a `null` `sha256map` differently from one that is present but lacks entires for a key. The former will just try and proceed without a hash (which can succeed), the latter always fails with a missing key error. Adding a default value pushes us into the latter case unless we manually set the `sha256map` to null.

I think we should try to find another way to make HLS work that doesn't break other uses. Or we could make the `sha256map` usage logic behave the same for a missing map and a map with a missing key.