### PR TITLE
Add reproduction case for failing quasiquoting when using JS backend

### DIFF
--- a/test/default.nix
+++ b/test/default.nix
@@ -221,6 +221,7 @@ let
     cabal-project-nix-path = callTest ./cabal-project-nix-path {};
     plugin = callTest ./plugin {};
     supported-languages = callTest ./supported-langauges {};
+    js-template-haskell = callTest ./js-template-haskell {};
     unit = unitTests;
   };
 

--- a/test/js-template-haskell/default.nix
+++ b/test/js-template-haskell/default.nix
@@ -1,0 +1,27 @@
+# Test building TH code that needs DLLs when cross compiling for windows
+{ stdenv, lib, project', haskellLib, recurseIntoAttrs, testSrc, compiler-nix-name, ... }:
+
+with lib;
+
+let
+  project = project' {
+    inherit compiler-nix-name;
+    src = testSrc "js-template-haskell";
+    modules = [
+      # Fix node: createProcess: posix_spawnp: does not exist (No such file or directory)
+      # ({ pkgs,... }: {
+      #   packages.js-template-haskell.components.library.build-tools = [ pkgs.pkgsBuildHost.nodejs ];
+      # })
+    ];
+  };
+
+  packages = project.hsPkgs;
+
+in recurseIntoAttrs {
+  ifdInputs = {
+    inherit (project) plan-nix;
+  };
+
+  build = packages.js-template-haskell.components.library;
+  build-profiled = packages.js-template-haskell.components.library.profiled;
+}

--- a/test/js-template-haskell/js-template-haskell.cabal
+++ b/test/js-template-haskell/js-template-haskell.cabal
@@ -10,7 +10,7 @@ common warnings
 library
     import:           warnings
     exposed-modules:  MyLib
-    build-depends:    base ^>=4.19.1.0
+    build-depends:    base
                     , uri-bytestring
     hs-source-dirs:   src
     default-language: Haskell2010

--- a/test/js-template-haskell/js-template-haskell.cabal
+++ b/test/js-template-haskell/js-template-haskell.cabal
@@ -1,0 +1,16 @@
+cabal-version:      3.0
+name:               js-template-haskell
+version:            0.1.0.0
+category:           Repro
+build-type:         Simple
+
+common warnings
+    ghc-options: -Wall
+
+library
+    import:           warnings
+    exposed-modules:  MyLib
+    build-depends:    base ^>=4.19.1.0
+                    , uri-bytestring
+    hs-source-dirs:   src
+    default-language: Haskell2010

--- a/test/js-template-haskell/src/MyLib.hs
+++ b/test/js-template-haskell/src/MyLib.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module MyLib (someFunc) where
+
+import URI.ByteString.QQ
+
+someFunc :: IO ()
+someFunc = putStrLn $ show [uri|https://www.example.com/|]


### PR DESCRIPTION
- When using quasiquoting, the JS backend is failing (with ghc-9.8.2) due to missing "nodejs" executable and "ghci" package.
- This PR adds a failing test to demonstrate this behaviour.

- Execute the test with:
  ```
  nix-build -A allJobs.x86_64-linux.unstable.ghc982.ghcjs.tests.js-template-haskell.build
  ```
  The error is:
  ```
  node: createProcess: posix_spawnp: does not exist (No such file or directory)
  ```
- We can add `nodejs` to the package build-tools to fix the nodejs issue:
  ```
      ({ pkgs,... }: {
        packages.js-template-haskell.components.library.build-tools = [ pkgs.pkgsBuildHost.nodejs ];
      })
  ```
- The error is now:
  ```
  JS interpreter: couldn't find "ghci" package
  ```
- I am unsure how to fix this error.

I think haskell.nix should add `nodejs` and `ghci` to the build environment when using the GHC JS backend, so that compiling code using quasiquoting/template haskell "just works" without too many headaches.

Evidence that `nodejs` and `ghci` are required:
 - `ghci`: https://gitlab.haskell.org/ghc/ghc/-/blob/ffe3e5c1e3868bb23bc1ce24dd671729d387f723/compiler/GHC/Runtime/Interpreter/JS.hs#L169
 - `nodejs`: https://gitlab.haskell.org/ghc/ghc/-/blob/ffe3e5c1e3868bb23bc1ce24dd671729d387f723/compiler/GHC/Runtime/Interpreter/JS.hs#L128