### PR TITLE
fix bug: fetchPackageRepo

### DIFF
--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -193,10 +193,11 @@ let
             then fetchgit { inherit (repoData) url sha256; rev = repoData.rev or repoData.ref; }
             else
               let drv = builtins.fetchGit
-                { inherit (repoData) url ; ref = repoData.ref or null; }
-                # fetchGit does not accept "null" as rev, so when it's null
-                # we have to omit the argument completely.
-                // pkgs.lib.optionalAttrs (repoData ? rev) { inherit (repoData) rev; };
+                ({ inherit (repoData) url ; }
+                  # fetchGit does not accept "null" as rev and ref, so when it's null
+                  # we have to omit the argument completely.
+                  // pkgs.lib.optionalAttrs (repoData ? ref) { inherit (repoData) ref; }
+                  // pkgs.lib.optionalAttrs (repoData ? rev) { inherit (repoData) rev; });
               in __trace "WARNING: No sha256 found for source-repository-package ${repoData.url} ref=${repoData.ref or "(unspecified)"} rev=${repoData.rev or "(unspecified)"} download may fail in restricted mode (hydra)"
                 (__trace "Consider adding `--sha256: ${hashPath drv}` to the ${cabalProjectFileName} file or passing in a sha256map argument"
                  drv);


### PR DESCRIPTION
There was a bug in branching when sha256 of fetchPackageRepo was not specified
The cause is the following two language specifications:

## `builtins.fetchGit` cannot have null ref as well as rev

```
$ nix eval --expr 'builtins.fetchGit { url = "https://github.com/input-output-hk/haskell.nix.git"; ref = null; rev = "b12959e3e7cc75076040222a1b2f1b992066f4c2"; }'
error:
       … while calling the 'fetchGit' builtin
         at «string»:1:1:
            1| builtins.fetchGit { url = "https://github.com/input-output-hk/haskell.nix.git"; ref = null; rev = "b12959e3e7cc75076040222a1b2f1b992066f4c2"; }
             | ^

       error: fetchTree argument 'ref' is null while a string, Boolean or integer is expected
```

## `f x // y` is `(f x) // y`, not `f (x // y)`
```
$ nix eval --expr 'let f = _: 1; in (f {} // {})'
error:
       … in the left operand of the update (//) operator
         at «string»:1:24:
            1| let f = _: 1; in (f {} // {})
             |                        ^

       error: expected a set but found an integer: 1
```