### PR TITLE
Add `enableExecutableDynamic` module option

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -44,6 +44,7 @@ let self =
 
 , enableStatic ? component.enableStatic
 , enableShared ? ghc.enableShared && component.enableShared && !haskellLib.isCrossHost
+, enableExecutableDynamic ? component.enableExecutableDynamic && !stdenv.hostPlatform.isMusl
 , enableDeadCodeElimination ? component.enableDeadCodeElimination
 , writeHieFiles ? component.writeHieFiles
 
@@ -203,6 +204,7 @@ let
       (enableFeature enableProfiling "profiling")
       (enableFeature enableStatic "static")
       (enableFeature enableShared "shared")
+      (enableFeature enableExecutableDynamic "executable-dynamic")
       (enableFeature doCoverage "coverage")
       (enableFeature (enableLibraryForGhci && !stdenv.hostPlatform.isGhcjs) "library-for-ghci")
     ] ++ lib.optionals (stdenv.hostPlatform.isMusl && (haskellLib.isExecutableType componentId)) [
@@ -210,7 +212,6 @@ let
       # If it uses other libraries it may be necessary for to add more
       # `--ghc-option=-optl=-L` options to the `configureFlags` of the
       # component.
-      "--disable-executable-dynamic"
       "--ghc-option=-optl=-pthread"
       "--ghc-option=-optl=-static"
     ] ++ lib.optional enableSeparateDataOutput "--datadir=$data/share/${ghc.name}"

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 0
+{ ifdLevel ? 1
 , checkMaterialization ? false
 , system ? builtins.currentSystem
 , evalSystem ? builtins.currentSystem or "x86_64-linux"

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 1
+{ ifdLevel ? 2
 , checkMaterialization ? false
 , system ? builtins.currentSystem
 , evalSystem ? builtins.currentSystem or "x86_64-linux"

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 2
+{ ifdLevel ? 3
 , checkMaterialization ? false
 , system ? builtins.currentSystem
 , evalSystem ? builtins.currentSystem or "x86_64-linux"

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 3
+{ ifdLevel ? 0
 , checkMaterialization ? false
 , system ? builtins.currentSystem
 , evalSystem ? builtins.currentSystem or "x86_64-linux"

--- a/modules/component-options.nix
+++ b/modules/component-options.nix
@@ -113,6 +113,12 @@
       default = true;
     };
 
+    enableExecutableDynamic = lib.mkOption {
+      description = "If set, links executables against shared libraries.";
+      type = lib.types.bool;
+      default = false;
+    };
+
     configureAllComponents = lib.mkOption {
       description = "If set all the components in the package are configured (useful for cabal-doctest).";
       type = lib.types.bool;


### PR DESCRIPTION
This patch adds the `enableExecutableDynamic` module option to manage the `--enable-executable-dynamic` configure flag, defaulting to disabled.