### PR TITLE
Use haskell.nix in for hadrian

### DIFF
--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -239,7 +239,7 @@ let
   # value for us.
   installStage1 = useHadrian && (haskell-nix.haskellLib.isCrossTarget || stdenv.targetPlatform.isMusl);
 
-  hadrian = buildPackages.haskell-nix.tool "ghc8107" "hadrian" {
+  hadrian = buildPackages.pinned-haskell-nix.tool "ghc8107" "hadrian" {
       compilerSelection = p: p.haskell.compiler;
       index-state = buildPackages.haskell-nix.internalHackageIndexState;
       # Verions of hadrian that comes with 9.6 depends on `time`

--- a/flake.nix
+++ b/flake.nix
@@ -156,7 +156,15 @@
       let
         legacyPackages = (self.internal.compat { inherit system; }).pkgs;
         nix-tools-hydraJobs =
-          let cf = callFlake { pkgs = legacyPackages; inherit system; src = ./nix-tools; };
+          let cf = callFlake {
+            pkgs = legacyPackages;
+            inherit system;
+            src = ./nix-tools;
+            override-inputs = {
+              # Avoid downloading another `hackage.nix`.
+              inherit (inputs) hackage;
+            };
+          };
           in cf.defaultNix.hydraJobs;
       in rec {
         inherit legacyPackages;

--- a/nix-tools/flake.nix
+++ b/nix-tools/flake.nix
@@ -7,8 +7,7 @@
       systems = [
         "x86_64-linux"
         "x86_64-darwin"
-        # TODO switch back on when ci.iog.io has builders for aarch64-linux
-        # "aarch64-linux"
+        "aarch64-linux"
         "aarch64-darwin"
       ];
 
@@ -48,6 +47,10 @@
 
       legacyPackages = forAllSystems (pkgs: pkgs);
 
+      lib = {
+        nix-tools = system: (haskellNix.legacyPackages.${system}.extend self.overlays.default).nix-tools;
+        haskell-nix = system: (haskellNix.legacyPackages.${system}.extend self.overlays.default).haskell-nix;
+      };
       project = forAllSystems (pkgs: pkgs.nix-tools.project);
 
       packages = forAllSystems (pkgs:


### PR DESCRIPTION
Using musl64 version of nix-tools goes some way to avoid recompiles of GHC when updating haskell.nix.  However any changes that impact the way `hadrian` will be built (for instance changes to `builder/comp-builder.nix`) will cause `hadrian` to need to be rebuilt.  This intern causes GHC >=9.4 to need rebuilding.

To make this less likely this change adds a `pinned-haskell-nix` using the `nix-tools` subflake.  Then hadrian is built using this.

Also when the static version of `nix-tools` cannot be used (macOS), a pinned version is used instead.

The `nixpkgs` used is also pinned, making it easier for people to use other versions of nixpkgs.

The `hackage.nix` is passed in to the `nix-tools` subflake to avoid downloading two copies when setting up a new machine (stackage.nix is not used).