### PR TITLE
Add 'preInstall' hook for GHC on darwin

### DIFF
--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -722,6 +722,10 @@ stdenv.mkDerivation (rec {
       substituteInPlace rts/win32/ThrIOManager.c --replace rts\\OSThreads.h rts/OSThreads.h
     fi
   '';
+  # Same hack as 'preBuild'
+  preInstall = lib.optionalString stdenv.buildPlatform.isDarwin ''
+    export XATTR=$(mktemp -d)/nothing
+  '';
 } // lib.optionalAttrs useHadrian {
   postConfigure = lib.optionalString stdenv.isDarwin ''
     substituteInPlace mk/system-cxx-std-lib-1.0.conf \
@@ -774,6 +778,7 @@ stdenv.mkDerivation (rec {
           --replace ',("windres command", "/bin/false")' ',("windres command", "${targetCC.bintools.targetPrefix}windres")'
       ''
       else ''
+        runHook preInstall
         ${hadrian}/bin/hadrian ${hadrianArgs} binary-dist-dir
         cd _build/bindist/ghc-*
         ./configure --prefix=$out ${lib.concatStringsSep " " configureFlags}


### PR DESCRIPTION
Problem: Since 9.2.3 'xattr' is used during GHC 'make install' on darwin. This introduces the same issue that was previously fixed for 'buildPhase'.

Solution: Add optional 'preInstall' attribuite that sets 'XATTR' to a non-existing path which will skip the 'xattr' invocations during 'make install'. Also explicitly call 'preInstall' hook during 'installPhase'.

Fixes #2008.