### PR TITLE
Reduce env size before launching wine for TH

### DIFF
--- a/overlays/mingw_w64.nix
+++ b/overlays/mingw_w64.nix
@@ -35,6 +35,7 @@ let
         # without restting it, wine might fail
         # due to a too large environment.
         unset configureFlags
+        unset configurePhase
         PORT=$((5000 + $RANDOM % 5000))
         (>&2 echo "---> Starting ${interpreter.exeName} on port $PORT")
         REMOTE_ISERV=$(mktemp -d)


### PR DESCRIPTION
We are not sure why, but running the remote iserv interpreter under wine fails to launch if the environment is too big.  This change will free up some more space.