### PR TITLE
Avoid overriding bionic when using prebuilt android

### DIFF
--- a/overlays/android.nix
+++ b/overlays/android.nix
@@ -23,6 +23,6 @@ _final: prev: prev.lib.optionalAttrs prev.stdenv.hostPlatform.isAndroid ({
   gmp6 = (prev.gmp6.override { withStatic = true; }).overrideAttrs(_: {
     hardeningDisable = [ "fortify" "stackprotector" "format" ];
   });
-}) // prev.lib.optionalAttrs prev.stdenv.targetPlatform.isAndroid ({
+}) // prev.lib.optionalAttrs (prev.stdenv.targetPlatform.isAndroid && (!prev.stdenv.hostPlatform.useAndroidPrebuilt)) ({
   bionic = prev.bionic.override { enableStatic = true; };
 })


### PR DESCRIPTION
On master:
```
nix-repl> pkgs-unstable.pkgsCross.aarch64-android-prebuilt.bionic
error:
       … while evaluating the attribute 'pkgsCross.aarch64-android-prebuilt.bionic'

         at /home/jringer/projects/haskell.nix/overlays/android.nix:27:3:

           26| }) // prev.lib.optionalAttrs prev.stdenv.targetPlatform.isAndroid ({
           27|   bionic = prev.bionic.override { enableStatic = true; };
             |   ^
           28| })

       … while evaluating the attribute 'bionic.override'

         at /nix/store/g2ysyzdx76m4z7lnmyddcwdz25lx7kn1-source/pkgs/top-level/all-packages.nix:19995:3:

        19994|   # TODO(@Ericson2314): Build bionic libc from source
        19995|   bionic = if stdenv.hostPlatform.useAndroidPrebuilt
             |   ^
        19996|     then pkgs."androidndkPkgs_${stdenv.hostPlatform.ndkVer}".libraries

       error: attribute 'override' missing

       at /home/jringer/projects/haskell.nix/overlays/android.nix:27:12:

           26| }) // prev.lib.optionalAttrs prev.stdenv.targetPlatform.isAndroid ({
           27|   bionic = prev.bionic.override { enableStatic = true; };
             |            ^
           28| })

nix-repl> 
```
My branch:
```
nix-repl> pkgs-unstable.pkgsCross.aarch64-android-prebuilt.bionic
«derivation /nix/store/rva8m97misqknplrhsnf8rdpwkblgrhd-bionic-prebuilt.drv»
```