### PR TITLE
Use github:stable-haskell/ghc/ghc-*-iog

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -86,7 +86,7 @@
     inherit (lib.systems.examples) ghcjs;
   } // lib.optionalAttrs (
          (__match ".*llvm" compiler-nix-name == null)
-      && ((system == "x86_64-linux"  && !builtins.elem compiler-nix-name ["ghc884"])
+      && ((system == "x86_64-linux"  && !builtins.elem compiler-nix-name ["ghc884" "ghc91120240620"]) # Including GHC HEAD here because the patches for rts/RtsSymbols.c no longer apply and mingwW64 GHC build fails without them
        || (system == "x86_64-darwin" && builtins.elem compiler-nix-name []))) { # TODO add ghc versions when we have more darwin build capacity
     inherit (lib.systems.examples) mingwW64;
   } // lib.optionalAttrs (nixpkgsName == "unstable"

--- a/flake.lock
+++ b/flake.lock
@@ -117,43 +117,6 @@
         "type": "github"
       }
     },
-    "ghc910X": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1714520650,
-        "narHash": "sha256-4uz6RA1hRr0RheGNDM49a/B3jszqNNU8iHIow4mSyso=",
-        "ref": "ghc-9.10",
-        "rev": "2c6375b9a804ac7fca1e82eb6fcfc8594c67c5f5",
-        "revCount": 62663,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "ref": "ghc-9.10",
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
-    "ghc911": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1714817013,
-        "narHash": "sha256-m2je4UvWfkgepMeUIiXHMwE6W+iVfUY38VDGkMzjCcc=",
-        "ref": "refs/heads/master",
-        "rev": "fc24c5cf6c62ca9e3c8d236656e139676df65034",
-        "revCount": 62816,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
     "hackage": {
       "flake": false,
       "locked": {
@@ -601,8 +564,6 @@
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "ghc910X": "ghc910X",
-        "ghc911": "ghc911",
         "hackage": "hackage",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",

--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,7 @@
     let
       callFlake = import flake-compat;
 
-      ifdLevel = 1;
+      ifdLevel = 2;
       compiler = "ghc928";
       config = import ./config.nix;
 

--- a/flake.nix
+++ b/flake.nix
@@ -14,14 +14,6 @@
     # And later it breaks in th-dll due to some change in the windows libs. We should probably
     # drop unsable.
     nixpkgs-unstable = { url = "github:NixOS/nixpkgs?rev=47585496bcb13fb72e4a90daeea2f434e2501998"; }; # nixpkgs-unstable };
-    ghc910X = {
-      flake = false;
-      url = "git+https://gitlab.haskell.org/ghc/ghc?ref=ghc-9.10&submodules=1";
-    };
-    ghc911 = {
-      flake = false;
-      url = "git+https://gitlab.haskell.org/ghc/ghc?submodules=1";
-    };
     flake-compat = { url = "github:input-output-hk/flake-compat/hkm/gitlab-fix"; flake = false; };
     "hls-1.10" = { url = "github:haskell/haskell-language-server/1.10.0.0"; flake = false; };
     "hls-2.0" = { url = "github:haskell/haskell-language-server/2.0.0.1"; flake = false; };
@@ -98,7 +90,7 @@
     let
       callFlake = import flake-compat;
 
-      ifdLevel = 3;
+      ifdLevel = 0;
       compiler = "ghc928";
       config = import ./config.nix;
 

--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,7 @@
     let
       callFlake = import flake-compat;
 
-      ifdLevel = 0;
+      ifdLevel = 1;
       compiler = "ghc928";
       config = import ./config.nix;
 

--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,7 @@
     let
       callFlake = import flake-compat;
 
-      ifdLevel = 2;
+      ifdLevel = 3;
       compiler = "ghc928";
       config = import ./config.nix;
 

--- a/lazy-inputs/default.nix
+++ b/lazy-inputs/default.nix
@@ -1,0 +1,36 @@
+final: prev:
+let
+  callFlake = import prev.haskell-nix.sources.flake-compat;
+in {
+  haskell-nix = prev.haskell-nix // {
+    sources = prev.haskell-nix.sources // {
+      inherit ((callFlake { pkgs = final; src = ./ghc8107; }).defaultNix) ghc8107;
+      inherit ((callFlake { pkgs = final; src = ./ghc901; }).defaultNix) ghc901;
+      inherit ((callFlake { pkgs = final; src = ./ghc902; }).defaultNix) ghc902;
+      inherit ((callFlake { pkgs = final; src = ./ghc921; }).defaultNix) ghc921;
+      inherit ((callFlake { pkgs = final; src = ./ghc922; }).defaultNix) ghc922;
+      inherit ((callFlake { pkgs = final; src = ./ghc923; }).defaultNix) ghc923;
+      inherit ((callFlake { pkgs = final; src = ./ghc924; }).defaultNix) ghc924;
+      inherit ((callFlake { pkgs = final; src = ./ghc925; }).defaultNix) ghc925;
+      inherit ((callFlake { pkgs = final; src = ./ghc926; }).defaultNix) ghc926;
+      inherit ((callFlake { pkgs = final; src = ./ghc927; }).defaultNix) ghc927;
+      inherit ((callFlake { pkgs = final; src = ./ghc928; }).defaultNix) ghc928;
+      inherit ((callFlake { pkgs = final; src = ./ghc941; }).defaultNix) ghc941;
+      inherit ((callFlake { pkgs = final; src = ./ghc942; }).defaultNix) ghc942;
+      inherit ((callFlake { pkgs = final; src = ./ghc943; }).defaultNix) ghc943;
+      inherit ((callFlake { pkgs = final; src = ./ghc944; }).defaultNix) ghc944;
+      inherit ((callFlake { pkgs = final; src = ./ghc945; }).defaultNix) ghc945;
+      inherit ((callFlake { pkgs = final; src = ./ghc946; }).defaultNix) ghc946;
+      inherit ((callFlake { pkgs = final; src = ./ghc947; }).defaultNix) ghc947;
+      inherit ((callFlake { pkgs = final; src = ./ghc948; }).defaultNix) ghc948;
+      inherit ((callFlake { pkgs = final; src = ./ghc961; }).defaultNix) ghc961;
+      inherit ((callFlake { pkgs = final; src = ./ghc962; }).defaultNix) ghc962;
+      inherit ((callFlake { pkgs = final; src = ./ghc963; }).defaultNix) ghc963;
+      inherit ((callFlake { pkgs = final; src = ./ghc964; }).defaultNix) ghc964;
+      inherit ((callFlake { pkgs = final; src = ./ghc965; }).defaultNix) ghc965;
+      inherit ((callFlake { pkgs = final; src = ./ghc981; }).defaultNix) ghc981;
+      inherit ((callFlake { pkgs = final; src = ./ghc982; }).defaultNix) ghc982;
+      inherit ((callFlake { pkgs = final; src = ./ghc9101; }).defaultNix) ghc9101;
+    };
+  };
+}

--- a/lazy-inputs/ghc8107/flake.lock
+++ b/lazy-inputs/ghc8107/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc8107": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1629288802,
+        "narHash": "sha256-WZcENDag6EclLpnuUryuw9HgZRNa66cIRpUSbWXEaFs=",
+        "ref": "ghc-8.10.7-iog",
+        "rev": "1f02b7430b2fbab403d7ffdde9cfd006e884678e",
+        "revCount": 55240,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-8.10.7-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc8107": "ghc8107"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc8107/flake.nix
+++ b/lazy-inputs/ghc8107/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc8107 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-8.10.7-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc901/flake.lock
+++ b/lazy-inputs/ghc901/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc901": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1612328754,
+        "narHash": "sha256-zJvtTZIoes5CFngGeqwSO/c/99xTIMuPPWrf3x3I7xA=",
+        "ref": "ghc-9.0.1-iog",
+        "rev": "da53a348150d30193a6f28e1b7ddcabdf45ab726",
+        "revCount": 56327,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.0.1-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc901": "ghc901"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc901/flake.nix
+++ b/lazy-inputs/ghc901/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc901 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.0.1-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc902/flake.lock
+++ b/lazy-inputs/ghc902/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc902": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1640385262,
+        "narHash": "sha256-kNYnGo7T21/q7HGhg+jxRTRn2UBSdrKr6o74CMCkBws=",
+        "ref": "ghc-9.0.2-iog",
+        "rev": "6554ff2843d53dddeb875cb145ab892725eac54c",
+        "revCount": 56629,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.0.2-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc902": "ghc902"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc902/flake.nix
+++ b/lazy-inputs/ghc902/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc902 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.0.2-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc9101/flake.lock
+++ b/lazy-inputs/ghc9101/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc9101": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715315814,
+        "narHash": "sha256-GxLntQzaqbb0rPNMIN2GxkQANbWFyiwNfEMUcCiD/bw=",
+        "ref": "ghc-9.10.1-iog",
+        "rev": "6d779c0fab30c39475aef50d39064ed67ce839d7",
+        "revCount": 62689,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.10.1-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc9101": "ghc9101"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc9101/flake.nix
+++ b/lazy-inputs/ghc9101/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc9101 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.10.1-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc911/flake.lock
+++ b/lazy-inputs/ghc911/flake.lock
@@ -1,0 +1,29 @@
+{
+  "nodes": {
+    "ghc911": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1718926152,
+        "narHash": "sha256-/8JCzx83juIl0ZZ68sYsc2BxVNy4XPXaGRkLz6w535I=",
+        "ref": "refs/heads/master",
+        "rev": "c8a8727ef67a3212abbf9f928bef67dfef276adf",
+        "revCount": 66999,
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      },
+      "original": {
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc911": "ghc911"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc911/flake.nix
+++ b/lazy-inputs/ghc911/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc911 = {
+      flake = false;
+      url = "git+https://gitlab.haskell.org/ghc/ghc?submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc921/flake.lock
+++ b/lazy-inputs/ghc921/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc921": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1635428734,
+        "narHash": "sha256-L2D8y3i2mnzbD3Ib7dM+EVbZGZSyoLd5i+Q8fE7HBME=",
+        "ref": "ghc-9.2.1-iog",
+        "rev": "82e6bf12786908ccda643dd1dceb42abcc97290c",
+        "revCount": 57665,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.2.1-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc921": "ghc921"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc921/flake.nix
+++ b/lazy-inputs/ghc921/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc921 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.2.1-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc922/flake.lock
+++ b/lazy-inputs/ghc922/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc922": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1646453911,
+        "narHash": "sha256-d9GKfBFOO00W67rTt5s9wKk53Ax6JKDG31X3xBYy+As=",
+        "ref": "ghc-9.2.2-iog",
+        "rev": "fbaee70d380973f71fa6e9e15be746532e5a4fc5",
+        "revCount": 57838,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.2.2-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc922": "ghc922"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc922/flake.nix
+++ b/lazy-inputs/ghc922/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc922 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.2.2-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc923/flake.lock
+++ b/lazy-inputs/ghc923/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc923": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1653643763,
+        "narHash": "sha256-MDgpz5H9In2RLf/Zq5JFbCK2rqUrznczjzpvYfWGgnA=",
+        "ref": "ghc-9.2.3-iog",
+        "rev": "a2f693f524830c2ab1e8a6e9d729839ac8b468c5",
+        "revCount": 57910,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.2.3-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc923": "ghc923"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc923/flake.nix
+++ b/lazy-inputs/ghc923/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc923 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.2.3-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc924/flake.lock
+++ b/lazy-inputs/ghc924/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc924": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1658904767,
+        "narHash": "sha256-hq81DxKcSxDIDemEWexLRUHkdKAgT7qA0rWB29/RbWc=",
+        "ref": "ghc-9.2.4-iog",
+        "rev": "a54827e0b48af33fa9cfde6ad131c6751c2fe321",
+        "revCount": 57966,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.2.4-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc924": "ghc924"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc924/flake.nix
+++ b/lazy-inputs/ghc924/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc924 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.2.4-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc925/flake.lock
+++ b/lazy-inputs/ghc925/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc925": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1667759797,
+        "narHash": "sha256-YMjMmsiX4cCH4Rtt2vupxdBHXX4ceBEgZt7moV4hYUg=",
+        "ref": "ghc-9.2.5-iog",
+        "rev": "74ca6191fa0dbbe8cee3dc53741b8d59fbf16b09",
+        "revCount": 57987,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.2.5-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc925": "ghc925"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc925/flake.nix
+++ b/lazy-inputs/ghc925/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc925 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.2.5-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc926/flake.lock
+++ b/lazy-inputs/ghc926/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc926": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675940452,
+        "narHash": "sha256-OquzrIKzmdHxWMQi82jdd0Rowp5a6JF+bCZolOwxda4=",
+        "ref": "ghc-9.2.6-iog",
+        "rev": "5383016c78fe4b2555e0aae9248bea5b42f67a78",
+        "revCount": 58043,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.2.6-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc926": "ghc926"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc926/flake.nix
+++ b/lazy-inputs/ghc926/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc926 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.2.6-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc927/flake.lock
+++ b/lazy-inputs/ghc927/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc927": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1677244066,
+        "narHash": "sha256-cunallsiH5VgUgvQlvcSBzCaiLwHsVHhgw/mUAQbCNc=",
+        "ref": "ghc-9.2.7-iog",
+        "rev": "b81cd709df8054b8b98ac05d3b9affcee9a8b840",
+        "revCount": 58059,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.2.7-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc927": "ghc927"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc927/flake.nix
+++ b/lazy-inputs/ghc927/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc927 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.2.7-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc928/flake.lock
+++ b/lazy-inputs/ghc928/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc928": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1685045870,
+        "narHash": "sha256-pd/x21CojgzD4u+cM5rQJNPj9yF6B8+OAjGGW9E1jjE=",
+        "ref": "ghc-9.2.8-iog",
+        "rev": "dfa834627a94d98aaeddb0cb3a0cedca934d2814",
+        "revCount": 58074,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.2.8-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc928": "ghc928"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc928/flake.nix
+++ b/lazy-inputs/ghc928/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc928 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.2.8-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc941/flake.lock
+++ b/lazy-inputs/ghc941/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc941": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1659841124,
+        "narHash": "sha256-/BEPtHKEVcyqFfV2UB7U8wHZG/E3WX6X4UBHFYRFktk=",
+        "ref": "ghc-9.4.1-iog",
+        "rev": "6d01245c458c49ca25c89ec13be3268ab6930a27",
+        "revCount": 59567,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.4.1-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc941": "ghc941"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc941/flake.nix
+++ b/lazy-inputs/ghc941/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc941 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.4.1-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc942/flake.lock
+++ b/lazy-inputs/ghc942/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc942": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661012429,
+        "narHash": "sha256-kOBvDGAQ9TKWrlO7l5E+Fdq8q/pgIJEMJBkKgqx7KI0=",
+        "ref": "ghc-9.4.2-iog",
+        "rev": "e8a889a7fc670532a3bf883a3e25acba92e6e6e1",
+        "revCount": 59603,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.4.2-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc942": "ghc942"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc942/flake.nix
+++ b/lazy-inputs/ghc942/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc942 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.4.2-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc943/flake.lock
+++ b/lazy-inputs/ghc943/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc943": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1667439539,
+        "narHash": "sha256-i5Lsh715xplcLhc/ubNmbWaHM32xfaDWmGJFCb3ymgU=",
+        "ref": "ghc-9.4.3-iog",
+        "rev": "8f8dba0190fe2a3a8b148fecf0dc83a725fb3fd2",
+        "revCount": 59630,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.4.3-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc943": "ghc943"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc943/flake.nix
+++ b/lazy-inputs/ghc943/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc943 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.4.3-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc944/flake.lock
+++ b/lazy-inputs/ghc944/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc944": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1671809493,
+        "narHash": "sha256-oGoHbDgOePfkx4q3LHliPrWBZ9a3OpRVN7YlIIa/Kik=",
+        "ref": "ghc-9.4.4-iog",
+        "rev": "cafe75946c465dd20c324918807464e09f12ac2f",
+        "revCount": 59670,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.4.4-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc944": "ghc944"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc944/flake.nix
+++ b/lazy-inputs/ghc944/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc944 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.4.4-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc945/flake.lock
+++ b/lazy-inputs/ghc945/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc945": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681638090,
+        "narHash": "sha256-ACv+xDiCecAJP6tPRM2uGjQiKVg9Q4vSxtIXTyV3m+M=",
+        "ref": "ghc-9.4.5-iog",
+        "rev": "a213d3676550a0e4d542172de539c0cfa2662431",
+        "revCount": 59818,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.4.5-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc945": "ghc945"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc945/flake.nix
+++ b/lazy-inputs/ghc945/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc945 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.4.5-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc946/flake.lock
+++ b/lazy-inputs/ghc946/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc946": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1691226979,
+        "narHash": "sha256-o2sfZe2iWaJvSCeZQ07ZcXVwPn1URvaPLVuAZPH/UrE=",
+        "ref": "ghc-9.4.6-iog",
+        "rev": "5f9929478e304868cbb6e1ea04da3f27ea4a1e8e",
+        "revCount": 59867,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.4.6-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc946": "ghc946"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc946/flake.nix
+++ b/lazy-inputs/ghc946/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc946 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.4.6-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc947/flake.lock
+++ b/lazy-inputs/ghc947/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc947": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1692583571,
+        "narHash": "sha256-a+FcDeaijzN1l0pTeuGox30pGdIFVpsUN7RKejXnsKU=",
+        "ref": "ghc-9.4.7-iog",
+        "rev": "00920f176b0235d5bb52a8e054d89a664f8938fe",
+        "revCount": 59878,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.4.7-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc947": "ghc947"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc947/flake.nix
+++ b/lazy-inputs/ghc947/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc947 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.4.7-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc948/flake.lock
+++ b/lazy-inputs/ghc948/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc948": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699376810,
+        "narHash": "sha256-EAk7BdqIcJcMvWE82zMFbrLwmSwvZwJaTwUDWFuyYro=",
+        "ref": "ghc-9.4.8-iog",
+        "rev": "8e9ea0f91305d9e4bb9df3d89f6a9e223ecb4dd3",
+        "revCount": 59903,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.4.8-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc948": "ghc948"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc948/flake.nix
+++ b/lazy-inputs/ghc948/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc948 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.4.8-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc961/flake.lock
+++ b/lazy-inputs/ghc961/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc961": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1678459345,
+        "narHash": "sha256-N/DFUCv6hW+0koUIOonVTp/7XvXJe+v6z6uBkc+8Bec=",
+        "ref": "ghc-9.6.1-iog",
+        "rev": "a58c028a181106312e1a783e82a37fc657ce9cfe",
+        "revCount": 60736,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.6.1-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc961": "ghc961"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc961/flake.nix
+++ b/lazy-inputs/ghc961/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc961 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.6.1-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc962/flake.lock
+++ b/lazy-inputs/ghc962/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc962": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1684801089,
+        "narHash": "sha256-rrlgGi4mi69Aj0yX+lsiEAzJjRMGJ2ys5F0HCkiuntw=",
+        "ref": "ghc-9.6.2-iog",
+        "rev": "7e70df17aee2e39bc599b43e59a52bb30064df4d",
+        "revCount": 60811,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.6.2-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc962": "ghc962"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc962/flake.nix
+++ b/lazy-inputs/ghc962/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc962 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.6.2-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc963/flake.lock
+++ b/lazy-inputs/ghc963/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc963": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695290340,
+        "narHash": "sha256-gLL0M4BdI+G/wJABtETDUnHKKaYkYzGd6ns+Rgqlj6Q=",
+        "ref": "ghc-9.6.3-iog",
+        "rev": "6819b70a7739205a75f0b4fefcfcc9fdab39cab9",
+        "revCount": 60904,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.6.3-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc963": "ghc963"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc963/flake.nix
+++ b/lazy-inputs/ghc963/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc963 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.6.3-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc964/flake.lock
+++ b/lazy-inputs/ghc964/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc964": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1704715572,
+        "narHash": "sha256-JFXkhikOmNCJkMQXyWcae7MOb0eLWaPDuM6mVpV2JiI=",
+        "ref": "ghc-9.6.4-iog",
+        "rev": "3187fc7644a41c182ec35292389b61bc0575e80b",
+        "revCount": 60970,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.6.4-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc964": "ghc964"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc964/flake.nix
+++ b/lazy-inputs/ghc964/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc964 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.6.4-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc965/flake.lock
+++ b/lazy-inputs/ghc965/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc965": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1713171936,
+        "narHash": "sha256-dmeB90iYdpUgVqtcFh29JMGznt46X2FSw4IKak+6djQ=",
+        "ref": "ghc-9.6.5-iog",
+        "rev": "650c34ab4e1cefb521209b143ecd75367ec03ee1",
+        "revCount": 61011,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.6.5-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc965": "ghc965"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc965/flake.nix
+++ b/lazy-inputs/ghc965/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc965 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.6.5-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc981/flake.lock
+++ b/lazy-inputs/ghc981/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc981": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696643148,
+        "narHash": "sha256-E02DfgISH7EvvNAu0BHiPvl1E5FGMDi0pWdNZtIBC9I=",
+        "ref": "ghc-9.8.1-iog",
+        "rev": "443e870d977b1ab6fc05f47a9a17bc49296adbd6",
+        "revCount": 61642,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.8.1-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc981": "ghc981"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc981/flake.nix
+++ b/lazy-inputs/ghc981/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc981 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.8.1-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lazy-inputs/ghc982/flake.lock
+++ b/lazy-inputs/ghc982/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "ghc982": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708625538,
+        "narHash": "sha256-EhZSGnr12aWkye9v5Jsm91vbMi/EDzRAPs8/W2aKTZ8=",
+        "ref": "ghc-9.8.2-iog",
+        "rev": "f3225ed4b3f3c4309f9342c5e40643eeb0cc45da",
+        "revCount": 61754,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.8.2-iog",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/stable-haskell/ghc"
+      }
+    },
+    "root": {
+      "inputs": {
+        "ghc982": "ghc982"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/lazy-inputs/ghc982/flake.nix
+++ b/lazy-inputs/ghc982/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "Lazy Input for Haskell.nix";
+
+  inputs = {
+    ghc982 = {
+      flake = false;
+      url = "git+https://github.com/stable-haskell/ghc?ref=ghc-9.8.2-iog&submodules=1";
+    };
+  };
+
+  outputs = inputs: inputs;
+}

--- a/lib/supported-languages.nix
+++ b/lib/supported-languages.nix
@@ -305,5 +305,8 @@ evalPackages.writeTextFile {
     NoUnliftedNewtypes
     ViewPatterns
     NoViewPatterns
-    '';
+    ${pkgs.lib.optionalString (builtins.compareVersions ghc.version "9.11" >=0) ''
+      OrPatterns
+      NoOrPatterns
+    ''}'';
 }

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -247,7 +247,7 @@ in {
                 ++ onWindowsOrMusl (fromUntil "9.8.2"  "9.11" ./patches/ghc/ghc-9.6-0006-Adds-support-for-Hidden-symbols-2.patch)
                 ++ fromUntil "9.9"  "9.12" ./patches/ghc/ghc-9.9-Cabal-3.11.patch
                 ++ fromUntil "9.8"  "9.9"  ./patches/ghc/ghc-9.8-text-upper-bound.patch
-                ++ fromUntil "9.10" "9.12" ./patches/ghc/ghc-9.10-containers-upper-bound.patch
+                ++ fromUntil "9.10" "9.11" ./patches/ghc/ghc-9.10-containers-upper-bound.patch
                 ++ fromUntil "9.10" "9.12" ./patches/ghc/ghc-9.10-merge-objects.patch
                 ;
         in ({

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -314,7 +314,7 @@ in {
             ghc921 = traceWarnOld "9.2" (final.callPackage ../compiler/ghc {
                 extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc921; };
 
-                bootPkgs = bootPkgs // {
+                bootPkgs = bootPkgsGhc94 // {
                   ghc = final.buildPackages.buildPackages.haskell-nix.compiler.ghc8107;
                 };
                 inherit sphinx;
@@ -331,7 +331,7 @@ in {
             ghc922 = traceWarnOld "9.2" (final.callPackage ../compiler/ghc {
                 extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc922; };
 
-                bootPkgs = bootPkgs // {
+                bootPkgs = bootPkgsGhc94 // {
                   ghc = final.buildPackages.buildPackages.haskell-nix.compiler.ghc8107;
                 };
                 inherit sphinx;
@@ -348,7 +348,7 @@ in {
             ghc923 = traceWarnOld "9.2" (final.callPackage ../compiler/ghc {
                 extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc923; };
 
-                bootPkgs = bootPkgs // {
+                bootPkgs = bootPkgsGhc94 // {
                   ghc = final.buildPackages.buildPackages.haskell-nix.compiler.ghc8107;
                 };
                 inherit sphinx;
@@ -365,7 +365,7 @@ in {
             ghc924 = traceWarnOld "9.2" (final.callPackage ../compiler/ghc {
                 extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc924; };
 
-                bootPkgs = bootPkgs // {
+                bootPkgs = bootPkgsGhc94 // {
                   ghc = final.buildPackages.buildPackages.haskell-nix.compiler.ghc8107;
                 };
                 inherit sphinx;
@@ -382,7 +382,7 @@ in {
             ghc925 = traceWarnOld "9.2" (final.callPackage ../compiler/ghc {
                 extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc925; };
 
-                bootPkgs = bootPkgs // {
+                bootPkgs = bootPkgsGhc94 // {
                   ghc = final.buildPackages.buildPackages.haskell-nix.compiler.ghc8107;
                 };
                 inherit sphinx;
@@ -399,7 +399,7 @@ in {
             ghc926 = traceWarnOld "9.2" (final.callPackage ../compiler/ghc {
                 extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc926; };
 
-                bootPkgs = bootPkgs // {
+                bootPkgs = bootPkgsGhc94 // {
                   ghc = final.buildPackages.buildPackages.haskell-nix.compiler.ghc8107;
                 };
                 inherit sphinx;
@@ -416,7 +416,7 @@ in {
             ghc927 = traceWarnOld "9.2" (final.callPackage ../compiler/ghc {
                 extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc927; };
 
-                bootPkgs = bootPkgs // {
+                bootPkgs = bootPkgsGhc94 // {
                   ghc = final.buildPackages.buildPackages.haskell-nix.compiler.ghc8107;
                 };
                 inherit sphinx;
@@ -433,7 +433,7 @@ in {
             ghc928 = traceWarnOld "9.2" (final.callPackage ../compiler/ghc {
                 extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc928; };
 
-                bootPkgs = bootPkgs // {
+                bootPkgs = bootPkgsGhc94 // {
                   ghc = final.buildPackages.buildPackages.haskell-nix.compiler.ghc8107;
                 };
                 inherit sphinx;

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -125,7 +125,7 @@ in {
                 ++ until              "9.0"    ./patches/ghc/dont-mark-evacuate_large-as-inline.patch
                 ++ onWindows (fromUntil "9.4.1"  "9.4.5"  ./patches/ghc/ghc-9.4-hadrian-win-cross.patch)
                 ++ onWindows (fromUntil "9.4.7"  "9.4.9"  ./patches/ghc/ghc-9.8-hadrian-win-cross.patch)
-                ++ onWindows (fromUntil "9.6.3"  "9.12"   ./patches/ghc/ghc-9.8-hadrian-win-cross.patch)
+                ++ onWindows (fromUntil "9.6.3"  "9.11"   ./patches/ghc/ghc-9.8-hadrian-win-cross.patch)
                 # support R_X86_64_PC64 (ELF constant 24) - IMAGE_REL_AMD64_SREL32 (PE constant 14), which seems to appear with 9.6 more frequently, and
                 # results in "unhandled PEi386 relocation type 14".
                 ++ onWindows (fromUntil "9.4.1"  "9.12"   ./patches/ghc/win-reloc-x86_64-pc64.patch)
@@ -143,12 +143,12 @@ in {
                   ++ onWindows (fromUntil "9.9"    "9.9.20231203" ./patches/ghc/no-ucrt-9.9.patch)
                 )
                 ++ onWindows (fromUntil "9.4.7"  "9.5"    ./patches/ghc/revert-289547580b6f2808ee123f106c3118b716486d5b.patch)
-                ++ onWindows (fromUntil "9.6.3"  "9.12"   ./patches/ghc/revert-289547580b6f2808ee123f106c3118b716486d5b.patch)
+                ++ onWindows (fromUntil "9.6.3"  "9.11"   ./patches/ghc/revert-289547580b6f2808ee123f106c3118b716486d5b.patch)
                 # the following is needed for cardano-prelude as it uses closure_sizeW :-/
-                ++ onWindows (fromUntil "9.4"    "9.12"   ./patches/ghc/win-add-closure_sizeW-to-rtssyms.patch)
+                ++ onWindows (fromUntil "9.4"    "9.11"   ./patches/ghc/win-add-closure_sizeW-to-rtssyms.patch)
                 ++ onWindows (until              "9.0"    ./patches/ghc/ghc-8.10-win-add-tzset-to-rtssyms.patch)
                 ++ onWindows (fromUntil "9.0"    "9.3"    ./patches/ghc/ghc-9.2-win-add-tzset-to-rtssyms.patch)
-                ++ onWindows (fromUntil "9.4"    "9.12"   ./patches/ghc/win-add-tzset-to-rtssyms.patch)
+                ++ onWindows (fromUntil "9.4"    "9.11"   ./patches/ghc/win-add-tzset-to-rtssyms.patch)
                 ++ onWindows (fromUntil "9.4.1"  "9.4.7"  ./patches/ghc/win-linker-no-null-deref.patch)
                 ++ onWindows (fromUntil "9.4.7"  "9.4.8"  ./patches/ghc/win-linker-no-null-deref-9.6.patch)
                 ++ onWindows (fromUntil "9.4.1"  "9.6"    ./patches/ghc/ghc-9.4-drop-mingwex-from-base.patch)

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -265,11 +265,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "8.10.7";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "179ws2q0dinl1a39wm9j37xzwm84zfz3c5543vz8v479khigdvp3";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc8107;
+                src-spec.version = "8.10.7";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "8.10.7";
             });
@@ -287,11 +285,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.0.1";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "1y9mi9bq76z04hmggavrn8jwi1gx92bm3zhx6z69ypq6wha068x5";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc901;
+                src-spec.version = "9.0.1";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.0.1";
             });
@@ -309,11 +305,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.0.2";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "15wii8can2r3dcl6jjmd50h2jvn7rlmn05zb74d2scj6cfwl43hl";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc902;
+                src-spec.version = "9.0.2";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.0.2";
             });
@@ -328,11 +322,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.2.1";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-9EQBL5ehNtmUD3fN/wP9pI+UdeLtD+yWbE01xN9V90Y=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc921;
+                src-spec.version = "9.2.1";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.2.1";
             });
@@ -347,11 +339,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.2.2";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-kCRjpMxu5Hmvk1i5+LLuMjewPpNKHqZbbR/PPg10nqY=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc922;
+                src-spec.version = "9.2.2";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.2.2";
             });
@@ -366,11 +356,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.2.3";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-UOzcK+8BPlGPmmKhUkXX2w5ECdc3xDsc6nMG/YLhZp4=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc923;
+                src-spec.version = "9.2.3";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.2.3";
             });
@@ -385,11 +373,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.2.4";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-FSE4iAZKDsTncj0HXzG4emeM4IUXc9WLRO96o96ZZFg=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc924;
+                src-spec.version = "9.2.4";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.2.4";
             });
@@ -404,11 +390,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.2.5";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-BgZ5fRs44tiO4iQ/OOxrmhqpPptXjpXw3pqcCkFEAhw=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc925;
+                src-spec.version = "9.2.5";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.2.5";
             });
@@ -423,11 +407,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.2.6";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-elTPA5itSItO0hnhXR0eZMC2h2xDoFZFUN0R8FQNcwU=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc926;
+                src-spec.version = "9.2.6";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.2.6";
             });
@@ -442,11 +424,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.2.7";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-olNWehe3NKTA3Q/6KW0zwqW1pUp335iIBqKh4cp+iLg=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc927;
+                src-spec.version = "9.2.7";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.2.7";
             });
@@ -461,11 +441,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.2.8";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-XxPReGv0/RL0tF+qN6vttbs/NtXlj32lMH6L/oilZ6E=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc928;
+                src-spec.version = "9.2.8";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.2.8";
             });
@@ -484,11 +462,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.4.1";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-y/7UZAvfAl4zulVDPa+M32mPTgSZrnqADd5EqC5zluM=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc941;
+                src-spec.version = "9.4.1";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.4.1";
             });
@@ -507,11 +483,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.4.2";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-cifvO14VoNcLjxpDrsMoZ+KpsthXzA7VVq7tFy1Ns6U";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc942;
+                src-spec.version = "9.4.2";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.4.2";
             });
@@ -530,11 +504,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.4.3";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-6vY5SVNu3lDuORefIpnVCU65FS2HzG+yF1AGvJjokFo=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc943;
+                src-spec.version = "9.4.3";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.4.3";
             });
@@ -553,11 +525,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.4.4";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-6M7yWm3tFTHNp6kEiNDPtteAZX0WY22qWUML4DDNZ+I=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc944;
+                src-spec.version = "9.4.4";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.4.4";
             });
@@ -576,11 +546,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.4.5";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-YlbPnK9tbce2Edz7skffLVKOhao50ippjocOWlkOhgE=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc945;
+                src-spec.version = "9.4.5";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.4.5";
             });
@@ -600,11 +568,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.4.7";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-BndaUrTROsCe3G2rwpn9EeWdiIa7yuRQrzZ7ruJoTI8=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc947;
+                src-spec.version = "9.4.7";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.4.7";
             });
@@ -625,37 +591,11 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.4.8";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-C/QH62f+PjwksPTI3qjLY+B/Y8oPds8gWFZRQ1B6uF4=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc948;
+                src-spec.version = "9.4.8";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.4.8";
-            });
-            ghc96020230302 = traceWarnOld "9.6" (final.callPackage ../compiler/ghc {
-                extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc96020230302; };
-
-                bootPkgs = bootPkgsGhc94 // {
-                  ghc = if final.stdenv.buildPlatform != final.stdenv.targetPlatform
-                    then final.buildPackages.buildPackages.haskell-nix.compiler.ghc96020230302
-                    else final.buildPackages.buildPackages.haskell.compiler.ghc962
-                          or final.buildPackages.buildPackages.haskell.compiler.ghc945
-                          or final.buildPackages.buildPackages.haskell.compiler.ghc944
-                          or final.buildPackages.buildPackages.haskell.compiler.ghc943;
-                };
-                inherit sphinx;
-
-                buildLlvmPackages = final.buildPackages.llvmPackages_12;
-                llvmPackages = final.llvmPackages_12;
-
-                src-spec = rec {
-                    version = "9.6.0.20230302";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-Vlj/E1eoL/7PUsYCsareTGPRGEvLzYtjPcxsYaSmNvM=";
-                };
-
-                ghc-patches = ghc-patches "9.6.1";
             });
             ghc961 = traceWarnOld "9.6" (final.callPackage ../compiler/ghc {
                 extra-passthru = { buildGHC = final.buildPackages.haskell-nix.compiler.ghc961; };
@@ -676,11 +616,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.6.1";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-/lrJCcuLsIfiNd6X+mOv9HqK5lDvqjeiFA9HgOIfNMs=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc961;
+                src-spec.version = "9.6.1";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.6.1";
             });
@@ -703,11 +641,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.6.2";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-G1EMX4dTw7okhRcCxsnafYHcXkf+Pst685x8JhOr8XA=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc962;
+                src-spec.version = "9.6.2";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.6.2";
             });
@@ -730,11 +666,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.6.3";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-383me0qlUKC4oam7gQWDXcmZ+tY5fM4z1y/VXSHrd/U=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc963;
+                src-spec.version = "9.6.3";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.6.3";
             });
@@ -757,11 +691,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.6.4";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-EL8luLBxdP3ZhotcDFbBfA7x7ctiR7S4ZL6TNlG/1MA=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc964;
+                src-spec.version = "9.6.4";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.6.4";
             });
@@ -784,11 +716,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.6.5";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-h7OJkk+YwaJsIFEidXM4yNqzOtH89nD6oiYidCQyuTw=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc965;
+                src-spec.version = "9.6.5";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.6.5";
             });
@@ -811,11 +741,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.8.1";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-svjta39zN5epJDb0/24IilIJExScmpvpBGW0CtHyB1E=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc981;
+                src-spec.version = "9.8.1";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.8.1";
             });
@@ -838,11 +766,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.8.2";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-4vt6fddGEjfSLoNlqD7dnhp30uFdBF85RTloRah3gck=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc982;
+                src-spec.version = "9.8.2";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.8.2";
             });
@@ -867,11 +793,9 @@ in {
                 buildLlvmPackages = final.buildPackages.llvmPackages_12;
                 llvmPackages = final.llvmPackages_12;
 
-                src-spec = rec {
-                    version = "9.10.1";
-                    url = "https://downloads.haskell.org/~ghc/${version}/ghc-${version}-src.tar.xz";
-                    sha256 = "sha256-vzhqMC1O4FR5H/1RdIkA8V1xdg/RmRV5ItEgzB+J4vc=";
-                };
+                src-spec.file = final.haskell-nix.sources.ghc9101;
+                src-spec.version = "9.10.1";
+                src-spec.needsBooting = true;
 
                 ghc-patches = ghc-patches "9.10.1";
             });

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -93,6 +93,7 @@ let
     cabalPkgConfig = import ./cabal-pkg-config.nix;
     cacheCompilerDeps = import ./cache-compiler-deps.nix;
     fetch-source = import ./fetch-source.nix;
+    lazy-inputs = import ../lazy-inputs;
   };
 
   composeExtensions = f: g: final: prev:
@@ -133,6 +134,7 @@ let
     (_: prev: { inherit (prev.haskell-nix-prev) haskell haskellPackages; })
     cacheCompilerDeps
     fetch-source
+    lazy-inputs
   ];
   combined = builtins.foldl' composeExtensions (_: _: { }) ordered;
 in overlays // { inherit combined; }

--- a/overlays/fetch-source.nix
+++ b/overlays/fetch-source.nix
@@ -1,6 +1,5 @@
 final: prev:
 let
-  lockFile = builtins.fromJSON (builtins.readFile ../flake.lock);
   # Courtesy of `flake-compat`
   # Format number of seconds in the Unix epoch as %Y%m%d%H%M%S.
   formatSecondsSinceEpoch = t:
@@ -28,7 +27,9 @@ let
     in "${toString y'}${pad (toString m)}${pad (toString d)}${pad (toString hours)}${pad (toString minutes)}${pad (toString seconds)}";
 in {
   haskell-nix = prev.haskell-nix // {
-    sources = prev.haskell-nix.sources // builtins.listToAttrs (map (name: {
+    sources = prev.haskell-nix.sources // builtins.listToAttrs (map (name:
+      let lockFile = builtins.fromJSON (builtins.readFile ../lazy-inputs/${name}/flake.lock);
+      in {
         inherit name;
         value = final.fetchFromGitLab {
                     domain = "gitlab.haskell.org";

--- a/overlays/patches/ghc/ghc-8.10.5-ubxt.patch
+++ b/overlays/patches/ghc/ghc-8.10.5-ubxt.patch
@@ -3427,23 +3427,10 @@ index 9b8b2e3fcb..769efb7fd6 100644
  -- | Tick scope identifier, allowing us to reason about what
  -- annotations in a Cmm block should scope over. We especially take
  -- care to allow optimisations to reorganise blocks without losing
-diff --git a/compiler/cmm/CmmParse.hs b/compiler/cmm/CmmParse.hs
+diff --git a/compiler/cmm/CmmParse.y b/compiler/cmm/CmmParse.y
 index e7527f8e50..454c0efd21 100644
---- a/compiler/cmm/CmmParse.hs
-+++ b/compiler/cmm/CmmParse.hs
-@@ -220,7 +220,7 @@ import GHC.StgToCmm.Closure
- import GHC.StgToCmm.Layout     hiding (ArgRep(..))
- import GHC.StgToCmm.Ticky
- import GHC.StgToCmm.Bind  ( emitBlackHoleCode, emitUpdateFrame )
--import CoreSyn          ( Tickish(SourceNote) )
-+import CoreSyn          ( GenTickish(SourceNote) )
- 
- import CmmOpt
- import MkGraph
-diff --git a/compiler/cmm/CmmParse.y.source b/compiler/cmm/CmmParse.y.source
-index e7527f8e50..454c0efd21 100644
---- a/compiler/cmm/CmmParse.y.source
-+++ b/compiler/cmm/CmmParse.y.source
+--- a/compiler/cmm/CmmParse.y
++++ b/compiler/cmm/CmmParse.y
 @@ -220,7 +220,7 @@ import GHC.StgToCmm.Closure
  import GHC.StgToCmm.Layout     hiding (ArgRep(..))
  import GHC.StgToCmm.Ticky

--- a/test/cabal.project.local
+++ b/test/cabal.project.local
@@ -22,7 +22,7 @@ repository head.hackage.ghc.haskell.org
      f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
      26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
      7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-  --sha256: sha256-dx4WtCafVcu1+IlaK1ABcqQ1UummqTN8HRo3svRdTOE=
+  --sha256: sha256-gDLkCAZPa4xALm37iKVjDVnmBj0CwNKT1qzY/xiiPOY=
 
 repository ghcjs-overlay
   url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/ed91ac93832fdfc50471ab8df13b8174e91b35ed

--- a/test/js-template-haskell/default.nix
+++ b/test/js-template-haskell/default.nix
@@ -1,11 +1,11 @@
 # Test building TH code that needs DLLs when cross compiling for windows
-{ stdenv, lib, project', haskellLib, recurseIntoAttrs, testSrc, compiler-nix-name, ... }:
+{ stdenv, lib, project', haskellLib, recurseIntoAttrs, testSrc, compiler-nix-name, evalPackages }:
 
 with lib;
 
 let
   project = project' {
-    inherit compiler-nix-name;
+    inherit compiler-nix-name evalPackages;
     src = testSrc "js-template-haskell";
     cabalProjectLocal = ''
       if arch(javascript)

--- a/test/plugin/default.nix
+++ b/test/plugin/default.nix
@@ -20,7 +20,7 @@ in recurseIntoAttrs {
 
   # Not sure why this breaks for ghc 8.10.7
   meta.disabled = compiler-nix-name == "ghc8107"
-    || builtins.elem compiler-nix-name [ "ghc9101x" "ghc91120240620" ]
+    || builtins.elem compiler-nix-name [ "ghc91120240620" ]
     || stdenv.hostPlatform.isMusl
     || stdenv.hostPlatform.isGhcjs
     || stdenv.hostPlatform.isWindows

--- a/test/plugin/default.nix
+++ b/test/plugin/default.nix
@@ -6,10 +6,9 @@ let
   project = project' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "plugin";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local;
-    modules = [{
-      reinstallableLibGhc = builtins.compareVersions buildPackages.haskell-nix.compiler.${compiler-nix-name}.version "9.8.1" < 0;
-    }];
+    cabalProjectLocal = builtins.readFile ../cabal.project.local + ''
+      allow-newer: polysemy-plugin:containers, polysemy:containers
+    '';
   };
 
   packages = project.hsPkgs;
@@ -21,7 +20,7 @@ in recurseIntoAttrs {
 
   # Not sure why this breaks for ghc 8.10.7
   meta.disabled = compiler-nix-name == "ghc8107"
-    || builtins.elem compiler-nix-name [ "ghc9101" "ghc91120240504" ]
+    || builtins.elem compiler-nix-name [ "ghc9101x" "ghc91120240620" ]
     || stdenv.hostPlatform.isMusl
     || stdenv.hostPlatform.isGhcjs
     || stdenv.hostPlatform.isWindows

--- a/test/supported-langauges/default.nix
+++ b/test/supported-langauges/default.nix
@@ -13,10 +13,14 @@ in recurseIntoAttrs {
 
     buildCommand = ''
       expected=$(mktemp)
-      ${ghc}/bin/${ghc.targetPrefix}ghc --supported-languages >$expected
+      dummy=$(mktemp)
+      ${ghc}/bin/${ghc.targetPrefix}ghc --supported-languages | sort >$expected
+      sort ${supported-langauges} > $dummy
 
-      echo 'diff -u $expected ${supported-langauges}'
-      diff -u $expected ${supported-langauges}
+      echo 'Expected `${ghc}/bin/${ghc.targetPrefix}ghc --supported-languages | sort`'
+      echo 'The calculated by lib/supported-languages.nix `sort ${supported-langauges}`'
+      echo 'diff -u $dummy $expected'
+      diff -u $dummy $expected
 
       touch $out
     '';


### PR DESCRIPTION
* Use github:stable-haskell/ghc/ghc-*-iog

* Use new happy for ghc 9.2

* Fix supported-languages dummy output

* Fix ghc plugin tests

* Disable mingwW64 for GHC HEAD (patches needed to build it no longer apply cleanly and the fix is not clear)

* Add missing evalPackages to js-template-haskell test