### PR TITLE
Pin sphinx to v5 for NixOS 23.11

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -76,7 +76,8 @@ in {
                   materialized = ../materialized/happy-1.20.0;
                 };
             };
-            sphinx = with final.buildPackages; (python3Packages.sphinx_1_7_9 or python3Packages.sphinx);
+            sphinx = with final.buildPackages; python3Packages.sphinx_1_7_9 or sphinx_5;
+
             D5123-patch = final.fetchpatch rec { # https://phabricator.haskell.org/D5123
                 url = "http://tarballs.nixos.org/sha256/${sha256}";
                 name = "D5123.diff";

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -79,6 +79,7 @@ let
     armv6l-linux = import ./armv6l-linux.nix;
     musl = import ./musl.nix;
     android = import ./android.nix;
+    sphinx = import ./sphinx.nix;
     tools = import ./tools.nix;
     emscripten = import ./emscripten.nix;
     nix-prefetch-git-minimal = import ./nix-prefetch-git-minimal.nix;
@@ -128,6 +129,7 @@ let
     hydra
     # Restore nixpkgs haskell and haskellPackages
     (_: prev: { inherit (prev.haskell-nix-prev) haskell haskellPackages; })
+    sphinx
     dummy-ghc-data
     cacheCompilerDeps
     default-setup

--- a/overlays/sphinx.nix
+++ b/overlays/sphinx.nix
@@ -1,0 +1,26 @@
+_: prev: {
+  # Most GHC builds aren't compatible with sphinx 6+
+  sphinx_5 = prev.sphinx.overridePythonAttrs(_: rec {
+    version = "5.3.0";
+
+    src = prev.fetchFromGitHub {
+      owner = "sphinx-doc";
+      repo = "sphinx";
+      rev = "refs/tags/v${version}";
+      postFetch = ''
+        # Change ä to æ in file names, since ä can be encoded multiple ways on different
+        # filesystems, leading to different hashes on different platforms.
+        cd "$out";
+        mv tests/roots/test-images/{testimäge,testimæge}.png
+        sed -i 's/testimäge/testimæge/g' tests/{test_build*.py,roots/test-images/index.rst}
+      '';
+      hash = "sha256-80bVg1rfBebgSOKbWkzP84vpm39iLgM8lWlVD64nSsQ=";
+    };
+
+    # Some tests require network access
+    doCheck = false;
+
+    pythonImportsCheck = [ "sphinx" ];
+  });
+
+}


### PR DESCRIPTION
Attempting to build with sphinx v7.x (current on NixOS 23.11). Will result in the following error:
```
Exception occurred:
  File "/nix/store/vj2i33l4cssf4lnx0a993k3vv3yhh6a6-python3.11-sphinx-7.2.6/lib/python3.11/site-packages/sphinx/ext/extlinks.py", line 108, in role
    title = caption % part
            ~~~~~~~~^~~~~~
TypeError: not all arguments converted during string formatting
```