### PR TITLE
DRAFT: remove dependency on deprecated libcxxabi package

### DIFF
--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -9,7 +9,7 @@ let self =
 # build-tools
 , bootPkgs
 , buildPackages
-, autoconf, automake, coreutils, fetchurl, fetchpatch, perl, python3, m4, sphinx, numactl, elfutils, libcxx, libcxxabi
+, autoconf, automake, coreutils, fetchurl, fetchpatch, perl, python3, m4, sphinx, numactl, elfutils, libcxx
 , autoreconfHook
 , bash
 
@@ -673,7 +673,7 @@ stdenv.mkDerivation (rec {
         done
       '' + lib.optionalString stdenv.isDarwin ''
         substituteInPlace mk/system-cxx-std-lib-1.0.conf \
-          --replace 'dynamic-library-dirs:' 'dynamic-library-dirs: ${libcxx}/lib ${libcxxabi}/lib'
+          --replace 'dynamic-library-dirs:' 'dynamic-library-dirs: ${libcxx}/lib'
         find . -name 'system*.conf*'
         cat mk/system-cxx-std-lib-1.0.conf
       '' + lib.optionalString (installStage1 && stdenv.targetPlatform.isMusl) ''
@@ -758,7 +758,7 @@ stdenv.mkDerivation (rec {
 } // lib.optionalAttrs useHadrian {
   postConfigure = lib.optionalString stdenv.isDarwin ''
     substituteInPlace mk/system-cxx-std-lib-1.0.conf \
-      --replace 'dynamic-library-dirs:' 'dynamic-library-dirs: ${libcxx}/lib ${libcxxabi}/lib'
+      --replace 'dynamic-library-dirs:' 'dynamic-library-dirs: ${libcxx}/lib'
     find . -name 'system*.conf*'
     cat mk/system-cxx-std-lib-1.0.conf
   '' + lib.optionalString (installStage1 && !haskell-nix.haskellLib.isCrossTarget && stdenv.targetPlatform.isMusl) ''
@@ -822,9 +822,9 @@ stdenv.mkDerivation (rec {
         ./configure --prefix=$out ${lib.concatStringsSep " " configureFlags}
         ${lib.optionalString stdenv.isDarwin ''
           substituteInPlace mk/system-cxx-std-lib-1.0.conf \
-            --replace 'dynamic-library-dirs:' 'dynamic-library-dirs: ${libcxx}/lib ${libcxxabi}/lib'
+            --replace 'dynamic-library-dirs:' 'dynamic-library-dirs: ${libcxx}/lib'
           substituteInPlace lib/package.conf.d/system-cxx-std-lib-1.0.conf \
-            --replace 'dynamic-library-dirs:' 'dynamic-library-dirs: ${libcxx}/lib ${libcxxabi}/lib'
+            --replace 'dynamic-library-dirs:' 'dynamic-library-dirs: ${libcxx}/lib'
         ''}
         mkdir -p utils
         cp -r ../../../utils/completion utils

--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -21,7 +21,7 @@ in
 # -- linux
 { crypto = [ openssl ];
   "c++" = [ libcxx ];
-  "c++abi" = [ libcxxabi ];
+  "c++abi" = [ libcxx ];
   system-cxx-std-lib = [];
   "stdc++" = gcclibs;
   "stdc++-6" = gcclibs;


### PR DESCRIPTION
Since https://github.com/NixOS/nixpkgs/pull/292043 the `libcxxabi` package was functionally integrated into `libcxx` and is no longer required―indeed, [using it now throws](https://github.com/NixOS/nixpkgs/pull/292043/files#diff-29ed0f5fda84c91253503c1664d60a194a324e29518d472adf846f30b8db52e3R557).

* Remove all uses of `libcxxabi` from the compiler build (which already references `libcxx` in all the same places.)

* Update the package alias to forward `c++abi` to `cxxabi` rather than `libcxxabi`