### PR TITLE
CI: dead code removal check

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,0 +1,32 @@
+name: "Lints"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+
+  push:
+    branches:
+      - master
+
+defaults:
+  run:
+    shell: bash
+
+# do we really want nixos-unstable?
+env:
+  NIX_PATH: "nixpkgs=channel:nixos-unstable"
+  REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  deadnix:
+    runs-on: [self-hosted, linux]
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          nix run github:astro/deadnix -- --edit --no-lambda-pattern-names
+          TMPFILE=$(mktemp)
+          git diff >"${TMPFILE}"
+          git stash -u && git stash drop
+          nix-shell -p reviewdog --run "reviewdog -f=diff -f.diff.strip=1 -reporter=github-pr-review < \"${TMPFILE}\""


### PR DESCRIPTION
This PR adds a CI job that runs the nix run `github:astro/deadnix -- --edit --no-lambda-pattern-names` command to remove dead code. If this command results in any uncommitted changes, the CI job will fail, indicating the presence of dead code in the repository that needs to be removed. See https://github.com/input-output-hk/haskell.nix/pull/1756