### PR TITLE
Fix "supportHpack: command not found"

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -423,7 +423,7 @@ let
               hpack $hpackFile
             ''
             else ''
-              echo WARNING $hpackFile has no .cabal file and `supportHpack` was not set.
+              echo "WARNING $hpackFile has no .cabal file and \`supportHpack\` was not set."
             ''
           }
         fi


### PR DESCRIPTION
Corrects the following failure signature to one which is at least sensible:
```
last 3 log lines:
> /build/.attr-0l2nkwhif96f51f4amnlf414lhl4rv9vh8iffyp431v6s28gsr90: line 22: supportHpack: command not found
> WARNING ./package.yaml has no .cabal file and was not set.
```

This was *invoking* `supportHpack` as an executable due to lack of escaping or proper quoting.