### PR TITLE
Fix components in `build-type: Custom` packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,7 @@
     let
       callFlake = import flake-compat;
 
-      ifdLevel = 0;
+      ifdLevel = 1;
       runningHydraEvalTest = false;
       compiler = "ghc928";
       config = import ./config.nix;

--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,7 @@
     let
       callFlake = import flake-compat;
 
-      ifdLevel = 2;
+      ifdLevel = 3;
       runningHydraEvalTest = false;
       compiler = "ghc928";
       config = import ./config.nix;

--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,7 @@
     let
       callFlake = import flake-compat;
 
-      ifdLevel = 1;
+      ifdLevel = 2;
       runningHydraEvalTest = false;
       compiler = "ghc928";
       config = import ./config.nix;

--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,7 @@
     let
       callFlake = import flake-compat;
 
-      ifdLevel = 3;
+      ifdLevel = 0;
       runningHydraEvalTest = false;
       compiler = "ghc928";
       config = import ./config.nix;

--- a/lib/load-cabal-plan.nix
+++ b/lib/load-cabal-plan.nix
@@ -47,7 +47,7 @@ let
               name = pkgs.lib.removePrefix "${prefix}:" n;
               value = (if cabal2nixComponents == null then {} else cabal2nixComponents.${collectionName}.${name}) // {
                 buildable = true;
-              } // lookupDependencies hsPkgs c.depends c.exe-depends;
+              } // lookupDependencies hsPkgs (c.depends ++ pkgs.lib.optional (p ? components) p.id) c.exe-depends;
             in { inherit name value; }
           )) components));
     in

--- a/test/setup-deps/pkg/src/Pkg.hs
+++ b/test/setup-deps/pkg/src/Pkg.hs
@@ -1,0 +1,4 @@
+module Pkg where
+
+foo :: Int
+foo = 1

--- a/test/setup-deps/pkg/src/conduit-test.hs
+++ b/test/setup-deps/pkg/src/conduit-test.hs
@@ -1,5 +1,0 @@
-module Main where
-
-import Conduit
-
-main = return ()


### PR DESCRIPTION
These components may depend on the `library` component of the package however `plan.json` does not include that dependency (since cabal will build all the components at once).  This fix adds the library component as a dependency of the other components.