### PR TITLE
Allow order independent overlays

### DIFF
--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -9,10 +9,10 @@ final: prev: {
         # Default modules, these will always be included.
         # They are here to be overridden/added to by other
         # overlays.
-        defaultModules = [];
+        defaultModules = prev.haskell-nix.defaultModules or [];
 
         # Additional user-provided mappings to augment ./../lib/pkgconf-nixpkgs-map.nix
-        extraPkgconfigMappings = {};
+        extraPkgconfigMappings = prev.haskell-nix.extraPkgconfigMappings or {};
         # Nix Flake based source pins.
         # To update all inputs, get unstable Nix and then `nix flake update --recreate-lock-file`
         # Or `nix-shell -p nixUnstable --run "nix --experimental-features 'nix-command flakes' flake update --recreate-lock-file"`


### PR DESCRIPTION
Currently the haskell.nix overlays ignore any `defaultModules` and `extraPkgconfigMappings` set in `prev`.  This means it is not possible to have an overly include these in an way that will work both before and after the haskell.nix overlays.

With this change an overlay can be written like this:

```
final: prev: {
  haskell-nix = prev.haskell-nix or {} // {
    extraPkgconfigMappings = prev.haskell-nix.extraPkgconfigMappings or {} // {
    ...
```

It can then be included before or after the haskell.nix overlays.

See #1954