### PR TITLE
Remove the `preCheck` for windows tests

### DIFF
--- a/overlays/mingw_w64.nix
+++ b/overlays/mingw_w64.nix
@@ -98,4 +98,4 @@ let
   '';
   testWrapper = lib.optional hostPlatform.isWindows "${wineTestWrapper}/bin/test-wrapper";
 
-in { inherit preCheck testWrapper postCheck setupBuildFlags configureFlags; }
+in { inherit testWrapper setupBuildFlags configureFlags; }

--- a/overlays/mingw_w64.nix
+++ b/overlays/mingw_w64.nix
@@ -98,24 +98,4 @@ let
   '';
   testWrapper = lib.optional hostPlatform.isWindows "${wineTestWrapper}/bin/test-wrapper";
 
-  preCheck = lib.optionalString hostPlatform.isWindows ''
-    echo "================================================================================"
-    echo "RUNNING TESTS for $name via wine64"
-    echo "================================================================================"
-    # copy all .dlls into the local directory.
-    # we ask ghc-pkg for *all* dynamic-library-dirs and then iterate over the unique set
-    # to copy over dlls as needed.
-    echo "Copying library dependencies..."
-    for libdir in $(${hostPlatform.config}-ghc-pkg field "*" dynamic-library-dirs --simple-output|xargs|sed 's/ /\n/g'|sort -u); do
-      if [ -d "$libdir" ]; then
-        find "$libdir" -iname '*.dll' -exec cp {} . \;
-      fi
-    done
-  '';
-  postCheck = lib.optionalString hostPlatform.isWindows ''
-    echo "================================================================================"
-    echo "END RUNNING TESTS"
-    echo "================================================================================"
-  '';
-
 in { inherit preCheck testWrapper postCheck setupBuildFlags configureFlags; }


### PR DESCRIPTION
This was copying DLLs need into place.  I don't think this is needed any more because it DLLs are copied into the `/bin` directory of the test derivation by the `installPhase` in `builder/comp-builder.nix`.