### PR TITLE
Make call-cabal-project-to-nix support top-level hidden directories

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -401,7 +401,7 @@ let
         exit 1
       ''}
     else
-      cp -r ${cleanedSource}/* .
+      rsync -a ${cleanedSource}/ ./
     fi
     chmod +w -R .
     # Decide what to do for each `package.yaml` file.


### PR DESCRIPTION
Currently, cabal files located inside hidden directories cannot be found by haskell.nix.  This patch fixes that, treating hidden directories the same as non-hidden directories.

This occurs in [Obelisk](https://github.com/obsidiansystems/obelisk) projects, where the Obelisk source code is located in `.obelisk/impl`, but the `cabal.project` file is located in the project root.