### PR TITLE
Include shell.buildInputs in devshellFor

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -546,7 +546,7 @@ in {
   # into a devshell module (https://github.com/numtide/devshell)
   # that should provide the same environnement.
   devshellFor = shell: {
-    packages = lib.filter lib.isDerivation (shell.nativeBuildInputs
+    packages = lib.filter lib.isDerivation (shell.buildInputs ++ shell.nativeBuildInputs
     # devshell does not use pkgs.mkShell / pkgs.stdenv.mkDerivation,
     # so we need to explicit required dependencies which
     # are provided implicitely by stdenv when using the normal shell:


### PR DESCRIPTION
Without `shell.buildInputs`, the final devshell may have an incomplete environment.
haskell.nix will successfully make a plan, but `cabal build` might fail, for example because it cannot find a package's sublibrary.
