### PR TITLE
Include flake-utils as an input to HaskellNix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,7 @@
     nixpkgs-2311 = { url = "github:NixOS/nixpkgs/nixpkgs-23.11-darwin"; };
     nixpkgs-2405 = { url = "github:NixOS/nixpkgs/nixpkgs-24.05-darwin"; };
     nixpkgs-unstable = { url = "github:NixOS/nixpkgs/nixpkgs-unstable"; };
+    flake-utils = { url = "github:numtide/flake-utils";};
     flake-compat = { url = "github:input-output-hk/flake-compat/hkm/gitlab-fix"; flake = false; };
     "hls-1.10" = { url = "github:haskell/haskell-language-server/1.10.0.0"; flake = false; };
     "hls-2.0" = { url = "github:haskell/haskell-language-server/2.0.0.1"; flake = false; };


### PR DESCRIPTION
Two weeks ago, [PR #67](https://github.com/NixOS/templates/pull/67) in the NixOS templates repository broke HaskellNix by changing the line:

    inputs.flake-utils.url = "github:numtide/flake-utils";

to:

    inputs.flake-utils.follows = "haskellNix/flake-utils";

This change makes `flake-utils` follow the input of HaskellNix, instead of a hard-coded URL. Unfortunately, as far as I'm aware, HaskellNix does not actually reference `flake-utils` anywhere. 

To fix this, I have added:

    flake-utils = { url = "github:numtide/flake-utils"; };

to `flake.nix`. This issue was also mentioned in #2242.
