### PR TITLE
Add .doc derivation to test components

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -361,7 +361,7 @@ let
       });
       profiled = self (drvArgs // { enableLibraryProfiling = true; });
       dwarf = self (drvArgs // { enableDWARF = true; });
-    } // lib.optionalAttrs (haskellLib.isLibrary componentId) ({
+    } // lib.optionalAttrs (haskellLib.isLibrary componentId || haskellLib.isTest componentId) ({
         inherit haddock;
         inherit (haddock) haddockDir; # This is null if `doHaddock = false`
       } // lib.optionalAttrs (haddock ? doc) {

--- a/builder/haddock-builder.nix
+++ b/builder/haddock-builder.nix
@@ -23,7 +23,7 @@
 
 let
   doHaddock' = doHaddock
-    && (haskellLib.isLibrary componentId)
+    && (haskellLib.isLibrary componentId || haskellLib.isTest componentId)
     && !haskellLib.isCrossHost;
 
   # the target dir for haddock documentation
@@ -111,6 +111,7 @@ let
       [[ -n $(find . -name "*.hs" -o -name "*.lhs") ]] && {
       $SETUP_HS haddock \
         "--html" \
+        ${lib.optionalString (haskellLib.isTest componentId) "--tests"} \
         ${lib.optionalString doHoogle "--hoogle"} \
         ${lib.optionalString hyperlinkSource "--hyperlink-source"} \
         ${lib.optionalString quickjump "--quickjump"} \

--- a/builder/haddock-builder.nix
+++ b/builder/haddock-builder.nix
@@ -26,8 +26,8 @@ let
     && (haskellLib.isLibrary componentId || haskellLib.isTest componentId)
     && !haskellLib.isCrossHost;
 
-  # the target dir for haddock documentation
-  docdir = docoutput: docoutput + "/share/doc/" + componentId.cname;
+  # The target dir for haddock documentation
+  docdir = docoutput: docoutput + "/share/doc/" + package.identifier.name;
 
   packageCfgDir = configFiles.packageCfgDir;
 

--- a/builder/haddock-builder.nix
+++ b/builder/haddock-builder.nix
@@ -130,7 +130,7 @@ let
            # Ensure that libraries are not pulled into the docs closure.
            # As an example, the prettified source code of a
            # Paths_package module will contain store paths of the library package.
-           for x in "$html/src/"*.html; do
+           for x in $(find "$html" -name "*.html"); do
              remove-references-to -t $out $x
              remove-references-to -t ${componentDrv} $x
            done

--- a/test/sublib-docs/default.nix
+++ b/test/sublib-docs/default.nix
@@ -46,9 +46,9 @@ in recurseIntoAttrs {
       otool -L $exe |grep .dylib
     '') + ''
 
-      # Check that it looks like we have docs
+      printf "check that it looks like we have docs..." >& 2
       test -f "${packages.sublib-docs.components.library.doc}/share/doc/sublib-docs/html/Lib.html"
-      test -f "${packages.sublib-docs.components.sublibs.slib.doc}/share/doc/slib/html/Slib.html"
+      test -f "${packages.sublib-docs.components.sublibs.slib.doc}/share/doc/sublib-docs/html/Slib.html"
 
       touch $out
     '';


### PR DESCRIPTION
This adds a `.doc` as it is available on `<package>.components.library.doc` also to test components `<package>.components.tests.<test>.doc`, for example https://github.com/input-output-hk/hydra/blob/77c612f2540bcca6cc43ca5c6c7094e35f0edd12/flake.nix#L53.

The output paths follow a similar pattern as `cabal-install` would produce (despite the fact that it puts things into completely different prefixes) and are easily combinable as also seen in the above link. For example a package with name "foo" and test suite "bar" will
have output paths:

$doc/share/doc/foo/html/index.html # library haddocks
$doc/share/doc/foo/html/bar/index.html # bar test suite haddocks