### PR TITLE
Add `--exclude materialized` to `deadnix` CI

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: |
-          nix run github:astro/deadnix -- --edit --no-lambda-pattern-names
+          nix run github:astro/deadnix -- --edit --no-lambda-pattern-names --exclude materialized
           TMPFILE=$(mktemp)
           git diff >"${TMPFILE}"
           git stash -u && git stash drop


### PR DESCRIPTION
> Can you remove the changes on the materialized files? They are autogenerated so we either fix the code gen or we tell deadnix to ignore them.

_Originally posted by @andreabedini in https://github.com/input-output-hk/haskell.nix/pull/1756#pullrequestreview-1632413096_

Fixed here https://github.com/astro/deadnix/pull/65