### PR TITLE
Unbreak busted linking.

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -68,28 +68,11 @@ in rec {
       };
     } // pkgs.lib.optionalAttrs (
       __compareVersions haskell.compiler.${compiler-nix-name}.version "9.0" >= 0 &&
-      __compareVersions haskell.compiler.${compiler-nix-name}.version "9.9" < 0
+      __compareVersions haskell.compiler.${compiler-nix-name}.version "9.8" < 0
     ) {
       "hls-24" = tool compiler-nix-name "haskell-language-server" {
         inherit evalPackages;
         src = pkgs.haskell-nix.sources."hls-2.4";
-        # Even though this is in the cabal.project it is inside a condional
-        # and so haskell.nix cannot parse it properly.  Luckily adding it
-        # again seems to work fine.
-        cabalProjectLocal = ''
-          repository head.hackage.ghc.haskell.org
-            url: https://ghc.gitlab.haskell.org/head.hackage/
-            secure: True
-            key-threshold: 3
-            root-keys:
-               f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-               26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-               7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-            --sha256: sha256-Bkn2Etb0JVmb7tM7jxuIoYLFnSp7acqraEYVq0I5oUM=
-
-          if impl(ghc < 9.7)
-            active-repositories: hackage.haskell.org
-        '';
       };
     })
   );

--- a/build.nix
+++ b/build.nix
@@ -85,7 +85,7 @@ in rec {
                f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
                26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
                7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-            --sha256: sha256-aVI93DtHziicNn2mGli0YE+bC5BeT7mOQQETp2Thi68=
+            --sha256: sha256-Bkn2Etb0JVmb7tM7jxuIoYLFnSp7acqraEYVq0I5oUM=
 
           if impl(ghc < 9.7)
             active-repositories: hackage.haskell.org

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 3
+{ ifdLevel ? 1
 , checkMaterialization ? false
 , system ? builtins.currentSystem
 , evalSystem ? builtins.currentSystem or "x86_64-linux"

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 1
+{ ifdLevel ? 2
 , checkMaterialization ? false
 , system ? builtins.currentSystem
 , evalSystem ? builtins.currentSystem or "x86_64-linux"

--- a/ci.nix
+++ b/ci.nix
@@ -1,6 +1,6 @@
 # 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluating
 # on a machine with e.g. no way to build the Darwin IFDs you need!
-{ ifdLevel ? 2
+{ ifdLevel ? 3
 , checkMaterialization ? false
 , system ? builtins.currentSystem
 , evalSystem ? builtins.currentSystem or "x86_64-linux"

--- a/flake.lock
+++ b/flake.lock
@@ -241,16 +241,16 @@
     "hls-2.4": {
       "flake": false,
       "locked": {
-        "lastModified": 1696939266,
-        "narHash": "sha256-VOMf5+kyOeOmfXTHlv4LNFJuDGa7G3pDnOxtzYR40IU=",
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "362fdd1293efb4b82410b676ab1273479f6d17ee",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
-        "ref": "2.4.0.0",
+        "ref": "2.4.0.1",
         "repo": "haskell-language-server",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -493,17 +493,17 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1701336116,
-        "narHash": "sha256-kEmpezCR/FpITc6yMbAh4WrOCiT2zg5pSjnKrq51h5Y=",
+        "lastModified": 1694822471,
+        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f5c27c6136db4d76c30e533c20517df6864c46ee",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
     "hls-2.0" = { url = "github:haskell/haskell-language-server/2.0.0.1"; flake = false; };
     "hls-2.2" = { url = "github:haskell/haskell-language-server/2.2.0.0"; flake = false; };
     "hls-2.3" = { url = "github:haskell/haskell-language-server/2.3.0.0"; flake = false; };
-    "hls-2.4" = { url = "github:haskell/haskell-language-server/2.4.0.0"; flake = false; };
+    "hls-2.4" = { url = "github:haskell/haskell-language-server/2.4.0.1"; flake = false; };
     hydra.url = "hydra";
     hackage = {
       url = "github:input-output-hk/hackage.nix";

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,10 @@
     nixpkgs-2211 = { url = "github:NixOS/nixpkgs/nixpkgs-22.11-darwin"; };
     nixpkgs-2305 = { url = "github:NixOS/nixpkgs/nixpkgs-23.05-darwin"; };
     nixpkgs-2311 = { url = "github:NixOS/nixpkgs/nixpkgs-23.11-darwin"; };
-    nixpkgs-unstable = { url = "github:NixOS/nixpkgs/nixpkgs-unstable"; };
+    # The libsodium bump in 85c6e70b555fe892a049fa3d9dce000dc23a9562 breaks th-dll tests.
+    # And later it breaks in th-dll due to some change in the windows libs. We should probably
+    # drop unsable.
+    nixpkgs-unstable = { url = "github:NixOS/nixpkgs?rev=47585496bcb13fb72e4a90daeea2f434e2501998"; }; # nixpkgs-unstable };
     ghc98X = {
       flake = false;
       url = "git+https://gitlab.haskell.org/ghc/ghc?ref=ghc-9.8&submodules=1";

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -1286,7 +1286,7 @@ in {
                f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
                26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
                7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-            --sha256: sha256-aVI93DtHziicNn2mGli0YE+bC5BeT7mOQQETp2Thi68=
+            --sha256: sha256-Bkn2Etb0JVmb7tM7jxuIoYLFnSp7acqraEYVq0I5oUM=
 
           active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
         '';

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -1272,7 +1272,11 @@ in {
         # version of nix-tools (on platforms where we cannot use the
         # static nix-tools).
         cabalProjectLocal = ''
-          allow-newer: *:*
+          -- allow newer packages, that are bound to be newer due to
+          -- being shipped with a newer compiler.  If you extend this
+          -- be very careful to only extend it for absolutely necessary packages
+          -- otherwise we risk running into broken build-plans down the line.
+          allow-newer: *:base, *:template-haskell, *:bytestring, *:text
 
           repository head.hackage.ghc.haskell.org
             url: https://ghc.gitlab.haskell.org/head.hackage/

--- a/overlays/darwin.nix
+++ b/overlays/darwin.nix
@@ -14,6 +14,13 @@ _final: prev:
               # https://github.com/NixOS/nixpkgs/pull/47676
               # https://github.com/NixOS/nixpkgs/issues/45042
               x509-system.components.library.preBuild = "substituteInPlace System/X509/MacOS.hs --replace security /usr/bin/security";
+            } // pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.isDarwin)
+            {
+              # fix broken c++ library selection for GHC < 9.4
+              # for GHC >= 9.4 the system-cxx-std-lib pseudo-package does this.
+              double-conversion.components.library.preConfigure = ''
+                substituteInPlace double-conversion.cabal --replace 'extra-libraries: c++' 'extra-libraries: c++ c++abi'
+              '';
             };
         })
     ];

--- a/test/cabal.project.local
+++ b/test/cabal.project.local
@@ -13,7 +13,7 @@ repository head.hackage.ghc.haskell.org
      f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
      26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
      7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-  --sha256: sha256-aVI93DtHziicNn2mGli0YE+bC5BeT7mOQQETp2Thi68=
+  --sha256: sha256-Bkn2Etb0JVmb7tM7jxuIoYLFnSp7acqraEYVq0I5oUM=
 
 repository ghcjs-overlay
   url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/91f4ce9bea0e7f739b7495647c3f72a308ed1c6f

--- a/test/cabal.project.local
+++ b/test/cabal.project.local
@@ -1,5 +1,9 @@
 if impl(ghc>=9.8)
-  allow-newer: *:*
+  -- allow newer packages, that are bound to be newer due to
+  -- being shipped with a newer compiler.  If you extend this
+  -- be very careful to only extend it for absolutely necessary packages
+  -- otherwise we risk running into broken build-plans down the line.
+  allow-newer: *:base, *:template-haskell, *:bytestring, *:text, *:ghc-prim, *:deepseq
 
 repository head.hackage.ghc.haskell.org
   url: https://ghc.gitlab.haskell.org/head.hackage/

--- a/test/haskell-language-server/cabal.nix
+++ b/test/haskell-language-server/cabal.nix
@@ -16,7 +16,7 @@ let
            f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
            26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
            7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-        --sha256: sha256-aVI93DtHziicNn2mGli0YE+bC5BeT7mOQQETp2Thi68=
+        --sha256: sha256-Bkn2Etb0JVmb7tM7jxuIoYLFnSp7acqraEYVq0I5oUM=
 
       if impl(ghc < 9.7)
         active-repositories: hackage.haskell.org

--- a/test/haskell-language-server/cabal.nix
+++ b/test/haskell-language-server/cabal.nix
@@ -33,5 +33,5 @@ in recurseIntoAttrs {
   meta.disabled =
     stdenv.hostPlatform != stdenv.buildPlatform
     || __compareVersions buildPackages.haskell-nix.compiler.${compiler-nix-name}.version "9.0.1" < 0
-    || __compareVersions buildPackages.haskell-nix.compiler.${compiler-nix-name}.version "9.9.0" >= 0;
+    || __compareVersions buildPackages.haskell-nix.compiler.${compiler-nix-name}.version "9.8.0" >= 0;
 }


### PR DESCRIPTION
We need to pass c++abi as well as c++, however double-conversion does not specify those.