### PR TITLE
Change `webkit2gtk` map to `webkitgtk_4_0`

### DIFF
--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -83,7 +83,7 @@ pkgs:
     "stdc++.dll"                         = []; # What is that?
     "systemd-journal"                    = [ "systemd" ];
     "tag_c"                              = [ "taglib" ];
-    "webkit2gtk"                         = [ "webkitgtk" ];
+    "webkit2gtk"                         = [ "webkitgtk_4_0" ];
     "xml2"                               = [ "libxml2" ];
     "yaml"                               = [ "libyaml" ];
     "z"                                  = [ "zlib" ];


### PR DESCRIPTION
`evaluation warning: Explicitly set the ABI version of 'webkitgtk'`

webkitgtk has been a warn since https://www.github.com/nixos/nixpkgs/commit/b9a93b632915e8a5064e5c46e4a11360a79e1e12