### PR TITLE
Add ignorePackageYaml support to cabalProject

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -61,6 +61,7 @@
                             # package.
 , evalPackages
 , supportHpack ? false      # Run hpack on package.yaml files with no .cabal file
+, ignorePackageYaml ? false # Ignore package.yaml files even if they exist
 , ...
 }@args:
 let
@@ -494,7 +495,7 @@ let
 
     # run `plan-to-nix` in $out.  This should produce files right there with the
     # proper relative paths.
-    (cd $out${subDir'} && plan-to-nix --full --plan-json $tmp${subDir'}/dist-newstyle/cache/plan.json -o .)
+    (cd $out${subDir'} && plan-to-nix --full ${if ignorePackageYaml then "--ignore-package-yaml" else ""} --plan-json $tmp${subDir'}/dist-newstyle/cache/plan.json -o .)
 
     # Replace the /nix/store paths to minimal git repos with indexes (that will work with materialization).
     ${fixedProject.replaceLocations}

--- a/modules/cabal-project.nix
+++ b/modules/cabal-project.nix
@@ -139,10 +139,6 @@ in {
       type = bool;
       default = false;
     };
-    ignorePackageYaml = mkOption {
-      type = bool;
-      default = false;
-    };
 
     # Used by mkCabalProjectPkgSet
     pkg-def-extras = mkOption {

--- a/modules/cabal-project.nix
+++ b/modules/cabal-project.nix
@@ -139,6 +139,10 @@ in {
       type = bool;
       default = false;
     };
+    ignorePackageYaml = mkOption {
+      type = bool;
+      default = false;
+    };
 
     # Used by mkCabalProjectPkgSet
     pkg-def-extras = mkOption {

--- a/modules/project-common.nix
+++ b/modules/project-common.nix
@@ -78,5 +78,15 @@ with lib.types;
     hsPkgs = lib.mkOption {
       type = lib.types.unspecified;
     };
+    # Used by stack and cabal projects via
+    # - ./lib/call-cabal-project-to-nix.nix
+    # - ./lib/call-stack-to-nix.nix
+    ignorePackageYaml = mkOption {
+      type = bool;
+      default = false;
+      description = ''
+        If set, prevents nix-tools from attempting to load package.yaml even if it is present.
+      '';
+    };
   };
 }

--- a/modules/stack-project.nix
+++ b/modules/stack-project.nix
@@ -9,10 +9,6 @@ with types;
       type = str;
       default = "stack.yaml";
     };
-    ignorePackageYaml = mkOption {
-      type = bool;
-      default = false;
-    };
     cache = mkOption {
       type = nullOr unspecified;
       default = null;

--- a/nix-tools/nix-tools/plan2nix/Plan2Nix.hs
+++ b/nix-tools/nix-tools/plan2nix/Plan2Nix.hs
@@ -86,7 +86,7 @@ plan2nix args Plan { packages, extras, components, compilerVersion, compilerPack
   cwd <- getCurrentDirectory
   extrasNix <- fmap (mkNonRecSet  . concat) . forM (Map.toList extras) $ \case
     (_name, Just (Package v flags (Just (LocalPath folder)) False)) ->
-      do cabalFiles <- findCabalFiles folder
+      do cabalFiles <- findCabalFiles (argHpackUse args) folder
          forM cabalFiles $ \cabalFile ->
            let pkg = cabalFilePkgName cabalFile
                nix = ".plan.nix" </> pkg <.> "nix"
@@ -155,7 +155,7 @@ plan2nix args Plan { packages, extras, components, compilerVersion, compilerPack
   cabalFromPath url rev subdir path = do
           d <- liftIO $ doesDirectoryExist path
           unless d $ fail ("not a directory: " ++ path)
-          cabalFiles <- liftIO $ findCabalFiles path
+          cabalFiles <- liftIO $ findCabalFiles (argHpackUse args) path
           return $ \sha256 ->
             forM cabalFiles $ \cabalFile -> do
             let pkg = cabalFilePkgName cabalFile

--- a/nix-tools/nix-tools/plan2nix/Plan2Nix/CLI.hs
+++ b/nix-tools/nix-tools/plan2nix/Plan2Nix/CLI.hs
@@ -1,11 +1,13 @@
 module Plan2Nix.CLI
   ( Args(..)
+  , HpackUse(..)
   , parsePlan2NixArgs
   ) where
 
 import Options.Applicative hiding (option)
 import Data.Semigroup ((<>))
 import Cabal2Nix (CabalDetailLevel(..))
+import Stack2nix.CLI (HpackUse(..))
 
 --------------------------------------------------------------------------------
 -- CLI Arguments
@@ -15,6 +17,7 @@ data Args = Args
   , argCabalProject :: FilePath
   , argCacheFile :: FilePath
   , argDetailLevel :: CabalDetailLevel
+  , argHpackUse  :: HpackUse
   } deriving Show
 
 -- Argument Parser
@@ -25,6 +28,7 @@ args = Args
   <*> strOption ( long "cabal-project" <> value "cabal.project" <> showDefault <> metavar "FILE" <> help "Override path to cabal.project" )
   <*> strOption ( long "cache" <> value ".nix-tools.cache" <> showDefault <> metavar "FILE" <> help "Dependency cache file" )
   <*> flag MinimalDetails FullDetails ( long "full" <> help "Output details needed to determine what files are used" )
+  <*> flag UsePackageYamlFirst IgnorePackageYaml (long "ignore-package-yaml" <> help "disable hpack run and use only cabal disregarding package.yaml existence")
 
 parsePlan2NixArgs :: IO Args
 parsePlan2NixArgs = execParser opts


### PR DESCRIPTION
This PR adds a command line flag to `plan-to-nix` that allows any `package.yaml` files to be completely ignored.

This implements a workaround for #1923 which is otherwise needed to support [hpack](https://github.com/sol/hpack) `local`-style defaults. Even if the user explicitly generates the associated `foo.cabal` files and commits them to the repo (or arranges for Nixago to do that 😏 on their behalf) the presence of the `package.yaml` files in the source causes `plan-to-nix` (regardless of the project's `supportHpack` setting) to read the `package.yaml` rather than the user generated `.cabal` file(s) and so consequently the absence of the defaults specified in that package.yaml in the cleaned sources causes `plan-to-nix` to fail.

To avoid changing the behaviour of projects which already set `supportHpack` to false but inadvertently rely on `plan-to-nix` loading the package.yaml files, it seemed wiser to create a new project option entirely.