### PR TITLE
Remove extra-test-libs for windows

### DIFF
--- a/overlays/mingw_w64.nix
+++ b/overlays/mingw_w64.nix
@@ -7,9 +7,6 @@
 , iserv-proxy
 , iserv-proxy-interpreter
 , gmp
-# extra libraries. Their dlls are copied
-# when tests are run.
-, extra-test-libs ? []
 , hostPlatform
 , symlinkJoin
 }:
@@ -105,10 +102,6 @@ let
     echo "================================================================================"
     echo "RUNNING TESTS for $name via wine64"
     echo "================================================================================"
-    echo "Copying extra test libraries ..."
-    for p in ${lib.concatStringsSep " "extra-test-libs}; do
-      find "$p" -iname '*.dll' -exec cp {} . \;
-    done
     # copy all .dlls into the local directory.
     # we ask ghc-pkg for *all* dynamic-library-dirs and then iterate over the unique set
     # to copy over dlls as needed.

--- a/overlays/windows.nix
+++ b/overlays/windows.nix
@@ -49,8 +49,6 @@ final: prev:
           # iserv-proxy needs to come from the buildPackages, as it needs to run on the
           # build host.
           inherit (final.haskell-nix.iserv-proxy-exes.${config.compiler.nix-name}) iserv-proxy iserv-proxy-interpreter;
-          # we need to use openssl.bin here, because the .dll's are in the .bin expression.
-          # extra-test-libs = [ pkgs.rocksdb pkgs.openssl.bin pkgs.libffi pkgs.gmp ];
         } // {
           # we can perform testing of cross compiled test-suites by using wine.
           # Therefore let's enable doCrossCheck here!


### PR DESCRIPTION
extra-test-libs is not used any more for windows