### PR TITLE
fix some aarch64-musl libc loading issues

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -265,6 +265,7 @@ in {
                 # ++ fromUntil "9.6.1" "9.10"                                                                                       ./patches/ghc/iserv-syms.patch
                 # Fix the bad fixups: https://gitlab.haskell.org/ghc/ghc/-/commit/2adc050857a9c1b992040fbfd55fbe65b2851b19
                 ++ final.lib.optional (versionAtLeast "9.6"    && versionLessThan "9.8" && final.stdenv.targetPlatform.isAarch64) ./patches/ghc/2adc050857a9c1b992040fbfd55fbe65b2851b19.patch
+                ++ final.lib.optional (versionAtLeast "8.10.7" && versionLessThan "9.0" && final.stdenv.targetPlatform.isAarch64 && final.stdenv.targetPlatform.isMusl && final.stdenv.targetPlatform != final.stdenv.hostPlatform) ./patches/ghc/ghc-8.10-aarch64-musl-gettimeofday.patch
                 ;
         in ({
             ghc865 = final.callPackage ../compiler/ghc (traceWarnOld "8.6" {

--- a/overlays/patches/ghc/ghc-8.10-aarch64-musl-gettimeofday.patch
+++ b/overlays/patches/ghc/ghc-8.10-aarch64-musl-gettimeofday.patch
@@ -1,0 +1,18 @@
+diff --git a/rts/RtsSymbols.c b/rts/RtsSymbols.c
+index e0901c3..05a4310 100644
+--- a/rts/RtsSymbols.c
++++ b/rts/RtsSymbols.c
+@@ -991,9 +991,13 @@
+       SymI_HasProto(cas)                                                \
+       SymI_HasProto(_assertFail)                                        \
+       SymI_HasProto(keepCAFs)                                           \
++      SymI_NeedsProto(gettimeofday)                                     \
++      SymI_HasProto(clock)                                              \
+       RTS_USER_SIGNALS_SYMBOLS                                          \
+       RTS_INTCHAR_SYMBOLS
+
++      // need gettimeofday, clock for split-mix; otherwise will segv when calling this from iserv :-/
++
+
+ // 64-bit support functions in libgcc.a
+ #if defined(__GNUC__) && SIZEOF_VOID_P <= 4 && !defined(_ABIN32)


### PR DESCRIPTION
This is pretty annoying, as we end up calling `gettimeofday` and `clock`, which result in SEGVs due to the state of the in-memory loaded libc, and the linked in libc mismatching. Interning the symbols _does_ work, but we need a better solution in 9.6. There is some experimentation in the armv7a branch, adding symbols into iserv, not GHC.