### PR TITLE
update nix-tools-static.nix

### DIFF
--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Wait for nix-tools meta job
         uses: input-output-hk/actions/wait-for-hydra@angerman/support-prs
         with:
-          check: 'nix-tools'
+          check: 'ci/hydra-build:nix-tools'
 
       - name: "Pull nix-tools"
         run: |

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Wait for nix-tools meta job
         uses: input-output-hk/actions/wait-for-hydra@angerman/support-prs
         with:
-          check: 'ci/hydra-build:nix-tools'
+          check: 'nix-tools'
 
       - name: "Pull nix-tools"
         run: |

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -269,7 +269,6 @@ let
       inherit compiler-nix-name;
       name = "hadrian";
       compilerSelection = p: p.haskell.compiler;
-      index-state = buildPackages.haskell-nix.internalHackageIndexState;
       evalPackages = hadrianEvalPackages;
       modules = [{
         reinstallableLibGhc = false;

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -151,7 +151,7 @@ in let
       let
         suitable-index-states =
           builtins.filter
-            (s: s > index-state-max) # This compare is why we need zulu time
+            (s: s >= index-state-max) # This compare is why we need zulu time
             (builtins.attrNames index-state-hashes);
       in
         if builtins.length suitable-index-states == 0

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -151,7 +151,7 @@ in let
       let
         suitable-index-states =
           builtins.filter
-            (s: s >= index-state-max) # This compare is why we need zulu time
+            (s: s > index-state-max) # This compare is why we need zulu time
             (builtins.attrNames index-state-hashes);
       in
         if builtins.length suitable-index-states == 0

--- a/nix-tools-static.nix
+++ b/nix-tools-static.nix
@@ -1,22 +1,22 @@
-pkgs: let baseurl = "https://github.com/input-output-hk/haskell.nix/releases/download/nix-tools-0.3.1/"; in {
+pkgs: let baseurl = "https://github.com/input-output-hk/haskell.nix/releases/download/nix-tools-0.3.2/"; in {
   aarch64-darwin = pkgs.fetchurl { 
      name = "aarch64-darwin-nix-tools-static";
      url = "${baseurl}aarch64-darwin-nix-tools-static.zip";
-     sha256 = "sha256-t/sxZAl/YH2vgjneIRainKlmYx2w/kXqrKGLwzDcb3Q=";
+     sha256 = "sha256-SlTAgNj3YjZpobl/aIZLI+o8EpxznW5X90UBTtHDwbw=";
   };
   x86_64-darwin = pkgs.fetchurl { 
      name = "x86_64-darwin-nix-tools-static";
      url = "${baseurl}x86_64-darwin-nix-tools-static.zip";
-     sha256 = "sha256-SG21YIF9lBX5zCJfK0WsLZrFFjZPVwzD4zl8Je7VSNQ=";
+     sha256 = "sha256-6m2f3DoARyoxR5Fh+87TfVCLkewwhozVLKbUzfXvUxs=";
   };
   aarch64-linux = pkgs.fetchurl { 
      name = "aarch64-linux-nix-tools-static";
      url = "${baseurl}aarch64-linux-nix-tools-static.zip";
-     sha256 = "sha256-/AJsmFO3xYi+CBHLXFcj0YdZ9LvPpwPyqo4OYNLsM3s=";
+     sha256 = "sha256-MX4u23nzjByT9zcSN+HlKOAgQNtYvcuR8iOh54wR41U=";
   };
   x86_64-linux = pkgs.fetchurl { 
      name = "x86_64-linux-nix-tools-static";
      url = "${baseurl}x86_64-linux-nix-tools-static.zip";
-     sha256 = "sha256-SNzh+OYfVZYlgsyifG0ZkxMKh/zJYSrA25I7HFRbKyI=";
+     sha256 = "sha256-QzTCy7HPY5xN6VFKJcibE1gWLsT4u8OPfJHvDMK3v7M=";
   };
 }

--- a/nix-tools-static.nix
+++ b/nix-tools-static.nix
@@ -1,22 +1,22 @@
-pkgs: let baseurl = "https://github.com/input-output-hk/haskell.nix/releases/download/nix-tools-0.2.6/"; in {
+pkgs: let baseurl = "https://github.com/input-output-hk/haskell.nix/releases/download/nix-tools-0.3.1/"; in {
   aarch64-darwin = pkgs.fetchurl { 
      name = "aarch64-darwin-nix-tools-static";
      url = "${baseurl}aarch64-darwin-nix-tools-static.zip";
-     sha256 = "sha256-9WpTIWlpUvG3pI+tcbAMh6sMH0QO/coZrxDYWD43iq0=";
+     sha256 = "sha256-t/sxZAl/YH2vgjneIRainKlmYx2w/kXqrKGLwzDcb3Q=";
   };
   x86_64-darwin = pkgs.fetchurl { 
      name = "x86_64-darwin-nix-tools-static";
      url = "${baseurl}x86_64-darwin-nix-tools-static.zip";
-     sha256 = "sha256-UUr9bo2OpLPsvHRSeO2B6DKVDVTsHepRlTqN6UZoZ2M=";
+     sha256 = "sha256-SG21YIF9lBX5zCJfK0WsLZrFFjZPVwzD4zl8Je7VSNQ=";
   };
   aarch64-linux = pkgs.fetchurl { 
      name = "aarch64-linux-nix-tools-static";
      url = "${baseurl}aarch64-linux-nix-tools-static.zip";
-     sha256 = "sha256-96s6RXN8st0JK0eYSOkTJvnlTxYVdE81+ZUGJEsC46A=";
+     sha256 = "sha256-/AJsmFO3xYi+CBHLXFcj0YdZ9LvPpwPyqo4OYNLsM3s=";
   };
   x86_64-linux = pkgs.fetchurl { 
      name = "x86_64-linux-nix-tools-static";
      url = "${baseurl}x86_64-linux-nix-tools-static.zip";
-     sha256 = "sha256-LMFVUKNycjVFBb3ChZsPbRNgab50zOHl7nMBrDdeTrQ=";
+     sha256 = "sha256-SNzh+OYfVZYlgsyifG0ZkxMKh/zJYSrA25I7HFRbKyI=";
   };
 }

--- a/nix-tools/cabal.project
+++ b/nix-tools/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2024-10-15T20:31:31Z
+index-state: 2025-04-06T00:00:00Z
 
 packages: nix-tools
 
@@ -36,5 +36,5 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/andreabedini/Cabal-syntax-json.git
-    tag: b7192832f730d9181a013ef7c77f2ad0b30cca43
-    --sha256: sha256-Yw2HQOCmjOvfKHi3xWbSniAZfyrshOvsgmUbqFmDDpU=
+    tag: b0033ed4d00a09340c64f4290cc649f4009deabd
+    --sha256: sha256-Aymi25AQLSMextVeXbsMnaOppxAO93qVbwo7Vt44ej4=

--- a/nix-tools/cabal.project
+++ b/nix-tools/cabal.project
@@ -1,4 +1,8 @@
-index-state: 2025-04-06T00:00:00Z
+index-state: 2025-04-12T00:00:00Z
+
+-- Needed for building aarch64-linux musl version with GHC 9.6
+constraints: containers installed, Cabal >=3.14.1.0
+allow-older: Cabal-syntax-json:base, Cabal-syntax-json:containers
 
 packages: nix-tools
 

--- a/nix-tools/flake.lock
+++ b/nix-tools/flake.lock
@@ -120,11 +120,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1744071887,
-        "narHash": "sha256-uZpGiJLh5dZ+qx1W0sMf7EJPcKC6kZ2i54GP7ihpmtg=",
+        "lastModified": 1744676755,
+        "narHash": "sha256-UxlAdjsE/mDKkONhvkOHeqDlExp6fw757+3iwGeUeFM=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "f96e7640f26b7dee9fe7d85da997c507c09ec4ea",
+        "rev": "a81af937e40034d4c89b80728f937bff6b997121",
         "type": "github"
       },
       "original": {
@@ -136,11 +136,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1744071877,
-        "narHash": "sha256-FSe02a5aLc6auchFxxObih6eE2/fpue/1U9WviZw2LA=",
+        "lastModified": 1744676745,
+        "narHash": "sha256-Wzgh3li2OARjgAwl2P0CmNAsqLJUT1Px4YtYtVRpILc=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "e484ace6463cc4b0e1ae94fdb26b2a0873b2a180",
+        "rev": "e1d749fd0df3cf34bcb0b5c4958e0f2a715f1e23",
         "type": "github"
       },
       "original": {
@@ -188,11 +188,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1744073515,
-        "narHash": "sha256-oXpWQMM7auoisX76hTmzEt3rTxB1hGbzGddyRtJqyf4=",
+        "lastModified": 1744678331,
+        "narHash": "sha256-R6Z3kRSRoENSPxJbaZXbHKGhNjH7x6NRppUlpOJxOsE=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "11deda8d1f242bda9e906f1c057b3edaf6fc5fbf",
+        "rev": "3a97196af86fa053ed267a91234f4e24511c7fd9",
         "type": "github"
       },
       "original": {
@@ -546,11 +546,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1744071122,
-        "narHash": "sha256-hpKwP5/SxwwcuCDxXZgFkZUzJ/eQhDvRRsmX/kyHnNg=",
+        "lastModified": 1744675976,
+        "narHash": "sha256-WvQ2HI/OtCNjUO1NE/fEdwCeTwf0rXu25Y6CcUXpo3Y=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "1033243b5d563dd4050034a5699180e55460a417",
+        "rev": "5a0a1124c429fdb16f1cde0f4c85c0ee658b9fba",
         "type": "github"
       },
       "original": {

--- a/nix-tools/flake.lock
+++ b/nix-tools/flake.lock
@@ -120,15 +120,32 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1729124899,
-        "narHash": "sha256-cmb4iMcgk5+jUGMiZGNMzPCAnG17Kz9J6WIitYM17Fc=",
+        "lastModified": 1744071887,
+        "narHash": "sha256-uZpGiJLh5dZ+qx1W0sMf7EJPcKC6kZ2i54GP7ihpmtg=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "138edf81c8bcc4209e9706966f7feece70c37a96",
+        "rev": "f96e7640f26b7dee9fe7d85da997c507c09ec4ea",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-for-stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1744071877,
+        "narHash": "sha256-FSe02a5aLc6auchFxxObih6eE2/fpue/1U9WviZw2LA=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "e484ace6463cc4b0e1ae94fdb26b2a0873b2a180",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
         "repo": "hackage.nix",
         "type": "github"
       }
@@ -143,8 +160,11 @@
         "flake-compat": "flake-compat",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",
+        "hackage-for-stackage": "hackage-for-stackage",
+        "hls": "hls",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
+        "hls-2.10": "hls-2.10",
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
         "hls-2.4": "hls-2.4",
@@ -154,35 +174,46 @@
         "hls-2.8": "hls-2.8",
         "hls-2.9": "hls-2.9",
         "hpc-coveralls": "hpc-coveralls",
-        "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
         "nixpkgs": [
           "haskellNix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-2003": "nixpkgs-2003",
-        "nixpkgs-2105": "nixpkgs-2105",
-        "nixpkgs-2111": "nixpkgs-2111",
-        "nixpkgs-2205": "nixpkgs-2205",
-        "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
         "nixpkgs-2311": "nixpkgs-2311",
         "nixpkgs-2405": "nixpkgs-2405",
+        "nixpkgs-2411": "nixpkgs-2411",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1729126246,
-        "narHash": "sha256-OXGwQF3AMERYaVdImhGLlvJgOE8Zr0yURef4J7zlp6k=",
+        "lastModified": 1744073515,
+        "narHash": "sha256-oXpWQMM7auoisX76hTmzEt3rTxB1hGbzGddyRtJqyf4=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "c2070f089bf688571c14af77744982c86f0c2e21",
+        "rev": "11deda8d1f242bda9e906f1c057b3edaf6fc5fbf",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741604408,
+        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "682d6894c94087da5e566771f25311c47e145359",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
         "type": "github"
       }
     },
@@ -216,6 +247,23 @@
       "original": {
         "owner": "haskell",
         "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743069404,
+        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.10.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -342,11 +390,11 @@
     "hls-2.9": {
       "flake": false,
       "locked": {
-        "lastModified": 1720003792,
-        "narHash": "sha256-qnDx8Pk0UxtoPr7BimEsAZh9g2WuTuMB/kGqnmdryKs=",
+        "lastModified": 1719993701,
+        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "0c1817cb2babef0765e4e72dd297c013e8e3d12b",
+        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
         "type": "github"
       },
       "original": {
@@ -372,176 +420,20 @@
         "type": "github"
       }
     },
-    "hydra": {
-      "inputs": {
-        "nix": "nix",
-        "nixpkgs": [
-          "haskellNix",
-          "hydra",
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1671755331,
-        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
-        "owner": "NixOS",
-        "repo": "hydra",
-        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
-        "type": "github"
-      },
-      "original": {
-        "id": "hydra",
-        "type": "indirect"
-      }
-    },
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1717479972,
-        "narHash": "sha256-7vE3RQycHI1YT9LHJ1/fUaeln2vIpYm6Mmn8FTpYeVo=",
+        "lastModified": 1742121966,
+        "narHash": "sha256-x4bg4OoKAPnayom0nWc0BmlxgRMMHk6lEPvbiyFBq1s=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "2ed34002247213fc435d0062350b91bab920626e",
+        "rev": "e9dc86ed6ad71f0368c16672081c8f26406c3a7e",
         "type": "github"
       },
       "original": {
         "owner": "stable-haskell",
         "ref": "iserv-syms",
         "repo": "iserv-proxy",
-        "type": "github"
-      }
-    },
-    "lowdown-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "type": "github"
-      }
-    },
-    "nix": {
-      "inputs": {
-        "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-regression": "nixpkgs-regression"
-      },
-      "locked": {
-        "lastModified": 1661606874,
-        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "2.11.0",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.05-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2003": {
-      "locked": {
-        "lastModified": 1620055814,
-        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-20.03-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2105": {
-      "locked": {
-        "lastModified": 1659914493,
-        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2111": {
-      "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2205": {
-      "locked": {
-        "lastModified": 1685573264,
-        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2211": {
-      "locked": {
-        "lastModified": 1688392541,
-        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.11-darwin",
-        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -579,11 +471,11 @@
     },
     "nixpkgs-2405": {
       "locked": {
-        "lastModified": 1726447378,
-        "narHash": "sha256-2yV8nmYE1p9lfmLHhOCbYwQC/W8WYfGQABoGzJOb1JQ=",
+        "lastModified": 1735564410,
+        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "086b448a5d54fd117f4dc2dee55c9f0ff461bdc1",
+        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
         "type": "github"
       },
       "original": {
@@ -593,29 +485,29 @@
         "type": "github"
       }
     },
-    "nixpkgs-regression": {
+    "nixpkgs-2411": {
       "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "lastModified": 1739151041,
+        "narHash": "sha256-uNszcul7y++oBiyYXjHEDw/AHeLNp8B6pyWOB+RLA/4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "rev": "94792ab2a6beaec81424445bf917ca2556fbeade",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
         "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1726583932,
-        "narHash": "sha256-zACxiQx8knB3F8+Ze+1BpiYrI+CbhxyWpcSID9kVhkQ=",
+        "lastModified": 1737110817,
+        "narHash": "sha256-DSenga8XjPaUV5KUFW/i3rNkN7jm9XmguW+qQ1ZJTR4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "658e7223191d2598641d50ee4e898126768fe847",
+        "rev": "041c867bad68dfe34b78b2813028a2e2ea70a23c",
         "type": "github"
       },
       "original": {
@@ -654,11 +546,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1729039017,
-        "narHash": "sha256-fGExfgG+7UNSOV8YfOrWPpOHWrCjA02gQkeSBhaAzjQ=",
+        "lastModified": 1744071122,
+        "narHash": "sha256-hpKwP5/SxwwcuCDxXZgFkZUzJ/eQhDvRRsmX/kyHnNg=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "df1d8f0960407551fea7af7af75a9c2f9e18de97",
+        "rev": "1033243b5d563dd4050034a5699180e55460a417",
         "type": "github"
       },
       "original": {

--- a/nix-tools/nix-tools/make-install-plan/MakeInstallPlan.hs
+++ b/nix-tools/nix-tools/make-install-plan/MakeInstallPlan.hs
@@ -36,6 +36,7 @@ import ProjectPlanOutput (writePlanExternalRepresentation)
 import System.Environment (getArgs)
 import System.FilePath
 import System.IO (IOMode (WriteMode), hClose, openFile)
+import Distribution.Simple.Utils (topHandler)
 
 main :: IO ()
 main = do
@@ -49,7 +50,7 @@ main = do
           flags@NixStyleFlags{configFlags} = mkflags (commandDefaultFlags cmdUI)
           verbosity = fromFlagOrDefault Verbosity.normal (configVerbosity configFlags)
           cliConfig = commandLineFlagsToProjectConfig globalFlags flags mempty
-       in installPlanAction verbosity cliConfig
+       in topHandler (installPlanAction verbosity cliConfig)
 
 cmdUI :: CommandUI (NixStyleFlags ())
 cmdUI =

--- a/nix-tools/nix-tools/make-install-plan/ProjectPlanOutput.hs
+++ b/nix-tools/nix-tools/make-install-plan/ProjectPlanOutput.hs
@@ -53,6 +53,7 @@ import qualified Data.Map as Map
 import System.FilePath
 
 import Distribution.Client.ProjectPlanning
+import Distribution.Utils.Path (makeSymbolicPath, getSymbolicPath)
 
 -----------------------------------------------------------------------------
 -- Writing plan.json files
@@ -230,7 +231,7 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig targ
       | elabSetupScriptCliVersion elab < mkVersion [3, 7, 0, 0] =
           "build-info" J..= J.Null
       | otherwise =
-          "build-info" J..= J.String (buildInfoPref dist_dir)
+          "build-info" J..= J.String (getSymbolicPath (buildInfoPref (makeSymbolicPath dist_dir)))
 
     packageLocationToJ :: PackageLocation (Maybe FilePath) -> J.Value
     packageLocationToJ pkgloc =

--- a/nix-tools/nix-tools/nix-tools.cabal
+++ b/nix-tools/nix-tools/nix-tools.cabal
@@ -15,14 +15,14 @@ common warnings
 
 common cabal-deps
   build-depends:
-    Cabal ^>=3.12,
-    Cabal-syntax ^>=3.12
+    Cabal ^>=3.14,
+    Cabal-syntax ^>=3.14
 
 common cabal-install-deps
   import: cabal-deps
   build-depends:
-    cabal-install ^>=3.12,
-    cabal-install-solver ^>=3.12
+    cabal-install ^>=3.14,
+    cabal-install-solver ^>=3.14
 
 library
   import:              warnings

--- a/nix-tools/overlay.nix
+++ b/nix-tools/overlay.nix
@@ -1,7 +1,7 @@
 final: _prev:
 
 let
-  compiler-nix-name = "ghc9101";
+  compiler-nix-name = "ghc96";
 
   nix-tools = nix-tools-set {
     nix-tools = nix-tools-unchecked;

--- a/nix-tools/static/packaging.nix
+++ b/nix-tools/static/packaging.nix
@@ -28,12 +28,13 @@ let
         text = ''
           for nixlib in $(otool -L "$1" |awk '/nix\/store/{ print $1 }'); do
               case "$nixlib" in
-              *libiconv.dylib)    install_name_tool -change "$nixlib" /usr/lib/libiconv.dylib "$1" ;;
+              *libiconv.dylib)    install_name_tool -change "$nixlib" /usr/lib/libiconv.dylib   "$1" ;;
               *libiconv.2.dylib)  install_name_tool -change "$nixlib" /usr/lib/libiconv.2.dylib "$1" ;;
-              *libffi.*.dylib)    install_name_tool -change "$nixlib" /usr/lib/libffi.dylib   "$1" ;;
-              *libc++.*.dylib)    install_name_tool -change "$nixlib" /usr/lib/libc++.dylib   "$1" ;;
-              *libz.dylib)        install_name_tool -change "$nixlib" /usr/lib/libz.dylib     "$1" ;;
-              *libresolv.*.dylib) install_name_tool -change "$nixlib" /usr/lib/libresolv.dylib   "$1" ;;
+              *libffi.*.dylib)    install_name_tool -change "$nixlib" /usr/lib/libffi.dylib     "$1" ;;
+              *libc++.*.dylib)    install_name_tool -change "$nixlib" /usr/lib/libc++.dylib     "$1" ;;
+              *libc++abi.*.dylib) install_name_tool -change "$nixlib" /usr/lib/libc++abi.dylib  "$1" ;;
+              *libz.dylib)        install_name_tool -change "$nixlib" /usr/lib/libz.dylib       "$1" ;;
+              *libresolv.*.dylib) install_name_tool -change "$nixlib" /usr/lib/libresolv.dylib  "$1" ;;
               *) ;;
               esac
           done

--- a/nix-tools/static/project.nix
+++ b/nix-tools/static/project.nix
@@ -64,7 +64,7 @@ let
 
   static-nix-tools-project = pkgs.haskell-nix.project' {
 
-    compiler-nix-name = "ghc967";
+    compiler-nix-name = "ghc9101";
 
     src = ../.;
 

--- a/nix-tools/static/project.nix
+++ b/nix-tools/static/project.nix
@@ -64,7 +64,7 @@ let
 
   static-nix-tools-project = pkgs.haskell-nix.project' {
 
-    compiler-nix-name = "ghc9101";
+    compiler-nix-name = "ghc96";
 
     src = ../.;
 

--- a/nix-tools/static/project.nix
+++ b/nix-tools/static/project.nix
@@ -64,7 +64,7 @@ let
 
   static-nix-tools-project = pkgs.haskell-nix.project' {
 
-    compiler-nix-name = "ghc928";
+    compiler-nix-name = "ghc967";
 
     src = ../.;
 

--- a/test/cabal.project.local
+++ b/test/cabal.project.local
@@ -23,14 +23,14 @@ repository head.hackage.ghc.haskell.org
      f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
      26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
      7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-  --sha256: sha256-RQS0PUBA6nAD1T0OSVFhcF7ldh+6L+cW+k96Hgo3z5s=
+  --sha256: sha256-xilNP+uPmCGM1NXZJYgCEYXmGdjnE8todMdQKJ2BkJw=
 
 repository ghcjs-overlay
   url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/ffb32dce467b9a4d27be759fdd2740a6edd09d0b
   secure: True
   root-keys:
   key-threshold: 0
-  --sha256: sha256-mHxgsrbjHdyE8yqOkhZsk4WGKGZDFqSn07ENMPy1rVA=
+  --sha256: sha256-RXRKmHMpOY7ePZGGabZ1YGhF42+eLslZEIMe2JUYwB0=
 
 if os(ghcjs)
   extra-packages: ghci

--- a/test/gi-gtk/default.nix
+++ b/test/gi-gtk/default.nix
@@ -10,6 +10,8 @@ let
     cabalProjectLocal = builtins.readFile ../cabal.project.local + ''
       -- The overloading feature of haskell-gi makes build times very long
       constraints: haskell-gi-overloading ==0.0
+      -- Needed for the current nix-tools TODO remove once nix-tools is updated
+      constraints: Cabal <3.12
     '';
   };
 

--- a/test/gi-gtk/default.nix
+++ b/test/gi-gtk/default.nix
@@ -10,8 +10,6 @@ let
     cabalProjectLocal = builtins.readFile ../cabal.project.local + ''
       -- The overloading feature of haskell-gi makes build times very long
       constraints: haskell-gi-overloading ==0.0
-      -- Needed for the current nix-tools TODO remove once nix-tools is updated
-      constraints: Cabal <3.12
     '';
   };
 


### PR DESCRIPTION
* Update nix-tools and use GHC 9.6.7 and Cabal 3.14 to build them

* Add libc++abi.dylib to fixup-nix-deps

* Fix wait for hydra

* Use new json format in dummy ghc code

* Fix index-state issues (related to use of newer Cabal in make-install-plan)

* Fix error output formatting now that details of failures are in exceptions thrown by the Cabal planner (they were printed before).