### PR TITLE
Enable aarch64-linux in ci

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 0
+{ ifdLevel ? 1
 , checkMaterialization ? false
 , system ? builtins.currentSystem
 , evalSystem ? builtins.currentSystem or "x86_64-linux"

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 1
+{ ifdLevel ? 2
 , checkMaterialization ? false
 , system ? builtins.currentSystem
 , evalSystem ? builtins.currentSystem or "x86_64-linux"

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 2
+{ ifdLevel ? 3
 , checkMaterialization ? false
 , system ? builtins.currentSystem
 , evalSystem ? builtins.currentSystem or "x86_64-linux"

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 3
+{ ifdLevel ? 0
 , checkMaterialization ? false
 , system ? builtins.currentSystem
 , evalSystem ? builtins.currentSystem or "x86_64-linux"

--- a/ci.nix
+++ b/ci.nix
@@ -84,7 +84,6 @@
         ghc928 = true;
         ghc947 = true;
         ghc962 = true;
-        ghc9820230704 = true;
         ${ghc980X nixpkgs} = true;
         ${ghc99X nixpkgs} = true;
       }));

--- a/ci.nix
+++ b/ci.nix
@@ -71,12 +71,7 @@
       # cabal-install and nix-tools plans.  When removing a ghc version
       # from here (so that is no longer cached) also remove ./materialized/ghcXXX.
       # Update supported-ghc-versions.md to reflect any changes made here.
-      nixpkgs.lib.optionalAttrs (nixpkgsName == "R2211") {
-        ghc8107 = false;
-        ghc902 = false;
-        ghc928 = false;
-        ghc947 = false;
-      } // nixpkgs.lib.optionalAttrs (nixpkgsName == "R2305") {
+      nixpkgs.lib.optionalAttrs (nixpkgsName == "R2305") {
         ghc8107 = false;
         ghc902 = false;
         ghc928 = false;

--- a/flake.nix
+++ b/flake.nix
@@ -107,8 +107,7 @@
       systems = [
         "x86_64-linux"
         "x86_64-darwin"
-        # TODO switch back on when ci.iog.io has builders for aarch64-linux
-        # "aarch64-linux"
+        "aarch64-linux"
         "aarch64-darwin"
       ];
 

--- a/nix-tools/flake.lock
+++ b/nix-tools/flake.lock
@@ -139,14 +139,14 @@
     "ghc99": {
       "flake": false,
       "locked": {
-        "lastModified": 1693974777,
-        "narHash": "sha256-r+uFw44X9XVPdDtxylfBuFL+l+5q5cX+vDVT7SCTHB8=",
-        "ref": "hkm/bump-Cabal",
-        "rev": "b2bddd0b8214ac1db6239cc25f7c0aabeb2ebb70",
-        "revCount": 61879,
+        "lastModified": 1695427505,
+        "narHash": "sha256-j0hXl6uEI+Uwf37z3WLuQZN4S0XqGtiepELv2Gl2aHU=",
+        "ref": "refs/heads/master",
+        "rev": "b8e4fe2318798185228fb5f8214ba2384ac95b4f",
+        "revCount": 61951,
         "submodules": true,
         "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/ghc"
+        "url": "https://gitlab.haskell.org/ghc/ghc"
       },
       "original": {
         "submodules": true,
@@ -157,11 +157,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1695255762,
-        "narHash": "sha256-MrGCZqwDlqTF3kTqlVthFxHdT3Q5myztd0w0HqDW7do=",
+        "lastModified": 1695774158,
+        "narHash": "sha256-P9zifDVeDpv94NbwxVd6IQD2oggMa47CaBTjKAMPXqY=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "b0baf08f845443fdb975dbf9c3b065296b83b434",
+        "rev": "ad01b49b5be1112aed7ad135bf667b7b92169ce1",
         "type": "github"
       },
       "original": {
@@ -203,11 +203,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1695257421,
-        "narHash": "sha256-OpDOkm0eVyUdUKQbdWvtUX49ats5epbmpmlsW2WiqHI=",
+        "lastModified": 1695863402,
+        "narHash": "sha256-TX2fQT084Y7lxxUiX7jpn8lhZlnODCNfPeyDPRS5ygc=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "3eacd039a459dc3ff2643b78936bef364e99a068",
+        "rev": "cb3f493ee45c3c27baedf2ce5335be4c7987df5f",
         "type": "github"
       },
       "original": {
@@ -458,11 +458,11 @@
     },
     "nixpkgs-2305": {
       "locked": {
-        "lastModified": 1690680713,
-        "narHash": "sha256-NXCWA8N+GfSQyoN7ZNiOgq/nDJKOp5/BHEpiZP8sUZw=",
+        "lastModified": 1695416179,
+        "narHash": "sha256-610o1+pwbSu+QuF3GE0NU5xQdTHM3t9wyYhB9l94Cd8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "rev": "715d72e967ec1dd5ecc71290ee072bcaf5181ed6",
         "type": "github"
       },
       "original": {
@@ -490,11 +490,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1690720142,
-        "narHash": "sha256-GywuiZjBKfFkntQwpNQfL+Ksa2iGjPprBGL0/psgRZM=",
+        "lastModified": 1695318763,
+        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3acb5c4264c490e7714d503c7166a3fde0c51324",
+        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
         "type": "github"
       },
       "original": {
@@ -533,11 +533,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1695254952,
-        "narHash": "sha256-SRgawuFHYEkgMgESXbOC2fbmBDPh1eJK7+Ix/C1byGM=",
+        "lastModified": 1695773356,
+        "narHash": "sha256-pNc857f4JgtrS4TZR2/GLu0N4VESNGAOSYK6lZVyUM4=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "571c97053533ef429a809c20815666cc2cf8ea45",
+        "rev": "bb18dc10e65c84525d17ac7f3985f47c6517e694",
         "type": "github"
       },
       "original": {

--- a/nix-tools/flake.lock
+++ b/nix-tools/flake.lock
@@ -203,11 +203,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1695863402,
-        "narHash": "sha256-TX2fQT084Y7lxxUiX7jpn8lhZlnODCNfPeyDPRS5ygc=",
+        "lastModified": 1695872581,
+        "narHash": "sha256-dGlLZsQItpgwnM0C6AFgEh9nbW/7FXICV/xkym4vQ3U=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "cb3f493ee45c3c27baedf2ce5335be4c7987df5f",
+        "rev": "1adcf2606e4dc674541a6856a7e22ca95d09e0cc",
         "type": "github"
       },
       "original": {

--- a/nix-tools/flake.nix
+++ b/nix-tools/flake.nix
@@ -73,8 +73,9 @@
           # tarballs with static builds.
           // lib.optionalAttrs (pkgs.buildPlatform.system == "x86_64-linux")
             { binary-tarball = mkTarball pkgs.pkgsCross.musl64; }
-          // lib.optionalAttrs (pkgs.buildPlatform.system == "aarch64-linux")
-            { binary-tarball = mkTarball pkgs.pkgsCross.aarch64-multiplatform-musl; }
+          # aarch64-multiplatform-musl cross compile is currently broken
+          # // lib.optionalAttrs (pkgs.buildPlatform.system == "aarch64-linux")
+          #   { binary-tarball = mkTarball pkgs.pkgsCross.aarch64-multiplatform-musl; }
         );
     };
 


### PR DESCRIPTION
We are not building haskell.nix CI on ci.iog.io for now.