### PR TITLE
Allow passing a tarball to hackage2nix without a url

### DIFF
--- a/nix-tools/hackage2nix/Main.hs
+++ b/nix-tools/hackage2nix/Main.hs
@@ -66,6 +66,7 @@ main = do
   (inp, src) <- case rest of
                  [tarball, url, hash] -> return (tarball, Just $ Repo url (Just hash))
                  [tarball, url] -> return (tarball, Just $ Repo url Nothing)
+                 [tarball] -> return (tarball, Nothing)
                  [] -> hackageTarball >>= \tarball -> return (tarball, Nothing)
 
   db    <- U.readTarball Nothing inp


### PR DESCRIPTION
cabal has started using XDG paths for the index and a quick fix is to just pass hackage2nix the path to the tarball. But so far we are forced to specify an url as well, which is not needed when you use hackageTarball. This difference in behaviour causes all nix files to change.

This change allows passing a tarball and no url, just like we do with hackage.

This is one step to fix https://github.com/input-output-hk/haskell.nix/issues/2013