### PR TITLE
Fetch stack.yaml extra-packages git submodules

### DIFF
--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -502,7 +502,7 @@ final: prev: {
                 # because it is not used by buitins.fetchGit.
                 assert isNull sha256;
                 builtins.fetchGit
-                  ({ inherit url rev; } //
+                  ({ inherit url rev; submodules = true; } //
                       final.buildPackages.lib.optionalAttrs (ref != null) { inherit ref; }
                   )
               else
@@ -515,6 +515,7 @@ final: prev: {
                   url = url;
                   rev = rev;
                   sha256 = sha256;
+                  submodules = true;
                 };
 
             # This is basically entireRepo, but focused on the subdir if it is specified.
@@ -593,11 +594,11 @@ final: prev: {
                         if is-private
                         then
                           builtins.fetchGit
-                            ({ inherit url rev; } //
+                            ({ inherit url rev; submodules = true; } //
                               final.buildPackages.lib.optionalAttrs (ref != null) { inherit ref; }
                             )
                         else
-                          final.fetchgit { inherit url rev sha256; };
+                          final.fetchgit { inherit url rev sha256; submodules = true; };
                     } // final.buildPackages.lib.optionalAttrs (subdir != null && subdir != ".") { postUnpack = "sourceRoot+=/${subdir}; echo source root reset to $sourceRoot"; };
                   };
 


### PR DESCRIPTION
I attempted to pull in a fork of `proto-lens` that I'm working on to ensure that it worked for an upstream project, and found that it failed to build `proto-lens-protbuf-types` due to a dependency on a submodule. When using `stack` directly, it always fetches submodules, so this PR updates calls to fetchGit for `stack` to do the same:

To repro: add this stanza to a `stack.yaml` and depend on `proto-lens-protobuf-types` in the Haskell package. Without this PR, it'll fail because the `.proto` files are used directly from the official Google protobuf repo by cloning it as a submodule.

```
extra-deps:
- git: git@github.com:iand675/proto-lens.git
  commit: 38b1ab1d6785c36694245b19ce6a85ee6869b04a
  subdirs:
  - proto-lens
  - proto-lens-protoc
  - proto-lens-protobuf-types
  - proto-lens-runtime
  - proto-lens-setup
  - proto-lens-json
```

With this PR, that issue doesn't crop up. Unfortunately, I run into a different issue, which is:

```
Error: couldn't find the executable "protoc" in your $PATH.
   Follow the installation instructions at https://google.github.io/proto-lens/installing-protoc.html .
```

So I guess unrelated to the exact change of this PR, can anyone help me understand how to override `buildInputs` and other details of the packages being pulled in from the `stack.yaml`?