### PR TITLE
Fix missing and replaced packages in 23.11

### DIFF
--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -2,6 +2,8 @@
 # See ../docs/tutorials/pkg-map.md
 pkgs:
   let
+    inherit (pkgs) lib;
+
     # Only include derivations that exist in the current pkgs.
     # This allows us to use this mapping to be used in allPkgConfigWrapper.
     # See ./overlas
@@ -3136,7 +3138,6 @@ pkgs:
     "libstilview" = [ "libsidplayfp" ];
     "libsieve" = [ "libsieve" ];
     "sigc++-2.0" = [ "libsigcxx" ];
-    "sigc++-1.2" = [ "libsigcxx12" ];
     "sigc++-3.0" = [ "libsigcxx30" ];
     "libsignal-protocol-c" = [ "libsignal-protocol-c" ];
     "libsignon-glib" = [ "libsignon-glib" ];
@@ -4807,7 +4808,6 @@ pkgs:
 #    "gmock" = [ "robo3t" ];
 #    "gtest_main" = [ "robo3t" ];
 #    "gtest" = [ "robo3t" ];
-    "libhsakmt" = [ "rocm-thunk" ];
     "rofi" = [ "rofi" ];
 #    "rofi" = [ "rofi-unwrapped" ];
 #    "rofi" = [ "rofi-wayland" ];
@@ -5732,4 +5732,16 @@ pkgs:
       else if pkgs ? gdk_pixbuf
         then [ pkgs.gdk_pixbuf ]
       else [];
+    # rocm-thunk was replaced by rocmPackages.rocm-thunk in 23.11
+    "libhsakmt" =
+      if pkgs ? rocmPackages && pkgs.rocmPackages ? rocm-thunk
+        then [ pkgs.rocmPackages.rocm-thunk ]
+      else if pkgs ? rocm-thunk
+        then [ pkgs.rocm-thunk ]
+      else [];
+    # libsigcxx12 was removed in 23.11
+    "sigc++-1.2" =
+      if pkgs ? libsigcxx12
+        then [ "libsigcxx12" ]
+        else [];
 }

--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -2,8 +2,6 @@
 # See ../docs/tutorials/pkg-map.md
 pkgs:
   let
-    inherit (pkgs) lib;
-
     # Only include derivations that exist in the current pkgs.
     # This allows us to use this mapping to be used in allPkgConfigWrapper.
     # See ./overlas
@@ -5721,22 +5719,14 @@ pkgs:
     "xorg-sgml-doctools" = [ "xorgsgmldoctools" ];
     "xtrans" = [ "xtrans" ];
 } // {
-    "gtkglext-1.0"                       =
-      if pkgs ? gnome2 && pkgs.gnome2 ? gtkglext && pkgs ? gtk2
-        then [ pkgs.gnome2.gtkglext pkgs.gtk2 ]
-        else [];
+    "gtkglext-1.0" = [ pkgs.gnome2.gtkglext pkgs.gtk2 ];
     # This was renamed
     "gdk-pixbuf-2.0" =
       if pkgs ? gdk-pixbuf
         then [ pkgs.gdk-pixbuf ]
-      else if pkgs ? gdk_pixbuf
-        then [ pkgs.gdk_pixbuf ]
-      else [];
+      else [ pkgs.gdk_pixbuf ];
     # rocm-thunk was replaced by rocmPackages.rocm-thunk in 23.11
-    "libhsakmt" =
-      if pkgs ? rocmPackages && pkgs.rocmPackages ? rocm-thunk
-        then [ pkgs.rocmPackages.rocm-thunk ]
-        else [ pkgs.rocm-thunk ];
+    "libhsakmt" = [ pkgs.rocmPackages.rocm-thunk or pkgs.rocm-thunk ];
 } // lib.optionalAttrs (pkgs ? libsigcxx12) {
     # libsigcxx12 was removed in 23.11
     "sigc++-1.2" = [ "libsigcxx12" ];

--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -2,6 +2,8 @@
 # See ../docs/tutorials/pkg-map.md
 pkgs:
   let
+    inherit (pkgs) lib;
+
     # Only include derivations that exist in the current pkgs.
     # This allows us to use this mapping to be used in allPkgConfigWrapper.
     # See ./overlas
@@ -5719,12 +5721,17 @@ pkgs:
     "xorg-sgml-doctools" = [ "xorgsgmldoctools" ];
     "xtrans" = [ "xtrans" ];
 } // {
-    "gtkglext-1.0" = [ pkgs.gnome2.gtkglext pkgs.gtk2 ];
+    "gtkglext-1.0"                       =
+      if pkgs ? gnome2 && pkgs.gnome2 ? gtkglext && pkgs ? gtk2
+        then [ pkgs.gnome2.gtkglext pkgs.gtk2 ]
+        else [];
     # This was renamed
     "gdk-pixbuf-2.0" =
       if pkgs ? gdk-pixbuf
         then [ pkgs.gdk-pixbuf ]
-      else [ pkgs.gdk_pixbuf ];
+      else if pkgs ? gdk_pixbuf
+        then [ pkgs.gdk_pixbuf ]
+      else [];
     # rocm-thunk was replaced by rocmPackages.rocm-thunk in 23.11
     "libhsakmt" = [ pkgs.rocmPackages.rocm-thunk or pkgs.rocm-thunk ];
 } // lib.optionalAttrs (pkgs ? libsigcxx12) {

--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -5736,12 +5736,8 @@ pkgs:
     "libhsakmt" =
       if pkgs ? rocmPackages && pkgs.rocmPackages ? rocm-thunk
         then [ pkgs.rocmPackages.rocm-thunk ]
-      else if pkgs ? rocm-thunk
-        then [ pkgs.rocm-thunk ]
-      else [];
+        else [ pkgs.rocm-thunk ];
+} // lib.optionalAttrs (pkgs ? libsigcxx12) {
     # libsigcxx12 was removed in 23.11
-    "sigc++-1.2" =
-      if pkgs ? libsigcxx12
-        then [ "libsigcxx12" ]
-        else [];
+    "sigc++-1.2" = [ "libsigcxx12" ];
 }


### PR DESCRIPTION
- Renames `rocm-thunk` to `rocmPackages.rocm-thunk`
- Removes `libsigcxx12`

Resolves #2121.
Resolves #2122.