### PR TITLE
section flags only for splitSections

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -249,6 +249,7 @@ in {
                 ++ final.lib.optional (versionAtLeast "8.10"   && versionLessThan "9.0" && final.stdenv.targetPlatform.isAarch64) ./patches/ghc/ghc-8.10-aarch64-handle-none-rela.patch
                 ++ final.lib.optional (versionAtLeast "9.0"                             && final.stdenv.targetPlatform.isAarch64) ./patches/ghc/ghc-9.0-better-symbol-addr-debug.patch
                 ++ final.lib.optional (versionAtLeast "9.0"                             && final.stdenv.targetPlatform.isAarch64) ./patches/ghc/ghc-9.0-aarch64-handle-none-rela.patch
+                ++ final.lib.optional (versionAtLeast "9.6.3"                           && final.stdenv.targetPlatform.isWindows) ./patches/ghc/ghc-9.6-hadrian-splitsections.patch
                 ;
         in ({
             ghc865 = final.callPackage ../compiler/ghc (traceWarnOld "8.6" {

--- a/overlays/patches/ghc/ghc-9.6-hadrian-splitsections.patch
+++ b/overlays/patches/ghc/ghc-9.6-hadrian-splitsections.patch
@@ -1,0 +1,17 @@
+diff --git a/compiler/GHC/CmmToAsm/Ppr.hs b/compiler/GHC/CmmToAsm/Ppr.hs
+index 45b0545..967391d 100644
+--- a/compiler/GHC/CmmToAsm/Ppr.hs
++++ b/compiler/GHC/CmmToAsm/Ppr.hs
+@@ -246,9 +246,10 @@ pprGNUSectionHeader config t suffix =
+         panic "PprBase.pprGNUSectionHeader: unknown section type"
+     flags = case t of
+       Text
+-        | OSMinGW32 <- platformOS platform
++        | OSMinGW32 <- platformOS platform, splitSections
+                     -> text ",\"xr\""
+-        | otherwise -> text ",\"ax\"," <> sectionType platform "progbits"
++        | splitSections
++                    -> text ",\"ax\"," <> sectionType platform "progbits"
+       CString
+         | OSMinGW32 <- platformOS platform
+                     -> empty


### PR DESCRIPTION
https://github.com/ghc/ghc/commit/3ece9856d157c85511d59f9f862ab351bbd9b38b added section flags unconditional for splitSections. This breaks for .text without suffix and has the assmebler complaining.

```
ghc_1.s:7849:0: error:
     Warning: Ignoring changed section attributes for .text
     |
7849 | .section .text,"xr"
     | ^
```