### PR TITLE
Avoid disabling default binary caches in tutorial

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -17,8 +17,8 @@ You can configure Nix to use our binary cache, which is pushed to by CI, so shou
 You need to add the following sections to `/etc/nix/nix.conf` or, if you are a trusted user, `~/.config/nix/nix.conf` (if you don't know what a "trusted user" is, you probably want to do the former). `[...]` denote any existing entries.
 
 ```
-trusted-public-keys = [...] hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= [...]
-substituters = [...] https://cache.iog.io [...]
+extra-trusted-public-keys = [...] hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= [...]
+extra-substituters = [...] https://cache.iog.io [...]
 ```
 
 If you're running NixOS, you need to add/update the following in your `/etc/nixos/configuration.nix` files instead.


### PR DESCRIPTION
Here's how the current instructions tripped me up:

* I made a fresh install of nix on a new machine, following the [official nix instructions](https://nixos.org/download.html)
* I went to <https://input-output-hk.github.io/haskell.nix/tutorials/getting-started> to setup `haskell.nix`
    * This said to update `trusted-public-keys` and `substituters` in my nix config
    * Since I had a fresh nix install, my nix config was empty
    * So I created the sections `trusted-public-keys = ...` and `substituters = ...`
* nix then started pulling the haskell toolchain (`ghc`, etc.) from binary cache (👍)
* However nix also started building non-haskell packages (`neovim`, `llvm`, `go`, etc.) from source (👎)
    * This is because the `trusted-public-keys = ...` and `substituters = ...` settings
      override the default settings, disabling the default binary cache

This PR removes the stumbling block by using the `extra-` variants of the settings,
which extend rather then override the defaults.

I haven't touched the NixOS instructions since I don't have a NixOS machine to test on.