### PR TITLE
Improve remote store eval time

### DIFF
--- a/lib/load-cabal-plan.nix
+++ b/lib/load-cabal-plan.nix
@@ -75,7 +75,9 @@ let
           buildable = true;
         } // lookupDependencies hsPkgs.pkgsBuildBuild (components.setup.depends or []) (components.setup.exe-depends or []);
       };
-  nixFilesDir = callProjectResults.projectNix + callProjectResults.src.origSubDir or "";
+  # We use unsafeDiscardStringContext to ensure that we don't query this derivation when importing
+  # each package. The cost can be very high when using a remote store, as we need to do a network call.
+  nixFilesDir = builtins.unsafeDiscardStringContext callProjectResults.projectNix.outPath + callProjectResults.src.origSubDir or "";
 in {
   # This replaces the `plan-nix/default.nix`
   pkgs = (hackage: {


### PR DESCRIPTION
This code used to put the .drv path into the string context for each package. That meant we had to query the store each time one of these was evaluated for the out path. This is pretty quick when using a non-remote store. But the latency with the remote store really slows us down.

We should just calculate the outPath once instead, and use that throughout.