### PR TITLE
Fix building stack projects with hix

### DIFF
--- a/modules/hix-project.nix
+++ b/modules/hix-project.nix
@@ -1,4 +1,4 @@
-{ lib, ... }: {
+{ config, lib, ... }: {
   _file = "haskell.nix/modules/hix-project.nix";
   options = {
     # These are options that only the Hix command wrappers use. If you make a flake
@@ -40,8 +40,10 @@
     };
   };
 
-  # Default values for other project options (things that do not have defaults for non hix projects)
-  config = {
-    compiler-nix-name = lib.mkDefault "ghc8107";
+  # Default value for compiler-nix-name (does not have a default for non hix projects).
+  # Stack projects do not require a default as the `resolver` in the `stack.yaml`
+  # specifies one.
+  config = lib.mkIf (!config ? "stackYaml") {
+    compiler-nix-name = lib.mkDefault "ghc945";
   };
 }


### PR DESCRIPTION
The default compiler-nix-name provided for hix projects conflicts with the one implied by the `stack.yaml` `resolver`.

Fixes #1997