### PR TITLE
Fix string contexts in cabal project parser

### DIFF
--- a/overlays/cabal-pkg-config.nix
+++ b/overlays/cabal-pkg-config.nix
@@ -56,8 +56,7 @@ final: prev:
         ${final.pkgs.lib.concatStrings (map (name: ''
           ${name}
         '') (__attrNames pkgconfigPkgs))
-         }
-        EOF2
+         }EOF2
         elif [[ "\$1" == "--modversion" ]]; then
           OUTPUT=\$(mktemp)
           ERROR=\$(mktemp)
@@ -65,8 +64,7 @@ final: prev:
         ${final.pkgs.lib.concatStrings (map (p: ''
           ${getVersion (builtins.head p)}
         '') (__attrValues pkgconfigPkgs))
-        }
-        EOF2
+        }EOF2
         else
           $out/bin/${targetPrefix}${baseBinName}-wrapped "\$@"
         fi


### PR DESCRIPTION
When both `repository` and `source-repository-packages` are included in a `cabal.project` (including `cabalProjectLocal`), the context needed for the `repository` is lost in the cabal project parser.

This means nix store path is not included in the dependencies of the plan-nix derivation and it fails with an error like this:

```
/nix/store/x-source/root.json:openBinaryFile: does not exist (No such file or directory)
```

This fix makes sure the context is correct by looking for /nix/store strings in the repository url and appending them to the context.