### PR TITLE
Add WASM-related os/arch for Cabal

### DIFF
--- a/lib/cabal-os-arch-comp.nix
+++ b/lib/cabal-os-arch-comp.nix
@@ -34,6 +34,7 @@
     isIOS       = false;
     isAndroid   = false;
     isGhcjs     = false;
+    isWasi      = false;
   };
   arch = {
     # Archs
@@ -54,5 +55,6 @@
     isM68k   = false;
     isVax    = false;
     isJavaScript = false;
+    isWasm32 = false;
   };
 }


### PR DESCRIPTION
Closes #2042 by adding the necessary defaults

Relevant Cabal PR: https://github.com/haskell/cabal/pull/8096