### PR TITLE
Free env space for tests run in wine

### DIFF
--- a/overlays/mingw_w64.nix
+++ b/overlays/mingw_w64.nix
@@ -89,6 +89,8 @@ let
     export LC_ALL=en_US.UTF-8
     export WINEPREFIX=$TMP
     Path="''${Path:-}"
+    unset configureFlags
+    unset configurePhase
     for path in ''${nativeBuildInputs:-}; do
       if [ -d "$path/bin" ]; then
         Path="$Path;$(${wine}/bin/winepath -w $path/bin)";

--- a/overlays/windows.nix
+++ b/overlays/windows.nix
@@ -36,11 +36,11 @@ final: prev:
       let
         withTH = import ./mingw_w64.nix {
           inherit (pkgs.stdenv) hostPlatform;
-          inherit (pkgs) stdenv lib writeScriptBin;
-          wine = pkgs.buildPackages.winePackages.minimal;
+          inherit (pkgs.pkgsBuildBuild) lib writeShellScriptBin;
+          wine = pkgs.pkgsBuildBuild.winePackages.minimal;
           inherit (pkgs.windows) mingw_w64_pthreads;
           inherit (pkgs) gmp;
-          inherit (pkgs.buildPackages) symlinkJoin;
+          inherit (pkgs.pkgsBuildBuild) symlinkJoin;
           # iserv-proxy needs to come from the buildPackages, as it needs to run on the
           # build host.
           inherit (final.haskell-nix.iserv-proxy-exes.${config.compiler.nix-name}) iserv-proxy iserv-proxy-interpreter;


### PR DESCRIPTION
We are not sure why, but wine seems to segfault if the environment is too large.  This PR adds the same work around we have used for the TH runner.