### PR TITLE
Add pgcommon and pgport to nixpkgs map

### DIFF
--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -52,6 +52,8 @@ in
   bz2 = [ bzip2 ];
   util = [ utillinux ];
   magic = [ file ];
+  pgcommon = [ postgresql ];
+  pgport = [ postgresql] ;
   pq = [ postgresql ];
   libpq = [ postgresql ];
   iconv = [ libiconv ];


### PR DESCRIPTION
It was necessary to add these to get static linking working on `musl` for a project using `postgres-simple`