### PR TITLE
Redesign ghcjs and head-hackage overlays

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -83,7 +83,7 @@ let
       then ghcOverride
       else
         if ghc != null
-          then __trace ("WARNING: A `ghc` argument was passed" + forName
+          then builtins.trace ("WARNING: A `ghc` argument was passed" + forName
             + " this has been deprecated in favour of `compiler-nix-name`. "
             + "Using `ghc` will break cross compilation setups, as haskell.nix cannot "
             + "pick the correct `ghc` package from the respective buildPackages. "
@@ -138,10 +138,6 @@ in let
       pkgs.lib.optionalString (cabalProjectLocal != null) ''
         -- Added from `cabalProjectLocal` argument to the `cabalProject` function
         ${cabalProjectLocal}
-      ''
-      + pkgs.lib.optionalString (cabalProjectDefaults != null) ''
-        -- Added from `cabalProjectDefaults` argument to the `cabalProject` function
-        ${cabalProjectDefaults}
       ''
     }
   '';

--- a/modules/cabal-project.nix
+++ b/modules/cabal-project.nix
@@ -1,17 +1,16 @@
-{ lib, config, pkgs, haskellLib, ... }:
+{ lib, config, pkgs, ... }:
 with lib;
 with types;
-let readIfExists = src: fileName:
-      # Using origSrcSubDir bypasses any cleanSourceWith.
-      # `lookForCabalProject` allows us to avoid looking in source from hackage
-      # for cabal.project files.  It is set in `modules/hackage-project.nix`.
-      let origSrcDir = src.origSrcSubDir or src;
-      in
-        if (src.lookForCabalProject or true) && builtins.elem ((__readDir origSrcDir)."${fileName}" or "") ["regular" "symlink"]
-          then __readFile (origSrcDir + "/${fileName}")
-          else null;
-in {
+{
   _file = "haskell.nix/modules/cabal-project.nix";
+
+  imports = [
+    ./cabal-project/ghcjs-overlay.nix
+    ./cabal-project/head-hackage.nix
+    ./cabal-project/read-src-project-config.nix
+    ./cabal-project/repositories.nix
+  ];
+
   options = {
     # Used by callCabalProjectToNix
     compiler-nix-name = mkOption {
@@ -73,56 +72,15 @@ in {
     };
     cabalProject = mkOption {
       type = nullOr lines;
-      default = readIfExists config.src config.cabalProjectFileName;
+      default = null;
     };
     cabalProjectLocal = mkOption {
       type = nullOr lines;
-      default = readIfExists config.src "${config.cabalProjectFileName}.local";
-    };
-    cabalProjectDefaults = mkOption {
-      type = nullOr lines;
-      default =
-        let
-          useHeadHackage = __compareVersions pkgs.buildPackages.haskell-nix.compiler.${config.compiler-nix-name}.version "9.8.0" >= 0;
-        in
-          # When building ghc 9.8 and ghc HEAD projects we need to include the
-          # `head.hackage` repository to get the patched versions of packages
-          # that are needed for those versions of GHC.
-          # TODO Currently the sha256 here will need regular updating as
-          # there is no way to pin `head.hackage`.
-          optionalString useHeadHackage ''
-              allow-newer: *:*
-
-              repository head.hackage.ghc.haskell.org
-                url: https://ghc.gitlab.haskell.org/head.hackage/
-                secure: True
-                key-threshold: 3
-                root-keys:
-                   f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-                   26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                   7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                --sha256: sha256-7BB/TeaP4wsQZggI08hZrhdxL7KzUjSyOrMEmuciUas=
-            ''
-            # When building to JS we need the patched versions of packages
-            # included in `hackage-overlay-ghcjs`.
-            + optionalString pkgs.stdenv.hostPlatform.isGhcjs ''
-              repository ghcjs-overlay
-                url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/91f4ce9bea0e7f739b7495647c3f72a308ed1c6f
-                secure: True
-                root-keys:
-                key-threshold: 0
-                --sha256: sha256-mZT7c+xR5cUTjLdCqOxpprjYL3kr/+9rmumtXvWAQlM=
-            ''
-            + ''
-              active-repositories: hackage.haskell.org${
-                  optionalString useHeadHackage ", head.hackage.ghc.haskell.org:override"
-                + optionalString pkgs.stdenv.hostPlatform.isGhcjs ", ghcjs-overlay:override"
-                + concatMapStrings (name: ", ${name}:override") (builtins.attrNames config.extra-hackage-tarballs)}
-            '';
+      default = null;
     };
     cabalProjectFreeze = mkOption {
       type = nullOr lines;
-      default = readIfExists config.src "${config.cabalProjectFileName}.freeze";
+      default = null;
     };
     ghc = mkOption {
       type = nullOr package;

--- a/modules/cabal-project/ghcjs-overlay.nix
+++ b/modules/cabal-project/ghcjs-overlay.nix
@@ -1,0 +1,31 @@
+{ lib, config, pkgs, ... }:
+let
+  cfg = config.ghcjs-overlay;
+in
+{
+  _file = "haskell.nix/modules/cabal-project/ghcjs-overlay.nix";
+
+  options = {
+    ghcjs-overlay.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = pkgs.stdenv.hostPlatform.isGhcjs;
+      defaultText = lib.literalExpression ''
+        pkgs.stdenv.hostPlatform.isGhcjs;
+      '';
+      example = true;
+      description = lib.mdDoc ''
+        When building to JS we need the patched versions of packages included in https://github.com/input-output-hk/hackage-overlay-ghcjs.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    repositories = [{
+      name = "ghcjs-overlay";
+      url = "https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/91f4ce9bea0e7f739b7495647c3f72a308ed1c6f";
+      secure = true;
+      sha256 = "sha256-mZT7c+xR5cUTjLdCqOxpprjYL3kr/+9rmumtXvWAQlM=";
+      override = true;
+    }];
+  };
+}

--- a/modules/cabal-project/head-hackage.nix
+++ b/modules/cabal-project/head-hackage.nix
@@ -1,0 +1,70 @@
+{ lib, config, pkgs, ... }:
+let
+  cfg = config.head-hackage;
+in
+{
+  _file = "haskell.nix/modules/cabal-project/head-hackage.nix";
+
+  options = {
+    head-hackage = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default =
+          builtins.compareVersions
+            pkgs.buildPackages.haskell-nix.compiler.${config.compiler-nix-name}.version
+            "9.8.0" >= 0;
+        defaultText = lib.literalExpression ''
+          builtins.compareVersions
+            pkgs.buildPackages.haskell-nix.compiler.''${config.compiler-nix-name}.version
+            "9.8.0" >= 0;
+        '';
+        example = true;
+        description = lib.mdDoc ''
+          When building ghc 9.8 and ghc HEAD projects we need to include the
+          `head.hackage` repository to get the patched versions of packages that
+          are needed for those versions of GHC.
+        '';
+      };
+
+      sha256 = lib.mkOption {
+        type = lib.types.str;
+        default = "sha256-DXv6ZLGdD17ppJdww7NUYdKnKtEAMOIayvK/hO4+DL8=";
+        description = lib.mdDoc ''
+          Currently the sha256 needs regular updating as there is no way to pin
+          `head.hackage`.
+        '';
+      };
+
+      allow-newer = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = lib.mdDoc ''
+          Whether or not include "allow-newer: all" in the cabal project config
+          file. True by default as it is often needed when working with new
+          compiler versions.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    repositories = [{
+      name = "head.hackage.ghc.haskell.org";
+      url = "https://ghc.gitlab.haskell.org/head.hackage/";
+      secure = true;
+      key-threshold = 3;
+      root-keys = [
+        "f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89"
+        "26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329"
+        "7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d"
+      ];
+      sha256 = cfg.sha256;
+      override = true;
+    }];
+
+    # TODO: this really should set cabalProject but the logic around
+    # missing/implicit cabal.project files is fragile. Revisit this in the
+    # future.
+    cabalProjectLocal = lib.mkIf cfg.allow-newer "allow-newer: all";
+  };
+}

--- a/modules/cabal-project/read-src-project-config.nix
+++ b/modules/cabal-project/read-src-project-config.nix
@@ -1,0 +1,27 @@
+{ lib, config, ... }:
+with lib;
+let
+  readIfExists = fileName:
+    # Using origSrcSubDir bypasses any cleanSourceWith.
+    # `lookForCabalProject` allows us to avoid looking in source from hackage
+    # for cabal.project files.  It is set in `modules/hackage-project.nix`.
+    let origSrcDir = config.src.origSrcSubDir or config.src;
+    in
+    if (config.src.lookForCabalProject or true) &&
+      builtins.elem ((__readDir origSrcDir)."${fileName}" or "") [ "regular" "symlink" ]
+    then builtins.readFile (origSrcDir + "/${fileName}")
+    else null;
+
+  cabalProjectOrNull = readIfExists config.cabalProjectFileName;
+  cabalProjectLocalOrNull = readIfExists "${config.cabalProjectFileName}.local";
+  cabalProjectFreezeOrNull = readIfExists "${config.cabalProjectFileName}.freeze";
+in
+{
+  _file = "haskell.nix/modules/cabal-project/read-src-project-config.nix";
+
+  config = {
+    cabalProject = lib.mkDefault cabalProjectOrNull;
+    cabalProjectLocal = lib.mkDefault cabalProjectLocalOrNull;
+    cabalProjectFreeze = lib.mkDefault cabalProjectFreezeOrNull;
+  };
+}

--- a/modules/cabal-project/repositories.nix
+++ b/modules/cabal-project/repositories.nix
@@ -1,0 +1,90 @@
+{ config, lib, ... }:
+with lib;
+let
+  repository = with types;
+    submodule {
+      options = {
+        name = mkOption { type = str; };
+        url = mkOption { type = str; };
+        secure = mkOption { type = bool; default = true; };
+        root-keys = mkOption { type = nullOr (listOf str); default = null; };
+        key-threshold = mkOption { type = nullOr int; default = null; };
+        sha256 = mkOption { type = nullOr str; default = null; };
+        override = mkOption { type = bool; default = false; };
+      };
+    };
+
+  renderRepository = repo:
+    ''
+      repository ${repo.name}
+        url: ${repo.url}
+        secure: ${ if repo.secure then "True" else "False" }
+    '' +
+    optionalString (repo.root-keys != null) (
+      "  root-keys:\n" +
+      concatMapStringsSep "\n" (str: "    ${str}") repo.root-keys +
+      "\n"
+    ) +
+    optionalString (repo.key-threshold != null)
+      "  key-threshold: ${builtins.toString repo.key-threshold}\n"
+    +
+    optionalString (repo.sha256 != null)
+      "  --sha256: ${repo.sha256}\n";
+in
+{
+  _file = "haskell.nix/modules/cabal-project/repositories.nix";
+
+  options = {
+    repositories = mkOption {
+      type = with types; listOf (either str repository);
+      default = [ ];
+      description = lib.mdDoc "Additional repository specifications";
+      example = [
+        {
+          name = "cardano-haskell-packages";
+          url = "https://input-output-hk.github.io/cardano-haskell-packages";
+          secure = true;
+        }
+        ''
+          repository ghcjs-overlay
+            url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/91f4ce9bea0e7f739b7495647c3f72a308ed1c6f
+            secure: True
+            root-keys:
+            key-threshold: 0
+            --sha256: sha256-mZT7c+xR5cUTjLdCqOxpprjYL3kr/+9rmumtXvWAQlM=
+        ''
+      ];
+    };
+
+    active-repositories = mkOption {
+      type = with types; listOf str;
+      description = "Specify active package repositories";
+    };
+  };
+
+  config = {
+    # TODO: this really should set cabalProject but the logic around
+    # missing/implicit cabal.project files is fragile. Revisit this in the
+    # future.
+    #
+    # Using mkMerge here and not directly concatStringsSep to avoid inserting an
+    # empty line into the configuration file.
+    cabalProjectLocal = lib.mkMerge (
+      (builtins.map
+        (repo: if isString repo then repo else renderRepository repo)
+        config.repositories)
+      ++
+      # Only :rest is the default value so we can avoid adding it to the
+      # configuration if it is the only value we have.
+      (lib.optional (config.active-repositories != [ ":rest" ])
+        "active-repositories: ${lib.concatStringsSep ", " config.active-repositories}")
+    );
+
+    active-repositories = lib.mkMerge [
+      [ ":rest" ]
+      (builtins.map
+        (repo: repo.name + lib.optionalString repo.override ":override")
+        config.repositories)
+    ];
+  };
+}


### PR DESCRIPTION
- Factor out the logic of applying ghcjs and head-hackage configurations into their own module. This makes more explicit when their are used and how they affect the rest of the project. Also this allows the user to turn them on and off at will.

- Introduce a `repositories` option and build the overlays configuration on top of that. This is limited to what is strictly necessary at this time but other repository-handling features (extra-hackage-tarballs, extra-hackages, ..) could be integrated later on.

- Move reading cabal.project files from the source files to a separate module. This should not introduce any change in behaviour.

Note: In this I add the resulting project configuration to cabal.project.local. I had started with adding it to cabal.project but I hit a roadblock dealing with the logic around the implicit cabal.project. I could not find a way to make it work! I guess it's work for another day.