### PR TITLE
Add context back to repo url strings

### DIFF
--- a/lib/load-cabal-plan.nix
+++ b/lib/load-cabal-plan.nix
@@ -5,6 +5,12 @@ let
   plan-json = builtins.fromJSON (
     builtins.unsafeDiscardStringContext (
       builtins.readFile (callProjectResults.projectNix + "/plan.json")));
+  # Function to add context back to the strings we get from `plan.json`
+  addContext = s:
+    let storeDirMatch = builtins.match ".*(${builtins.storeDir}/[^/]+).*" s;
+    in if storeDirMatch == null
+      then s
+      else builtins.appendContext s { ${builtins.head storeDirMatch} = { path = true; }; };
   # All the units in the plan indexed by unit ID.
   by-id = pkgs.lib.listToAttrs (map (x: { name = x.id; value = x; }) plan-json.install-plan);
   # Find the names of all the pre-existing packages used by a list of dependencies
@@ -104,7 +110,7 @@ in {
                   + pkgs.lib.optionalString (p.pkg-src.source-repo.subdir != ".") "/${p.pkg-src.source-repo.subdir}";
               } // pkgs.lib.optionalAttrs (p.pkg-src.type or "" == "repo-tar") {
                 src = pkgs.lib.mkDefault (pkgs.fetchurl {
-                  url = p.pkg-src.repo.uri + "${pkgs.lib.optionalString (!pkgs.lib.hasSuffix "/" p.pkg-src.repo.uri) "/"}package/${p.pkg-name}-${p.pkg-version}.tar.gz";
+                  url = addContext p.pkg-src.repo.uri + "${pkgs.lib.optionalString (!pkgs.lib.hasSuffix "/" p.pkg-src.repo.uri) "/"}package/${p.pkg-name}-${p.pkg-version}.tar.gz";
                   sha256 = p.pkg-src-sha256;
                 });
               } // pkgs.lib.optionalAttrs (cabal2nix ? package-description-override && p.pkg-version == cabal2nix.package.identifier.version) {


### PR DESCRIPTION
This should fixes a source of errors that look like this:

```
curl: (37) Couldn't open file /nix/store/7g8b1vz8nlai5zkjzfps25jl7fvdjk3s-source/package/contra-tracer-0.1.0.2.tar.gz
```

Reproducing this issue turned out to be difficult because if the `sha256` is in the nix cache there is no error.  To reproduce the issue:

* Remove the `addContext` call.
* Build a project with `repository` in `cabal.project` with an `inputMap`.
* Force the `src` derivation to rebuild.

We can force the src derivation to rebuild by giving it invalid `sha256` (ignore the hash mismatch errors, if it has a hash then the download worked):

```
# sha256 = p.pkg-src-sha256;
sha256 = __substring 0 (__stringLength p.pkg-src-sha256 - 6) p.pkg-src-sha256 + "000000";
```