### PR TITLE
Allow reinstall of filepath in GHC 9.4.8

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -13,7 +13,7 @@
 #
 # tl;dr: the builder must not re-introduce any reference to the build plan.
 
-{ pkgs, buildPackages, evalPackages, stdenv, lib, haskellLib, ghc, compiler-nix-name, fetchurl, nonReinstallablePkgs, hsPkgs, compiler }:
+{ pkgs, buildPackages, pkgsBuildBuild, evalPackages, stdenv, lib, haskellLib, ghc, compiler-nix-name, fetchurl, nonReinstallablePkgs, hsPkgs, compiler }:
 
 let
   # Builds a single component of a package.
@@ -85,7 +85,7 @@ let
 
   # Same as haskellPackages.shellFor in nixpkgs.
   shellFor = haskellLib.weakCallPackage pkgs ./shell-for.nix {
-    inherit hsPkgs ghcForComponent makeConfigFiles hoogleLocal haskellLib buildPackages evalPackages compiler;
+    inherit hsPkgs ghcForComponent makeConfigFiles hoogleLocal haskellLib pkgsBuildBuild evalPackages compiler;
     inherit (buildPackages) glibcLocales;
   };
 

--- a/builder/shell-for.nix
+++ b/builder/shell-for.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, mkShell, glibcLocales, pkgconfig, ghcForComponent, makeConfigFiles, hsPkgs, hoogleLocal, haskellLib, buildPackages, evalPackages, compiler }:
+{ lib, stdenv, mkShell, glibcLocales, pkgconfig, ghcForComponent, makeConfigFiles, hsPkgs, hoogleLocal, haskellLib, pkgsBuildBuild, evalPackages, compiler }:
 
 { # `packages` function selects packages that will be worked on in the shell itself.
   # These packages will not be built by `shellFor`, but their
@@ -149,7 +149,7 @@ let
     # inherit (hsPkgs) hoogle;
   } // (
     lib.optionalAttrs (args ? tools && args.tools ? hoogle) {
-      hoogle = buildPackages.haskell-nix.hackage-tool (
+      hoogle = pkgsBuildBuild.haskell-nix.hackage-tool (
         haskellLib.versionOrModToMods args.tools.hoogle ++ [{
           name = "hoogle";
           compiler-nix-name = compiler.nix-name;
@@ -168,12 +168,12 @@ in
     nativeBuildInputs = [ ghcEnv.drv ]
       ++ nativeBuildInputs
       ++ mkDrvArgs.nativeBuildInputs or []
-      ++ lib.attrValues (buildPackages.haskell-nix.tools' evalPackages compiler.nix-name tools)
+      ++ lib.attrValues (pkgsBuildBuild.haskell-nix.tools' evalPackages compiler.nix-name tools)
       # If this shell is a cross compilation shell include
       # wrapper script for running cabal build with appropriate args.
       # Includes `--with-compiler` in case the `cabal.project` file has `with-compiler:` in it.
       ++ lib.optional (ghcEnv.targetPrefix != "") (
-            buildPackages.writeShellScriptBin "${ghcEnv.targetPrefix}cabal" ''
+            pkgsBuildBuild.writeShellScriptBin "${ghcEnv.targetPrefix}cabal" ''
               exec cabal \
                 --with-ghc=${ghcEnv.targetPrefix}ghc \
                 --with-compiler=${ghcEnv.targetPrefix}ghc \

--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,7 @@
     let
       callFlake = import flake-compat;
 
-      ifdLevel = 3;
+      ifdLevel = 2;
       compiler = "ghc928";
       config = import ./config.nix;
 

--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,7 @@
     let
       callFlake = import flake-compat;
 
-      ifdLevel = 2;
+      ifdLevel = 3;
       compiler = "ghc928";
       config = import ./config.nix;
 

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -455,7 +455,7 @@ let
                 ''}
 
                 EXPOSED_MODULES_${varname name}="$(tr '\n' ' ' <<< "$exposed_modules $reexported_modules")"
-                DEPS_${varname name}="$(jq -r '.library."build-depends"[]|select(type=="array")[],select(type=="object").then[]' $json_cabal_file | sed 's/^\([A-Za-z0-9-]*\).*$/\1/g' | sort -u | tr '\n' ' ')"
+                DEPS_${varname name}="$(jq -r '.library."build-depends"[]|select(type=="array")[],select(type=="object" and .if.not.flag != "vendor-filepath").then[]' $json_cabal_file | sed 's/^\([A-Za-z0-9-]*\).*$/\1/g' | sort -u | tr '\n' ' ')"
                 VER_${varname name}="$(jq -r '.version' $json_cabal_file)"
                 PKGS+=" ${name}"
                 LAST_PKG="${name}"

--- a/test/githash/default.nix
+++ b/test/githash/default.nix
@@ -15,9 +15,8 @@ let
   project = haskell-nix.cabalProject' {
     inherit src;
     cabalProjectLocal = builtins.readFile ../cabal.project.local;
-    # When haskell.nix has come from the store (e.g. on hydra) we need to provide
-    # a suitable mock of the cleaned source with a .git dir.
-    modules = (optional (!(src ? origSrc && __pathExists (src.origSrc + "/.git"))) {
+    # Mock the .git dir to avoid rebuilding on every commit.
+    modules = [{
       packages.githash-test.src =
         rec {
           origSrc = evalPackages.runCommand "githash-test-src" { nativeBuildInputs = [ evalPackages.gitReallyMinimal ]; } ''
@@ -32,7 +31,6 @@ let
           origSrcSubDir = origSrc + origSubDir;
           outPath = origSrcSubDir;
         };
-      }) ++ [{
         packages.githash-test.components.exes.githash-test.build-tools = mkForce [ git ];
       }];
     inherit compiler-nix-name evalPackages;

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -123,7 +123,7 @@ if [ "$TESTS" == "shellFor-multiple-package" ] || [ "$TESTS" == "all" ]; then
       --pure ./default.nix \
       --argstr compiler-nix-name $SHELL_FOR_GHC \
       -A shell-for.envPkga \
-      --run 'cd shell-for && CABAL_DIR=$(mktemp -d) cabal new-build --project=single.project all'
+      --run 'cd shell-for && CABAL_DIR=$(mktemp -d) cabal new-build --project-file=single.project all'
   echo >& 2
 fi
 

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -96,11 +96,12 @@ fi
 
 if [ "$TESTS" == "multi-target" ] || [ "$TESTS" == "all" ]; then
   printf "*** Checking that a nix-shell works for a multi-target project...\n" >& 2
+  TEST_CABAL_DIR=$(mktemp -d)
   nix-shell $NIX_BUILD_ARGS \
       --pure ./default.nix \
       --argstr compiler-nix-name "$GHC" \
       -A cabal-simple.test-shell \
-      --run 'cd cabal-simple && CABAL_DIR=$(mktemp -d) cabal new-build'
+      --run "cd cabal-simple && CABAL_DIR=$TEST_CABAL_DIR cabal update && CABAL_DIR=$TEST_CABAL_DIR cabal build"
   echo >& 2
 fi
 


### PR DESCRIPTION
A cabal flag (`vendor-filepath`) was used to avoid the `template-haskell` dependency on `filepath` in the version of `template-haskell` (2.19.0.0) used by `ghc` 9.4.8.

```
    if flag(vendor-filepath)
      other-modules:
        System.FilePath
        System.FilePath.Posix
        System.FilePath.Windows
      hs-source-dirs: ./vendored-filepath .
      default-extensions:
        ImplicitPrelude
    else
      build-depends: filepath
      hs-source-dirs: .
```

The `dummy-ghc` code in haskell.nix does not evaluate conditionals (instead it just includes all of the dependencies.  This leads to issues where the planner is unable to come up with a plan because it thinks `filepath` cannot be reinstalled.

This fix works around the by hard coding a rule for `vendor-filepath`.