### PR TITLE
Improve the way `sha256map` works

### DIFF
--- a/lib/cabal-project-parser.nix
+++ b/lib/cabal-project-parser.nix
@@ -84,8 +84,8 @@ let
     url = repo.location;
     "${refOrRev}" = repo.tag;
     sha256 = repo."--sha256" or (
-      if sha256map != null
-        then sha256map."${repo.location}"."${repo.tag}"
+      if sha256map != null && sha256map ? ${repo.location}
+        then sha256map.${repo.location}.${repo.tag}
         else null);
     subdirs = if repo ? subdir
       then pkgs.lib.filter (x: x != "") (pkgs.lib.splitString " " repo.subdir)
@@ -136,7 +136,7 @@ let
       attrs = parseBlockLines x.fst;
       sha256 = attrs."--sha256" or (
         if sha256map != null
-          then sha256map."${attrs.url}"
+          then sha256map.${attrs.url} or null
           else null);
     in rec {
       # This is `some-name` from the `repository some-name` line in the `cabal.project` file.

--- a/lib/stack-cache-generator.nix
+++ b/lib/stack-cache-generator.nix
@@ -82,8 +82,10 @@ concatMap (dep:
         let
             is-private = private dep.url;
             sha256 =
-              if dep.sha256 != null then dep.sha256
-              else if sha256map != null then sha256map."${dep.url}"."${dep.rev}"
+              if dep.sha256 != null
+                then dep.sha256
+              else if sha256map != null && sha256map ? ${dep.url}
+                then sha256map.${dep.url}.${dep.rev}
               else null;
             branch = lookupBranch {
               location = dep.url;


### PR DESCRIPTION
This change makes it so `sha256map = null` and `sha256map = {}` work the same.  When looking up a sha256 in the map it will only now fail if the map  contains an entry for the url, but not for the tag required.