### PR TITLE
Use llvm12 instead of llvm9 for ghc 8.10+

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -408,8 +408,8 @@ in {
                 inherit sphinx;
 
                 useLLVM = !final.stdenv.targetPlatform.isx86;
-                buildLlvmPackages = final.buildPackages.llvmPackages_9;
-                llvmPackages = final.llvmPackages_9;
+                buildLlvmPackages = final.buildPackages.llvmPackages_12;
+                llvmPackages = final.llvmPackages_12;
 
                 src-spec = rec {
                     version = "8.10.1";
@@ -430,8 +430,8 @@ in {
                 inherit sphinx;
 
                 useLLVM = !final.stdenv.targetPlatform.isx86;
-                buildLlvmPackages = final.buildPackages.llvmPackages_9;
-                llvmPackages = final.llvmPackages_9;
+                buildLlvmPackages = final.buildPackages.llvmPackages_12;
+                llvmPackages = final.llvmPackages_12;
 
                 src-spec = rec {
                     version = "8.10.2";
@@ -452,8 +452,8 @@ in {
                 inherit sphinx;
 
                 useLLVM = !final.stdenv.targetPlatform.isx86;
-                buildLlvmPackages = final.buildPackages.llvmPackages_9;
-                llvmPackages = final.llvmPackages_9;
+                buildLlvmPackages = final.buildPackages.llvmPackages_12;
+                llvmPackages = final.llvmPackages_12;
 
                 src-spec = rec {
                     version = "8.10.3";
@@ -474,8 +474,8 @@ in {
                 inherit sphinx;
 
                 useLLVM = !final.stdenv.targetPlatform.isx86;
-                buildLlvmPackages = final.buildPackages.llvmPackages_9;
-                llvmPackages = final.llvmPackages_9;
+                buildLlvmPackages = final.buildPackages.llvmPackages_12;
+                llvmPackages = final.llvmPackages_12;
 
                 src-spec = rec {
                     version = "8.10.4";
@@ -496,8 +496,8 @@ in {
                 inherit sphinx;
 
                 useLLVM = !final.stdenv.targetPlatform.isx86;
-                buildLlvmPackages = final.buildPackages.llvmPackages_9;
-                llvmPackages = final.llvmPackages_9;
+                buildLlvmPackages = final.buildPackages.llvmPackages_12;
+                llvmPackages = final.llvmPackages_12;
 
                 src-spec = rec {
                     version = "8.10.5";
@@ -518,8 +518,8 @@ in {
                 inherit sphinx;
 
                 useLLVM = !final.stdenv.targetPlatform.isx86;
-                buildLlvmPackages = final.buildPackages.llvmPackages_9;
-                llvmPackages = final.llvmPackages_9;
+                buildLlvmPackages = final.buildPackages.llvmPackages_12;
+                llvmPackages = final.llvmPackages_12;
 
                 src-spec = rec {
                     version = "8.10.6";
@@ -562,8 +562,8 @@ in {
                 inherit sphinx;
 
                 useLLVM = !final.stdenv.targetPlatform.isx86;
-                buildLlvmPackages = final.buildPackages.llvmPackages_9;
-                llvmPackages = final.llvmPackages_9;
+                buildLlvmPackages = final.buildPackages.llvmPackages_12;
+                llvmPackages = final.llvmPackages_12;
 
                 src-spec = rec {
                     version = "9.0.1";
@@ -584,8 +584,8 @@ in {
                 inherit sphinx;
 
                 useLLVM = !final.stdenv.targetPlatform.isx86;
-                buildLlvmPackages = final.buildPackages.llvmPackages_9;
-                llvmPackages = final.llvmPackages_9;
+                buildLlvmPackages = final.buildPackages.llvmPackages_12;
+                llvmPackages = final.llvmPackages_12;
 
                 src-spec = rec {
                     version = "9.0.2";


### PR DESCRIPTION
Upstream pruned older llvm versions (example: https://github.com/NixOS/nixpkgs/pull/283591). So all version <12 are now unavailable in unstable (soon to be 24.05).

I wasn't sure what to do for GHC version earlier than 8.10, but I feel like 8.10+ is a reasonable compromise for just this PR.