### PR TITLE
add apply-refact to toolPackageName

### DIFF
--- a/overlays/tools.nix
+++ b/overlays/tools.nix
@@ -50,6 +50,7 @@ in { haskell-nix = prev.haskell-nix // {
     cabal = "cabal-install";
     sos = "steeloverseer";
     gen-hie = "implicit-hie";
+    refactor = "apply-refact";
   };
 
   # Packages that are better known by their package name.  We are not
@@ -59,6 +60,7 @@ in { haskell-nix = prev.haskell-nix // {
     cabal-install = "cabal";
     steeloverseer = "sos";
     implicit-hie = "gen-hie";
+    apply-refact = "refactor";
   };
 
   hackage-tool = projectModules:


### PR DESCRIPTION
the haskell package apply-refact contains the refactor executable, which is used by hlint to automatically apply hints.