### PR TITLE
Support conditional source-repository-packages

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -23,7 +23,7 @@ jobs:
   deadnix:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: |
           nix run github:astro/deadnix -- --edit --no-lambda-pattern-names --exclude materialized
           TMPFILE=$(mktemp)

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,126 +21,126 @@ jobs:
   nix-build:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Run tests with ghc8107: Running the nix-build tests..."
         run: "./test/tests.sh ghc8107 nix-build"
 
   unit-tests:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Run tests with ghc8107: Running the unit tests..."
         run: "./test/tests.sh ghc8107 unit-tests"
 
   runghc:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Run tests with ghc8107: Checking that a nix-shell works for runghc..."
         run: "./test/tests.sh ghc8107 runghc"
 
   cabal:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Run tests with ghc8107: Checking that a nix-shell works for cabal..."
         run: "./test/tests.sh ghc8107 cabal"
 
   cabal-doExactConfig:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Run tests with ghc8107: Checking that a nix-shell works for cabal (doExactConfig component)..."
         run: "./test/tests.sh ghc8107 cabal-doExactConfig"
 
   tests-benchmarks:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Run tests with ghc8107: Checking that a nix-shell works for a project with test-suite build-tools and benchmarks..."
         run: "./test/tests.sh ghc8107 tests-benchmarks"
 
   multi-target:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Run tests with ghc8107: Checking that a nix-shell works for a multi-target project..."
         run: "./test/tests.sh ghc8107 multi-target"
 
   shellFor-single-package:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Run tests with ghc8107: Checking shellFor works for a cabal project, multiple packages..."
         run: "./test/tests.sh ghc8107 shellFor-single-package"
 
   shellFor-multiple-package:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Run tests with ghc8107: Checking shellFor works for a cabal project, single package...y"
         run: "./test/tests.sh ghc8107 shellFor-multiple-package"
 
   shellFor-hoogle:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Run tests with ghc8107: Checking shellFor works for a cabal project, single package..."
         run: "./test/tests.sh ghc8107 shellFor-hoogle"
 
   shellFor-not-depends:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Run tests with ghc8107: Checking shellFor does not depend on given packages...y"
         run: "./test/tests.sh ghc8107 shellFor-not-depends"
 
   maintainer-scripts:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Run tests with ghc8107: Checking the maintainer scripts...y"
         run: "./test/tests.sh ghc8107 maintainer-scripts"
 
   plan-extra-hackages:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Run tests with ghc8107: Checking that plan construction works with extra Hackages..."
         run: "./test/tests.sh ghc8107 plan-extra-hackages"
 
   build-extra-hackages:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Run tests with ghc8107: Checking that package with extra Hackages can be build..."
         run: "./test/tests.sh ghc8107 build-extra-hackages"
 
   hix:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Run tests with ghc8107: End-2-end test of hix project initialization and flakes development shell ..."
         run: "./test/tests.sh ghc8107 hix"
 
 #  template:
 #    runs-on: [self-hosted, linux]
 #    steps:
-#      - uses: actions/checkout@v3
+#      - uses: actions/checkout@v4
 #      - name: "Run tests with ghc8107: End-2-end test of hix project initialization and flakes development shell ..."
 #        run: "./test/tests.sh ghc8107 template"
 
   docs:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Test examples in documentation ..."
         run: "./test/tests.sh ghc8107 docs"
 
   hydra-ifdLevel-0-and-1:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Check that jobset will evaluate in Hydra at ifdLevel 0 and 1"
         run: |
           nix-build build.nix -A maintainer-scripts.check-hydra -o check-hydra.sh
@@ -150,7 +150,7 @@ jobs:
   hydra-ifdLevel-2:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Check that jobset will evaluate in Hydra at ifdLevel 2"
         run: |
           nix-build build.nix -A maintainer-scripts.check-hydra -o check-hydra.sh
@@ -159,7 +159,7 @@ jobs:
   hydra-ifdLevel-3-and-ghc-8-10:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Check that jobset will evaluate in Hydra at ifdLevel 3 and ghc 8.10"
         run: |
           nix-build build.nix -A maintainer-scripts.check-hydra -o check-hydra.sh
@@ -168,7 +168,7 @@ jobs:
   hydra-ifdLevel-3-and-ghc-9-2:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Check that jobset will evaluate in Hydra at ifdLevel 3 and ghc 9.2"
         run: |
           nix-build build.nix -A maintainer-scripts.check-hydra -o check-hydra.sh
@@ -177,7 +177,7 @@ jobs:
   hydra-ifdLevel-3-and-not-ghc-8-10-or-9-2:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Check that jobset will evaluate in Hydra at ifdLevel 3 and not (ghc 8.10 or ghc 9.2)"
         run: |
           nix-build build.nix -A maintainer-scripts.check-hydra -o check-hydra.sh
@@ -186,7 +186,7 @@ jobs:
   closure-size:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Check closure size with ghc8107"
         run: |
           nix-build build.nix -A maintainer-scripts.check-closure-size --argstr compiler-nix-name ghc8107 -o check-closure-size.sh
@@ -196,7 +196,7 @@ jobs:
   update-docs:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Update docs"
         run: |
           nix-build build.nix -A maintainer-scripts.update-docs -o update-docs.sh
@@ -205,7 +205,7 @@ jobs:
   check-materialization-concurrency:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Make sure materialize function does not limit concurrency"
         run: |
           nix-build build.nix -A maintainer-scripts.check-materialization-concurrency -o check-materialization-concurrency.sh
@@ -214,7 +214,7 @@ jobs:
   check-path-support:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Make sure non store paths like can be used as src"
         run: |
           nix-build build.nix -A maintainer-scripts.check-path-support --argstr compiler-nix-name ghc8107 -o check-path-support.sh
@@ -223,26 +223,26 @@ jobs:
   haskell-nix-roots-do-not-require-IFDs:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Check that the haskell.nix roots do not require IFDs"
         run: nix build .#roots.x86_64-linux --accept-flake-config --option allow-import-from-derivation false
 
   hydra-without-remote-builders:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Check that evaluation of hydra jobs works without using remote builders"
         run: nix path-info --derivation .#requiredJobs.x86_64-darwin.required-unstable-ghc8107-native --show-trace --builders ''
 
   hix-cabal:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Check hix -- run github:haskell/cabal/3.10#cabal-install:exe:cabal -- --version"
         run: "HIX_DIR=$(mktemp -d) nix run .#hix --accept-flake-config -- run github:haskell/cabal/3.10#cabal-install:exe:cabal --accept-flake-config --override-input haskellNix . -- --version"
 
   nix-tools:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: nix build ./nix-tools#checks.x86_64-linux.truncate-index --accept-flake-config

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -9,7 +9,7 @@ jobs:
   update-pins:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v15
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -230,9 +230,23 @@ let
       sourceRepoPackageResult = pkgs.haskell-nix.haskellLib.parseSourceRepositoryPackages
         cabalProjectFileName sha256map source-repo-override projectFile;
 
-      # Parse the `repository` blocks
-      repoResult = pkgs.haskell-nix.haskellLib.parseRepositories
-        evalPackages cabalProjectFileName sha256map inputMap cabal-install nix-tools sourceRepoPackageResult.otherText;
+      sourceRepoFixedProjectFile =
+        sourceRepoPackageResult.initialText +
+        pkgs.lib.strings.concatMapStrings (block:
+            if block ? sourceRepo
+              then
+                let
+                  f = fetchPackageRepo evalPackages.fetchgit block.sourceRepo;
+                in ''
+
+                  ${block.indentation}source-repository-package
+                  ${block.indentation}  type: git
+                  ${block.indentation}  location: file://${f.location}
+                  ${block.indentation}  subdir: ${builtins.concatStringsSep " " f.subdirs}
+                  ${block.indentation}  tag: ${f.tag}
+                '' + block.followingText
+              else block.followingText
+          ) sourceRepoPackageResult.sourceRepos;
 
       # we need the repository content twice:
       # * at eval time (below to build the fixed project file)
@@ -243,28 +257,19 @@ let
       #   on the target system would use, so that the derivation is unaffected
       #   and, say, a linux release build job can identify the derivation
       #   as built by a darwin builder, and fetch it from a cache
-      sourceReposEval = builtins.map (fetchPackageRepo evalPackages.fetchgit) sourceRepoPackageResult.sourceRepos;
-      sourceReposBuild = builtins.map (x: (fetchPackageRepo pkgs.fetchgit x).fetched) sourceRepoPackageResult.sourceRepos;
+      sourceReposEval = builtins.map (x: (fetchPackageRepo evalPackages.fetchgit x.sourceRepo)) sourceRepoPackageResult.sourceRepos;
+      sourceReposBuild = builtins.map (x: (fetchPackageRepo pkgs.fetchgit x.sourceRepo).fetched) sourceRepoPackageResult.sourceRepos;
+
+      # Parse the `repository` blocks
+      repoResult = pkgs.haskell-nix.haskellLib.parseRepositories
+        evalPackages cabalProjectFileName sha256map inputMap cabal-install nix-tools sourceRepoFixedProjectFile;
     in {
       sourceRepos = sourceReposBuild;
       inherit (repoResult) repos extra-hackages;
       makeFixedProjectFile = ''
-        cp -f ${evalPackages.writeText "cabal.project" sourceRepoPackageResult.otherText} ./cabal.project
-      '' +
-        pkgs.lib.optionalString (builtins.length sourceReposEval != 0) (''
+        cp -f ${evalPackages.writeText "cabal.project" sourceRepoFixedProjectFile} ./cabal.project
         chmod +w -R ./cabal.project
-        # The newline here is important in case cabal.project does not have one at the end
-        echo >> ./cabal.project
-      '' +
-        # Add replacement `source-repository-package` blocks pointing to the minimal git repos
-        ( pkgs.lib.strings.concatMapStrings (f: ''
-              echo "source-repository-package" >> ./cabal.project
-              echo "  type: git" >> ./cabal.project
-              echo "  location: file://${f.location}" >> ./cabal.project
-              echo "  subdir: ${builtins.concatStringsSep " " f.subdirs}" >> ./cabal.project
-              echo "  tag: ${f.tag}" >> ./cabal.project
-            '') sourceReposEval
-        ));
+      '';
       # This will be used to replace refernces to the minimal git repos with just the index
       # of the repo.  The index will be used in lib/import-and-filter-project.nix to
       # lookup the correct repository in `sourceReposBuild`.  This avoids having

--- a/modules/configuration-nix.nix
+++ b/modules/configuration-nix.nix
@@ -44,7 +44,7 @@ in {
     (fromUntil "3.2.0.0" "3.5" ../overlays/patches/Cabal/Cabal-3.0.0.0-no-final-checks.diff)
     (fromUntil "3.6.0.0" "3.11" ../overlays/patches/Cabal/Cabal-3.6.0.0-drop-pkg-db-check.diff)
     (fromUntil "3.6.0.0" "3.11" ../overlays/patches/Cabal/Cabal-3.6.0.0-no-final-checks.diff)
-    (fromUntil "3.10" "3.11" ../overlays/patches/Cabal/9220.patch)
+    (fromUntil "3.10" "3.10.3" ../overlays/patches/Cabal/9220.patch)
   ];
 
   # These two patches are:

--- a/test/unit.nix
+++ b/test/unit.nix
@@ -58,7 +58,7 @@ lib.runTests {
   };
 
   testParseBlock1 = {
-    expr = __toJSON (haskellLib.parseSourceRepositoryPackageBlock "cabal.project" {} ''
+    expr = __toJSON (haskellLib.parseSourceRepositoryPackageBlock "cabal.project" {} {} "" ''
         type: git
         location: https://github.com/input-output-hk/haskell.nix.git
         tag: 487eea1c249537d34c27f6143dff2b9d5586c657
@@ -66,13 +66,14 @@ lib.runTests {
       -- end of block
     '');
     expected = __toJSON {
-      otherText = "-- end of block\n";
+      followingText = "-- end of block\n";
+      indentation = "";
       sourceRepo = testRepoData // { subdirs = ["."]; };
     };
   };
 
   testParseBlock2 = {
-    expr = __toJSON (haskellLib.parseSourceRepositoryPackageBlock "cabal.project" {} ''
+    expr = __toJSON (haskellLib.parseSourceRepositoryPackageBlock "cabal.project" {} {} "" ''
         type: git
         location: https://github.com/input-output-hk/haskell.nix.git
         tag: 487eea1c249537d34c27f6143dff2b9d5586c657
@@ -81,13 +82,14 @@ lib.runTests {
       -- end of block
     '');
     expected = __toJSON {
-      otherText = "-- end of block\n";
+      followingText = "-- end of block\n";
+      indentation = "";
       sourceRepo = testRepoData // { subdirs = ["dir"]; };
     };
   };
 
   testParseBlock3 = {
-    expr = __toJSON (haskellLib.parseSourceRepositoryPackageBlock "cabal.project" {} ''
+    expr = __toJSON (haskellLib.parseSourceRepositoryPackageBlock "cabal.project" {} {} "" ''
         type: git
         location: https://github.com/input-output-hk/haskell.nix.git
         tag: 487eea1c249537d34c27f6143dff2b9d5586c657
@@ -96,13 +98,14 @@ lib.runTests {
       -- end of block
     '');
     expected = __toJSON {
-      otherText = "-- end of block\n";
+      followingText = "-- end of block\n";
+      indentation = "";
       sourceRepo = testRepoData // { subdirs = ["dir1" "dir2"]; };
     };
   };
 
   testParseBlock4 = {
-    expr = __toJSON (haskellLib.parseSourceRepositoryPackageBlock "cabal.project" {} ''
+    expr = __toJSON (haskellLib.parseSourceRepositoryPackageBlock "cabal.project" {} {} "" ''
         type: git
         location: https://github.com/input-output-hk/haskell.nix.git
         tag: 487eea1c249537d34c27f6143dff2b9d5586c657
@@ -113,7 +116,8 @@ lib.runTests {
       -- end of block
     '');
     expected = __toJSON {
-      otherText = "-- end of block\n";
+      followingText = "-- end of block\n";
+      indentation = "";
       sourceRepo = testRepoData // { subdirs = ["dir1" "dir2"]; };
     };
   };
@@ -131,7 +135,7 @@ lib.runTests {
             }) vers
           ) x.hackage;
       };
-    in rec {
+      result = rec {
       expr = __toJSON (removeNix (haskellLib.parseRepositoryBlock evalPackages "cabal.project" {} {}
         evalPackages.haskell-nix.cabal-install.${compiler-nix-name}
         evalPackages.haskell-nix.nix-tools ''
@@ -321,4 +325,5 @@ lib.runTests {
         };
       };
     };
+    in __trace (__toJSON result) result;
 }

--- a/test/unit.nix
+++ b/test/unit.nix
@@ -325,5 +325,5 @@ lib.runTests {
         };
       };
     };
-    in __trace (__toJSON result) result;
+    in result;
 }


### PR DESCRIPTION
Updates the way haskell.nix handles source-repository-package blocks so that this can work:

```
if !os(ghcjs)
  source-repository-package
    type: git
    location: https://github.com/hamishmack/hs-libsodium.git
    tag: c094f210f3bd34d97204451ea57855a5d17e2086
    --sha256: sha256-6iCKvdLdjwg2jcoWMEj3qcFTvKe3P4BYxgKeXY3QwRM=

```