### PR TITLE
Add the attribute `options` to projects

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -335,7 +335,7 @@ in {
             inherit (project) hsPkgs;
           })
         ];
-      }).config;
+      });
     in project;
 
   # Converts from a `compoent.depends` value to a library derivation.


### PR DESCRIPTION
Previously we only exposed the config of the evaluated project
configuration modules under the name args (because effectively it is
what you could have passed to the project function).

This patch exposes also the options attribute from the configuration
evaluation. This is very helpful while troubleshooting how the final
configuration comes to be.
