### PR TITLE
Fix cabal pkg-config performance issue

### DIFF
--- a/overlays/cabal-pkg-config.nix
+++ b/overlays/cabal-pkg-config.nix
@@ -56,8 +56,7 @@ final: prev:
         ${final.pkgs.lib.concatStrings (map (name: ''
           ${name}
         '') (__attrNames pkgconfigPkgs))
-         }
-        EOF2
+         }EOF2
         elif [[ "\$1" == "--modversion" ]]; then
           OUTPUT=\$(mktemp)
           ERROR=\$(mktemp)
@@ -65,8 +64,7 @@ final: prev:
         ${final.pkgs.lib.concatStrings (map (p: ''
           ${getVersion (builtins.head p)}
         '') (__attrValues pkgconfigPkgs))
-        }
-        EOF2
+        }EOF2
         else
           $out/bin/${targetPrefix}${baseBinName}-wrapped "\$@"
         fi


### PR DESCRIPTION
The dummy version of `pkg-config` we provide to cabal-install-solver so that it can make an appropriate plan includes an extra blank line at the end of it's output.

In more recent versions of cabal-install-solver the following change has been made:

https://github.com/haskell/cabal/commit/0b34b4eaac65fb5a5ece8f7846077c4a3d627520

This change now filters the `null` values from the list of package names.  Then when the versions are looked up the output is not the expected length (because there is also a blank line at the end of the version list).

This change updates the dummy pkg-config script so that it does not include the extra blank lines at the end of the output.