### PR TITLE
Fix test-only failure for ghcjs

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -545,7 +545,7 @@ let
               # we assume that if the SETUP_HS command fails and the following line was found in the error
               # log, that it was the only error. Hence if we do _not_ find the line, grep will fail and this derivation
               # will be marked as failure.
-              cat $SETUP_ERR | grep 'No executables and no library found\. Nothing to do\.'
+              cat $SETUP_ERR | grep 'No executables and no library found\. Nothing to'
             fi
             ''}
       ${lib.optionalString (haskellLib.isLibrary componentId) ''


### PR DESCRIPTION
The new `default-setup-ghcjs` has a longer name than `default-setup` and that causes the word `do` to wrap onto the next line.

The expected error now looks like this for ghcjs:

```
Error: default-setup-ghcjs: No executables and no library found. Nothing to
do.
```