### PR TITLE
remove use of unquoted URL literals

### DIFF
--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -744,7 +744,7 @@ stdenv.mkDerivation (rec {
   } // extra-passthru;
 
   meta = {
-    homepage = http://haskell.org/ghc;
+    homepage = "https://haskell.org/ghc";
     description = "The Glasgow Haskell Compiler";
     maintainers = [];
     inherit (ghc.meta) license platforms;


### PR DESCRIPTION
It has been agreed upon by RFC process that this syntax is not to be used: https://github.com/NixOS/rfcs/pull/45