### PR TITLE
Fix tests that break with latest random package and ghc 9.12.1

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,7 @@
     let
       callFlake = import flake-compat;
 
-      ifdLevel = 3;
+      ifdLevel = 2;
       runningHydraEvalTest = false;
       defaultCompiler = "ghc928";
       config = import ./config.nix;

--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,7 @@
     let
       callFlake = import flake-compat;
 
-      ifdLevel = 2;
+      ifdLevel = 3;
       runningHydraEvalTest = false;
       defaultCompiler = "ghc928";
       config = import ./config.nix;

--- a/test/cabal.project.local
+++ b/test/cabal.project.local
@@ -3,7 +3,7 @@ if impl(ghc>=9.12.1)
   -- being shipped with a newer compiler.  If you extend this
   -- be very careful to only extend it for absolutely necessary packages
   -- otherwise we risk running into broken build-plans down the line.
-  allow-newer: *:base, *:template-haskell, *:ghc-prim
+  allow-newer: *:base, *:template-haskell, *:ghc-prim, uuid-types:random, QuickCheck:random, cabal-install:random
 
 if impl(ghc > 9.13)
   allow-newer: *:containers, *:time, *:ghc-bignum


### PR DESCRIPTION
Without this fix the cabal planner chooses a plan that while valid based on the constraints, uses old versions of some packages that fail to build.