### PR TITLE
ghc8*: backport GCC inline fix for NixOS 23.11

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -199,6 +199,7 @@ in {
                 ++ fromUntil "9.2.2"  "9.3"    ./patches/ghc/ghc-9.2.2-fix-warnings-building-with-self.patch # https://gitlab.haskell.org/ghc/ghc/-/commit/c41c478eb9003eaa9fc8081a0039652448124f5d
                 ++ fromUntil "8.6.5"  "9.5"    ./patches/ghc/ghc-hpc-response-files.patch   # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/8194
                 ++ fromUntil "9.2"    "9.10"   ./patches/ghc/sanity-check-find-file-name.patch
+                ++ fromUntil "8.0"    "9.0"    ./patches/ghc/dont-mark-evacuate_large-as-inline.patch
                 ++ final.lib.optionals (final.stdenv.targetPlatform.isWindows) (fromUntil "9.4.1"  "9.4.5"  ./patches/ghc/ghc-9.4-hadrian-win-cross.patch)
                 ++ final.lib.optionals (final.stdenv.targetPlatform.isWindows) (fromUntil "9.4.7"  "9.4.9"  ./patches/ghc/ghc-9.8-hadrian-win-cross.patch)
                 ++ final.lib.optionals (final.stdenv.targetPlatform.isWindows) (fromUntil "9.6.3"  "9.10"   ./patches/ghc/ghc-9.8-hadrian-win-cross.patch)

--- a/overlays/patches/ghc/dont-mark-evacuate_large-as-inline.patch
+++ b/overlays/patches/ghc/dont-mark-evacuate_large-as-inline.patch
@@ -1,0 +1,41 @@
+From 27cc2e7b1c1268e59c9d16b4530f27c0d40e9464 Mon Sep 17 00:00:00 2001
+From: Ben Gamari <ben@smart-cactus.org>
+Date: Mon, 23 Mar 2020 12:36:25 -0400
+Subject: [PATCH] rts: Don't mark evacuate_large as inline
+
+This function has two callsites and is quite large. GCC consequently
+decides not to inline and warns instead. Given the situation, I can't
+blame it. Let's just remove the inline specifier.
+---
+ rts/sm/Evac.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rts/sm/Evac.c b/rts/sm/Evac.c
+index 521fd4eef45..e9a1c5d796f 100644
+--- a/rts/sm/Evac.c
++++ b/rts/sm/Evac.c
+@@ -298,7 +298,7 @@ copy(StgClosure **p, const StgInfoTable *info,
+    that has been evacuated, or unset otherwise.
+    -------------------------------------------------------------------------- */
+ 
+-STATIC_INLINE void
++static void
+ evacuate_large(StgPtr p)
+ {
+   bdescr *bd;
+-- 
+GitLab
+
+diff --git a/rts/sm/Evac.c b/rts/sm/Evac.c
+index 3ef9fe6..704f10d 100644
+--- a/rts/sm/Evac.c
++++ b/rts/sm/Evac.c
+@@ -58,7 +58,7 @@
+ #define MAX_THUNK_SELECTOR_DEPTH 16
+
+ static void eval_thunk_selector (StgClosure **q, StgSelector *p, bool);
+-STATIC_INLINE void evacuate_large(StgPtr p);
++static void evacuate_large(StgPtr p);
+
+ /* -----------------------------------------------------------------------------
+    Allocate some space in which to copy an object.


### PR DESCRIPTION
This is a backport of https://gitlab.haskell.org/ghc/ghc/-/merge_requests/2943, and another diff I made which un-inlined the forward declaration.

Without this, I was unable to compile `ghc8107` on top of NixOS-23.11. You get the following error:
```
rts/sm/Evac.c:393:1: error:
     warning: inlining failed in call to ‘evacuate_large’: --param max-inline-insns-single limit reached [-Winline]
      393 | evacuate_large(StgPtr p)
          | ^~~~~~~~~~~~~~
    |
393 | evacuate_large(StgPtr p)
    | ^

rts/sm/Evac.c:790:11: error:
     note: called from here
      790 |           evacuate_large((P_)q);
          |           ^~~~~~~~~~~~~~~~~~~~~
    |
790 |           evacuate_large((P_)q);
    |           ^
rts/sm/Evac.c: In function ‘evacuate_BLACKHOLE’:

rts/sm/Evac.c:393:1: error:
     warning: inlining failed in call to ‘evacuate_large’: --param max-inline-insns-single limit reached [-Winline]
      393 | evacuate_large(StgPtr p)
          | ^~~~~~~~~~~~~~
    |
393 | evacuate_large(StgPtr p)
    | ^

rts/sm/Evac.c:1107:9: error:
     note: called from here
     1107 |         evacuate_large((P_)q);
          |         ^~~~~~~~~~~~~~~~~~~~~
     |
1107 |         evacuate_large((P_)q);
     |         ^
```