### PR TITLE
Fix nix devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -99,17 +99,17 @@
 
       traceNames = prefix: builtins.mapAttrs (n: v:
         if builtins.isAttrs v
-          then if v ? type && v.type == "derivation"
-            then builtins.trace (prefix + n) v
-            else traceNames (prefix + n + ".") v
-          else v);
+        then if v ? type && v.type == "derivation"
+        then builtins.trace (prefix + n) v
+        else traceNames (prefix + n + ".") v
+        else v);
 
       traceHydraJobs = x: x // { inherit (traceNames "" x) hydraJobs; };
 
       # systems supported by haskell.nix
       systems = [
         "x86_64-linux"
-      ] ++ (if runningHydraEvalTest then [] else [
+      ] ++ (if runningHydraEvalTest then [ ] else [
         "x86_64-darwin"
         "aarch64-darwin"
       ]);
@@ -128,190 +128,215 @@
         filterDerivations;
 
       flake = {
-      inherit config;
-      overlay = self.overlays.combined;
-      overlays = import ./overlays { sources = inputs; };
+        inherit config;
+        overlay = self.overlays.combined;
+        overlays = import ./overlays { sources = inputs; };
 
-      internal = {
-        nixpkgsArgs = {
-          inherit config;
-          overlays = [ self.overlay ];
+        internal = {
+          nixpkgsArgs = {
+            inherit config;
+            overlays = [ self.overlay ];
+          };
+
+          sources = inputs;
+
+          overlaysOverrideable =
+            lib.warn
+              "Using this attribute is deprecated. Import ${./overlays} directly or use the flake overlays output with override-inut."
+              (import ./overlays);
+
+          # Compatibility with old default.nix
+          compat =
+            lib.warn
+              "Using this attribute is deprecated. You can pass the same arguments to ${./default.nix} instead"
+              (import ./default.nix);
         };
 
-        sources = inputs;
+        legacyPackages = forEachSystem (system:
+          import nixpkgs {
+            inherit config;
+            overlays = [ self.overlay ];
+            localSystem = { inherit system; };
+          });
 
-        overlaysOverrideable =
-          lib.warn
-            "Using this attribute is deprecated. Import ${./overlays} directly or use the flake overlays output with override-inut."
-            (import ./overlays);
+        legacyPackagesUnstable = forEachSystem (system:
+          import nixpkgs-unstable {
+            inherit config;
+            overlays = [ self.overlay ];
+            localSystem = { inherit system; };
+          });
 
-        # Compatibility with old default.nix
-        compat =
-          lib.warn
-            "Using this attribute is deprecated. You can pass the same arguments to ${./default.nix} instead"
-            (import ./default.nix);
-      };
+        # Exposed so CI can check that `allow-import-from-derivation=false` works
+        # for core of haskell.nix E.g. this should always work:
+        #   nix build .#roots.x86_64-linux --accept-flake-config --option allow-import-from-derivation false
+        roots = forEachSystem (system:
+          self.legacyPackagesUnstable.${system}.haskell-nix.roots compiler);
 
-      legacyPackages = forEachSystem (system:
-        import nixpkgs {
-          inherit config;
-          overlays = [ self.overlay ];
-          localSystem = { inherit system; };
-        });
-
-      legacyPackagesUnstable = forEachSystem (system:
-        import nixpkgs-unstable {
-          inherit config;
-          overlays = [ self.overlay ];
-          localSystem = { inherit system; };
-        });
-
-      # Exposed so CI can check that `allow-import-from-derivation=false` works
-      # for core of haskell.nix E.g. this should always work:
-      #   nix build .#roots.x86_64-linux --accept-flake-config --option allow-import-from-derivation false
-      roots = forEachSystem (system:
-        self.legacyPackagesUnstable.${system}.haskell-nix.roots compiler);
-
-      # Note: `nix flake check` evaluates outputs for all platforms, and haskell.nix
-      # uses IFD heavily, you have to have the ability to build for all platforms
-      # supported by haskell.nix, e.g. with remote builders, in order to check this flake.
-      # If you want to run the tests for just your platform, run `./test/tests.sh` or
-      # `nix-build -A checks.$PLATFORM`
-      checks = forEachSystemPkgs (pkgs:
-        builtins.listToAttrs (
-          map
-            (pkg: { name = pkg.name; value = pkg; })
-            (lib.collect
-              lib.isDerivation
-              (import ./test {
-                haskellNix.sources = inputs;
-                haskellNix.nixpkgsArgs = nixpkgsArgs;
-                compiler-nix-name = compiler;
-                inherit pkgs;
-              })
+        # Note: `nix flake check` evaluates outputs for all platforms, and haskell.nix
+        # uses IFD heavily, you have to have the ability to build for all platforms
+        # supported by haskell.nix, e.g. with remote builders, in order to check this flake.
+        # If you want to run the tests for just your platform, run `./test/tests.sh` or
+        # `nix-build -A checks.$PLATFORM`
+        checks = forEachSystemPkgs (pkgs:
+          builtins.listToAttrs (
+            map
+              (pkg: { name = pkg.name; value = pkg; })
+              (lib.collect
+                lib.isDerivation
+                (import ./test {
+                  haskellNix.sources = inputs;
+                  haskellNix.nixpkgsArgs = nixpkgsArgs;
+                  compiler-nix-name = compiler;
+                  inherit pkgs;
+                })
               )
-            )
+          )
         );
 
-      # NOTE: these are the hix cli utilities, which is a separate thing from
-      # the hix.nix overlays (which extends haskell.nix with hixProject).
-      packages = forEachSystemPkgs (pkgs:
-        (import ./hix/default.nix { inherit pkgs; }).apps
-      );
-      apps = forEachSystemPkgs (pkgs:
-        builtins.mapAttrs (name: exe: {
-          type = "app";
-          program = exe + "/bin/${name}";
-        }) pkgs.haskell-nix.nix-tools-unchecked.exes
-      );
+        # NOTE: these are the hix cli utilities, which is a separate thing from
+        # the hix.nix overlays (which extends haskell.nix with hixProject).
+        packages = forEachSystemPkgs (pkgs:
+          (import ./hix/default.nix { inherit pkgs; }).apps
+        );
+        apps = forEachSystemPkgs (pkgs:
+          builtins.mapAttrs
+            (name: exe: {
+              type = "app";
+              program = exe + "/bin/${name}";
+            })
+            pkgs.haskell-nix.nix-tools-unchecked.exes
+        );
 
-      allJobs = forEachSystem (system:
-        stripAttrsForHydra (filterDerivations (
-          # This is awkward.
-          import ./ci.nix {
-            inherit ifdLevel system;
-            haskellNix = self;
-          })));
+        allJobs = forEachSystem (system:
+          stripAttrsForHydra (filterDerivations (
+            # This is awkward.
+            import ./ci.nix {
+              inherit ifdLevel system;
+              haskellNix = self;
+            }
+          )));
 
-      requiredJobs = forEachSystem (system:
-        let
-          inherit (self.legacyPackages.${system}) releaseTools;
-        in
-          lib.concatMapAttrs (nixpkgsVer:
-            lib.concatMapAttrs (compiler-nix-name:
-              lib.concatMapAttrs (crossPlatform: ghcJobs:
-                let
-                  name = "required-${nixpkgsVer}-${compiler-nix-name}-${crossPlatform}";
-                  value = releaseTools.aggregate {
+        requiredJobs = forEachSystem (system:
+          let
+            inherit (self.legacyPackages.${system}) releaseTools;
+          in
+          lib.concatMapAttrs
+            (nixpkgsVer:
+              lib.concatMapAttrs (compiler-nix-name:
+                lib.concatMapAttrs (crossPlatform: ghcJobs:
+                  let
+                    name = "required-${nixpkgsVer}-${compiler-nix-name}-${crossPlatform}";
+                    value = releaseTools.aggregate {
                       name = "haskell.nix-${nixpkgsVer}-${compiler-nix-name}-${crossPlatform}";
                       meta.description = "All ${nixpkgsVer} ${compiler-nix-name} ${crossPlatform} jobs";
                       constituents = lib.collect lib.isDerivation ghcJobs;
-                  };
-                in
-                lib.optionalAttrs
-                  (crossPlatform != "recurseForDerivations" && crossPlatform != "meta")
-                  { ${name} = value; })
+                    };
+                  in
+                  lib.optionalAttrs
+                    (crossPlatform != "recurseForDerivations" && crossPlatform != "meta")
+                    { ${name} = value; })
               )
             )
             self.allJobs.${system}
-          );
+        );
 
-      hydraJobs = forEachSystem (system:
-        let
-          # Include hydraJobs from nix-tools subflake.
-          # NOTE: These derivations do not depend on the haskell.nix in ./. but
-          # on the version of haskell.nix locked in the subflake. They are
-          # evaluated within their own flake and independently of anything
-          # else. Here we only expose them in the main flake.
-          nix-tools-hydraJobs =
-            let cf = callFlake {
-              inherit system;
-              pkgs = self.legacyPackages.${system};
-              src = ./nix-tools;
-            };
-            in cf.defaultNix.hydraJobs;
-        in
-        self.allJobs.${system}
+        hydraJobs = forEachSystem (system:
+          let
+            # Include hydraJobs from nix-tools subflake.
+            # NOTE: These derivations do not depend on the haskell.nix in ./. but
+            # on the version of haskell.nix locked in the subflake. They are
+            # evaluated within their own flake and independently of anything
+            # else. Here we only expose them in the main flake.
+            nix-tools-hydraJobs =
+              let
+                cf = callFlake {
+                  inherit system;
+                  pkgs = self.legacyPackages.${system};
+                  src = ./nix-tools;
+                };
+              in
+              cf.defaultNix.hydraJobs;
+          in
+          self.allJobs.${system}
           // lib.optionalAttrs (ifdLevel > 2)
-            { nix-tools = nix-tools-hydraJobs.${system} or {}; }
-      );
+            { nix-tools = nix-tools-hydraJobs.${system} or { }; }
+        );
 
-      devShells = forEachSystemPkgs (pkgs:
-        let inherit (pkgs) mkShell nixUnstable cabal-install haskell-nix;
-        in {
-          default =
-            mkShell {
-              buildInputs = [
-                nixUnstable
-                cabal-install
-                haskell-nix.compiler.${compiler}
-              ];
-            };
-        }
-        //
-        builtins.mapAttrs
-          (compiler-nix-name: compiler:
-            mkShell {
-              buildInputs = [
-                compiler
-                haskell-nix.cabal-install.${compiler-nix-name}
-              ];
-            })
-          ( # Exclude old versions of GHC to speed up `nix flake check`
-            builtins.removeAttrs haskell-nix.compiler
-              [ "ghc844"
-                "ghc861" "ghc862" "ghc863" "ghc864"
-                "ghc881" "ghc882" "ghc883"
-                "ghc8101" "ghc8102" "ghc8103" "ghc8104" "ghc8105" "ghc8106" "ghc810420210212"
-                "ghc901"
-                "ghc921" "ghc922" "ghc923"])
-      );
-    }; in with (import nixpkgs { system = "x86_64-linux"; });
-          traceHydraJobs (lib.recursiveUpdate flake (lib.optionalAttrs (ifdLevel > 2) {
-            hydraJobs.nix-tools = pkgs.releaseTools.aggregate {
-              name = "nix-tools";
-              constituents = (if runningHydraEvalTest then [] else [
-                "aarch64-darwin.nix-tools.static.zipped.nix-tools-static"
-                "x86_64-darwin.nix-tools.static.zipped.nix-tools-static"
-                "aarch64-darwin.nix-tools.static.zipped.nix-tools-static-no-ifd"
-                "x86_64-darwin.nix-tools.static.zipped.nix-tools-static-no-ifd"
-              ]) ++ [
-                "x86_64-linux.nix-tools.static.zipped.nix-tools-static"
-                "x86_64-linux.nix-tools.static.zipped.nix-tools-static-arm64"
-                "x86_64-linux.nix-tools.static.zipped.nix-tools-static-no-ifd"
-                "x86_64-linux.nix-tools.static.zipped.nix-tools-static-arm64-no-ifd"
-                (writeText "gitrev" (self.rev or "0000000000000000000000000000000000000000"))
-              ];
-            };
-          }));
+        devShells = forEachSystemPkgs (pkgs:
+          let inherit (pkgs) mkShell nixUnstable cabal-install haskell-nix;
+          in {
+            default =
+              mkShell {
+                buildInputs = [
+                  nixUnstable
+                  cabal-install
+                  haskell-nix.compiler.${compiler}
+                ];
+              };
+          }
+          //
+          builtins.mapAttrs
+            (compiler-nix-name: compiler:
+              mkShell {
+                buildInputs = [
+                  compiler
+                  haskell-nix.cabal-install.${compiler-nix-name}
+                ];
+              })
+            (
+              # Exclude old versions of GHC to speed up `nix flake check`
+              builtins.removeAttrs haskell-nix.compiler
+                [
+                  "ghc844"
+                  "ghc861"
+                  "ghc862"
+                  "ghc863"
+                  "ghc864"
+                  "ghc881"
+                  "ghc882"
+                  "ghc883"
+                  "ghc8101"
+                  "ghc8102"
+                  "ghc8103"
+                  "ghc8104"
+                  "ghc8105"
+                  "ghc8106"
+                  "ghc810420210212"
+                  "ghc901"
+                  "ghc921"
+                  "ghc922"
+                  "ghc923"
+                ]
+            )
+        );
+      };
+    in
+    with (import nixpkgs { system = "x86_64-linux"; });
+    traceHydraJobs (lib.recursiveUpdate flake (lib.optionalAttrs (ifdLevel > 2) {
+      hydraJobs.nix-tools = pkgs.releaseTools.aggregate {
+        name = "nix-tools";
+        constituents = (if runningHydraEvalTest then [ ] else [
+          "aarch64-darwin.nix-tools.static.zipped.nix-tools-static"
+          "x86_64-darwin.nix-tools.static.zipped.nix-tools-static"
+          "aarch64-darwin.nix-tools.static.zipped.nix-tools-static-no-ifd"
+          "x86_64-darwin.nix-tools.static.zipped.nix-tools-static-no-ifd"
+        ]) ++ [
+          "x86_64-linux.nix-tools.static.zipped.nix-tools-static"
+          "x86_64-linux.nix-tools.static.zipped.nix-tools-static-arm64"
+          "x86_64-linux.nix-tools.static.zipped.nix-tools-static-no-ifd"
+          "x86_64-linux.nix-tools.static.zipped.nix-tools-static-arm64-no-ifd"
+          (writeText "gitrev" (self.rev or "0000000000000000000000000000000000000000"))
+        ];
+      };
+    }));
 
   # --- Flake Local Nix Configuration ----------------------------
   nixConfig = {
     # This sets the flake to use the IOG nix cache.
     # Nix should ask for permission before using it,
     # but remove it here if you do not want it to.
-    extra-substituters = ["https://cache.iog.io"];
-    extra-trusted-public-keys = ["hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="];
+    extra-substituters = [ "https://cache.iog.io" ];
+    extra-trusted-public-keys = [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
     allow-import-from-derivation = "true";
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -272,34 +272,16 @@
                   pkgs.haskell-nix.compiler.${compiler-nix-name}
                 ];
               };
-            shells = lib.genAttrs
-              (
-                # Exclude old versions of GHC to speed up `nix flake check`
-                lib.attrNames (
-                  lib.removeAttrs pkgs.haskell-nix.compiler
-                    [
-                      "ghc844"
-                      "ghc861"
-                      "ghc862"
-                      "ghc863"
-                      "ghc864"
-                      "ghc881"
-                      "ghc882"
-                      "ghc883"
-                      "ghc8101"
-                      "ghc8102"
-                      "ghc8103"
-                      "ghc8104"
-                      "ghc8105"
-                      "ghc8106"
-                      "ghc810420210212"
-                      "ghc901"
-                      "ghc921"
-                      "ghc922"
-                      "ghc923"
-                    ]
-                )
-              )
+            shells = lib.genAttrs (
+              # Exclude old versions of GHC to speed up `nix flake check`
+              lib.attrNames (
+                lib.removeAttrs pkgs.haskell-nix.compiler
+                  ([ "ghc844" ] ++
+                    [ "ghc861" "ghc862" "ghc863" "ghc864" ] ++
+                    [ "ghc881" "ghc882" "ghc883" ] ++
+                    [ "ghc8101" "ghc8102" "ghc8103" "ghc8104" "ghc810420210212" "ghc8105" "ghc8106" ] ++
+                    [ "ghc901" ] ++ [ "ghc921" "ghc922" "ghc923" ])
+              ))
               mkHaskellNixShell;
           in
           shells // { default = shells.${compiler}; });

--- a/flake.nix
+++ b/flake.nix
@@ -263,12 +263,12 @@
         );
 
         devShells = forEachSystemPkgs (pkgs:
-          let inherit (pkgs) mkShell nixUnstable cabal-install haskell-nix;
+          let inherit (pkgs) mkShell nixVersions cabal-install haskell-nix;
           in {
             default =
               mkShell {
                 buildInputs = [
-                  nixUnstable
+                  nixVersions.latest
                   cabal-install
                   haskell-nix.compiler.${compiler}
                 ];

--- a/flake.nix
+++ b/flake.nix
@@ -77,13 +77,6 @@
     { self
     , nixpkgs
     , nixpkgs-unstable
-    , nixpkgs-2105
-    , nixpkgs-2111
-    , nixpkgs-2205
-    , nixpkgs-2211
-    , nixpkgs-2305
-    , nixpkgs-2311
-    , nixpkgs-2405
     , flake-compat
     , ...
     }@inputs:

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -15,7 +15,7 @@ final: prev: {
         extraPkgconfigMappings = prev.haskell-nix.extraPkgconfigMappings or {};
         # Nix Flake based source pins.
         # To update all inputs, get unstable Nix and then `nix flake update --recreate-lock-file`
-        # Or `nix-shell -p nixUnstable --run "nix --experimental-features 'nix-command flakes' flake update --recreate-lock-file"`
+        # Or `nix-shell -p nixVersions.latest --run "nix --experimental-features 'nix-command flakes' flake update --recreate-lock-file"`
         sources = sources;
 
         # We provide a `callPackage` function to consumers for


### PR DESCRIPTION
- Fix the nix devshell by replacing nixUnstable with nixVersions.latest.
- Ensure the devshells for different compilers are built in the same way.
- Small code improvements (reformat, naming, reduce the use of `with`).