### PR TITLE
Fix building stack tool

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -46,12 +46,9 @@ in rec {
     } // pkgs.lib.optionalAttrs (__compareVersions haskell.compiler.${compiler-nix-name}.version "9.6" < 0) {
       stack =
         tool compiler-nix-name "stack" {
-          cabalProjectLocal = ''
-            constraints: optparse-applicative <0.18
-          '';
           version =
             if __compareVersions haskell.compiler.${compiler-nix-name}.version "9.2" < 0
-              then "2.9.3"
+              then "2.9.3.1"
               else "2.11.1";
           inherit evalPackages;
         };

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -1,14 +1,4 @@
 { pkgs, runCommand, cacert, index-state-hashes, haskellLib }@defaults:
-let readIfExists = src: fileName:
-      # Using origSrcSubDir bypasses any cleanSourceWith.
-      # `lookForCabalProject` allows us to avoid looking in source from hackage
-      # for cabal.project files.  It is set in `modules/hackage-project.nix`.
-      let origSrcDir = src.origSrcSubDir or src;
-      in
-        if (src.lookForCabalProject or true) && builtins.elem ((__readDir origSrcDir)."${fileName}" or "") ["regular" "symlink"]
-          then __readFile (origSrcDir + "/${fileName}")
-          else null;
-in
 { name          ? src.name or null # optional name for better error messages
 , src
 , materialized-dir ? ../materialized
@@ -19,9 +9,9 @@ in
 , materialized  ? null # Location of a materialized copy of the nix files
 , checkMaterialization ? null # If true the nix files will be generated used to check plan-sha256 and material
 , cabalProjectFileName ? "cabal.project"
-, cabalProject         ? readIfExists src cabalProjectFileName
-, cabalProjectLocal    ? readIfExists src "${cabalProjectFileName}.local"
-, cabalProjectFreeze   ? readIfExists src "${cabalProjectFileName}.freeze"
+, cabalProject         ? null
+, cabalProjectLocal    ? null
+, cabalProjectFreeze   ? null
 , caller               ? "callCabalProjectToNix" # Name of the calling function for better warning messages
 , compilerSelection    ? p: p.haskell-nix.compiler
 , ghc           ? null # Deprecated in favour of `compiler-nix-name`

--- a/modules/cabal-project.nix
+++ b/modules/cabal-project.nix
@@ -2,9 +2,12 @@
 with lib;
 with types;
 let readIfExists = src: fileName:
+      # Using origSrcSubDir bypasses any cleanSourceWith.
+      # `lookForCabalProject` allows us to avoid looking in source from hackage
+      # for cabal.project files.  It is set in `modules/hackage-project.nix`.
       let origSrcDir = src.origSrcSubDir or src;
       in
-        if builtins.elem ((__readDir origSrcDir)."${fileName}" or "") ["regular" "symlink"]
+        if (src.lookForCabalProject or true) && builtins.elem ((__readDir origSrcDir)."${fileName}" or "") ["regular" "symlink"]
           then __readFile (origSrcDir + "/${fileName}")
           else null;
 in {

--- a/modules/hackage-quirks.nix
+++ b/modules/hackage-quirks.nix
@@ -43,16 +43,13 @@ in [
     }
   )
 
-  # The latest version of stack (2.9.1) in hackage fails to build because the
-  # of version of rio-prettyprint (recently released 0.1.4.0) chosen by cabal.
-  # https://github.com/commercialhaskell/stack/issues/5963
+  # Avoid pantry 0.9 in versions without https://github.com/commercialhaskell/stack/pull/6187
+  # Also avoid optparse-applicative 0.18
   ({config, lib, pkgs, ...}:
     { _file = "haskell.nix/overlays/hackage-quirks.nix#stack"; } //
-    lib.mkIf (config.name == "stack" && builtins.compareVersions config.version "2.9.3" <= 0) {
+    lib.mkIf (config.name == "stack" && builtins.compareVersions config.version "2.11.1" <= 0) {
       cabalProjectLocal = ''
-        constraints: unix-compat <0.7${
-          lib.optionalString (builtins.compareVersions config.version "2.9.1" <= 0)
-            " rio-prettyprint <0.1.4.0"}
+        constraints: pantry <0.9, optparse-applicative <0.18
       '';
     }
   )


### PR DESCRIPTION
Avoid pantry 0.9 in versions without https://github.com/commercialhaskell/stack/pull/6187

This also:
* moves the `optparse-applicative` upper bound into `modules/hackage-quirks.nix`
* Fixes `readIfExists` in `modules/cabal-project.nix`.
* Removes `readIfExists` from `lib/call-cabal-project-to-nix.nix`.