### PR TITLE
remove libgtkpod from pkgconfig map

### DIFF
--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -2167,7 +2167,7 @@ pkgs:
     "gdkmm-3.0" = [ "gtkmm3" ];
     "gtkmm-3.0" = [ "gtkmm3" ];
     "gtkmm-4.0" = [ "gtkmm4" ];
-    "libgtkpod-1.1.0" = [ "gtkpod" ];
+#    "libgtkpod-1.1.0" = [ "gtkpod" ];
 #    "gtksourceview-3.0" = [ "gtksourceview" ];
     "gtksourceview-3.0" = [ "gtksourceview3" ];
     "gtksourceview-4" = [ "gtksourceview4" ];


### PR DESCRIPTION
Building with today's nixos-unstable and haskell.nix gives this error:

```
error: 'gtkpod' was removed due to one of its dependencies, 'anjuta' being unmaintained
```

`gtkpod` was indeed removed and haskell.nix still refers to it.  This PR removes that reference.
