### PR TITLE
Respect defaults in `shellFor` (fixes #2306)

### DIFF
--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -823,7 +823,7 @@ final: prev: {
             shellFor = shellArgs:
               let
                 # These are the args we will pass to the main shell.
-                args' = builtins.removeAttrs shellArgs [ "crossPlatforms" ];
+                args' = builtins.removeAttrs (rawProject.args.shell // shellArgs) [ "crossPlatforms" ];
                 # These are the args we will pass to the shells for the corss compiler
                 argsCross =
                   # These things should match main shell
@@ -847,7 +847,7 @@ final: prev: {
                 });
 
             # Default shell
-            shell = shellFor rawProject.args.shell;
+            shell = shellFor {};
 
             # Like `.hsPkgs.${packageName}` but when compined with `getComponent` any
             # cabal configure errors are defered until the components derivation builds.


### PR DESCRIPTION
`shellFor` has an argument `allToolDeps` that when set to `true` tells haskell.nix to include all the tool dependencies of all the packages in the shell.  This does not work well for `stackProject` projects (since stackage includes a lot of packages).  So it is disabled by default in `modules/stack-project.nix`.

This default is currently ignored if `shellFor` is called directly.

This change ensures that `shellFor` respects the defaults and any shell arguments passed to the project. As a result, `project.shell` and `project.shellFor {}` will now behave consistently.