### PR TITLE
Properly transcode absolute LoadDLL paths for WINE

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -210,7 +210,6 @@ in {
                 ++ final.lib.optional (versionAtLeast "8.10"   && versionLessThan "9.0" && final.stdenv.targetPlatform.isAarch64) ./patches/ghc/ghc-8.10-aarch64-handle-none-rela.patch
                 ++ final.lib.optional (versionAtLeast "9.0"                             && final.stdenv.targetPlatform.isAarch64) ./patches/ghc/ghc-9.0-better-symbol-addr-debug.patch
                 ++ final.lib.optional (versionAtLeast "9.0"                             && final.stdenv.targetPlatform.isAarch64) ./patches/ghc/ghc-9.0-aarch64-handle-none-rela.patch
-                ++ final.lib.optional (versionAtLeast "8.10.6")                                                                   ./patches/ghc/ghc-8.10.7-iserv-proxy-load-dlls.patch
                 ;
         in ({
             ghc865 = final.callPackage ../compiler/ghc (traceWarnOld "8.6" {

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -210,7 +210,7 @@ in {
                 ++ final.lib.optional (versionAtLeast "8.10"   && versionLessThan "9.0" && final.stdenv.targetPlatform.isAarch64) ./patches/ghc/ghc-8.10-aarch64-handle-none-rela.patch
                 ++ final.lib.optional (versionAtLeast "9.0"                             && final.stdenv.targetPlatform.isAarch64) ./patches/ghc/ghc-9.0-better-symbol-addr-debug.patch
                 ++ final.lib.optional (versionAtLeast "9.0"                             && final.stdenv.targetPlatform.isAarch64) ./patches/ghc/ghc-9.0-aarch64-handle-none-rela.patch
-                ++ final.lib.optional (versionAtLeast "8.10.6"                          && final.stdenv.targetPlatform.isWindows) ./patches/ghc/ghc-8.10.7-iserv-proxy-load-dlls.patch
+                ++ final.lib.optional (versionAtLeast "8.10.6")                                                                   ./patches/ghc/ghc-8.10.7-iserv-proxy-load-dlls.patch
                 ;
         in ({
             ghc865 = final.callPackage ../compiler/ghc (traceWarnOld "8.6" {

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -210,6 +210,7 @@ in {
                 ++ final.lib.optional (versionAtLeast "8.10"   && versionLessThan "9.0" && final.stdenv.targetPlatform.isAarch64) ./patches/ghc/ghc-8.10-aarch64-handle-none-rela.patch
                 ++ final.lib.optional (versionAtLeast "9.0"                             && final.stdenv.targetPlatform.isAarch64) ./patches/ghc/ghc-9.0-better-symbol-addr-debug.patch
                 ++ final.lib.optional (versionAtLeast "9.0"                             && final.stdenv.targetPlatform.isAarch64) ./patches/ghc/ghc-9.0-aarch64-handle-none-rela.patch
+                ++ final.lib.optional (versionAtLeast "8.10.6"                          && final.stdenv.targetPlatform.isWindows) ./patches/ghc/ghc-8.10.7-iserv-proxy-load-dlls.patch
                 ;
         in ({
             ghc865 = final.callPackage ../compiler/ghc (traceWarnOld "8.6" {

--- a/overlays/ghc-packages.nix
+++ b/overlays/ghc-packages.nix
@@ -250,7 +250,10 @@ in rec {
                        + "/${ghc-extra-projects-type proj.ghc}/${ghcName}";
       compiler-nix-name = ghcName;
       configureArgs = "--disable-tests --disable-benchmarks --allow-newer='terminfo:base'"; # avoid failures satisfying bytestring package tests dependencies
-      modules = [{ reinstallableLibGhc = false; }];
+      modules = [{
+        packages.iserv-proxy.patches = [./patches/ghc/ghc-8.10.7-iserv-proxy-load-dlls.patch];
+        reinstallableLibGhc = false;
+      }];
     }))
     ghc-extra-pkgs-cabal-projects;
 

--- a/overlays/patches/ghc/ghc-8.10.7-iserv-proxy-load-dlls.patch
+++ b/overlays/patches/ghc/ghc-8.10.7-iserv-proxy-load-dlls.patch
@@ -1,7 +1,7 @@
 diff --git a/utils/iserv-proxy/src/Main.hs b/utils/iserv-proxy/src/Main.hs
 index 364a2af..68d7307 100644
---- a/utils/iserv-proxy/src/Main.hs
-+++ b/utils/iserv-proxy/src/Main.hs
+--- a/src/Main.hs
++++ b/src/Main.hs
 @@ -283,8 +283,15 @@ proxy verbose local remote = loop
          LoadDLL path@('C':':':_) -> do
            fwdCall msg' >>= reply >> loop

--- a/overlays/patches/ghc/ghc-8.10.7-iserv-proxy-load-dlls.patch
+++ b/overlays/patches/ghc/ghc-8.10.7-iserv-proxy-load-dlls.patch
@@ -1,0 +1,22 @@
+diff --git a/utils/iserv-proxy/src/Main.hs b/utils/iserv-proxy/src/Main.hs
+index 364a2af..68d7307 100644
+--- a/utils/iserv-proxy/src/Main.hs
++++ b/utils/iserv-proxy/src/Main.hs
+@@ -283,8 +283,15 @@ proxy verbose local remote = loop
+         LoadDLL path@('C':':':_) -> do
+           fwdCall msg' >>= reply >> loop
+         LoadDLL path | isAbsolute path -> do
+-          resp <- fwdLoadCall verbose local remote msg'
+-          reply resp
++          target <- lookupEnv "ISERV_TARGET"
++          case target of
++            Just "WINE" -> do
++              let path' = 'Z':':':'\\':map (\c -> if c == '/' then '\\' else c) path
++              resp <- fwdCall (LoadDLL path')
++              reply resp
++            Nothing -> do
++              resp <- fwdLoadCall verbose local remote msg'
++              reply resp
+           loop
+         Shutdown{}    -> fwdCall msg' >> return ()
+         _other        -> fwdCall msg' >>= reply >> loop


### PR DESCRIPTION
We have this sub-protocol in the iserv-proxy (which follows the sub-TH protocol). The design is horrendous, and needs to be rethought.  The issue we were seeing is that we started the sub-protocol, because a path looked like it was absolute, however on the receiving end (windows), the path /foo/bar/baz, is _not_ an absolute windows path. Thus the corresponding branch dealing with the sub-protocol was not taken and we were stuck with messages sent for the primary protocol, and not understood by the sub-protocol.

This change transcodes unix paths to windows paths, _IF_ the ISERV_TARGET environment var is set to WINE. In this case we know we can use Z:\\ as / and share the same file system. This is good enough for haskell.nix, but a massive hack generally.