### PR TITLE
Fix coverage test

### DIFF
--- a/test/coverage/cabal.project
+++ b/test/coverage/cabal.project
@@ -1,8 +1,2 @@
 packages: pkga
           pkgb
-
-source-repository-package
-  type: git
-  location: https://github.com/glguy/th-abstraction.git
-  tag: 24b9ea9b498b182e44abeb3a755e2b4e35c48788
-  --sha256: sha256-nWWZVEek0fNVRI+P5oXkuJyrPJWts5tCphymFoYWIPg=


### PR DESCRIPTION
Removes the th-abstraction source-repository-package that does not seem to be needed any more.