### PR TITLE
Fix terminfo dep in dummy ghc for haskeline

### DIFF
--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -668,7 +668,7 @@ haskell-nix.haskellLib.makeCompilerDeps (stdenv.mkDerivation (rec {
     '';
 
   passthru = {
-    inherit bootPkgs targetPrefix libDir llvmPackages enableShared useLLVM hadrian hadrianProject;
+    inherit bootPkgs targetPrefix libDir llvmPackages enableShared enableTerminfo useLLVM hadrian hadrianProject;
 
     # Our Cabal compiler name
     haskellCompilerName = "ghc-${version}";

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -540,7 +540,13 @@ let
                 ''}
                 ${pkgs.lib.optionalString (!pkgs.stdenv.targetPlatform.isWindows) ''
                 deps+=" $(jq -r '.components.lib."build-depends"[]|select(._if.not.os == "windows")|._then[]|.package' $json_cabal_file)"
-                ''}
+                ''
+                # Fix problem with `haskeline` using a `terminfo` flag
+                # For haskell-nix ghc we can use ghc.enableTerminfo to get the flag setting
+                + pkgs.lib.optionalString (name == "haskeline" && !pkgs.stdenv.targetPlatform.isWindows && ghc.enableTerminfo or true) ''
+                deps+=" terminfo"
+                ''
+                }
                 DEPS_${varname name}="$(tr '\n' ' ' <<< "$deps")"
                 VER_${varname name}="$(jq -r '.version' $json_cabal_file)"
                 PKGS+=" ${name}"

--- a/lib/call-cabal-project-to-nix.nix
+++ b/lib/call-cabal-project-to-nix.nix
@@ -546,6 +546,10 @@ let
                 + pkgs.lib.optionalString (name == "haskeline" && !pkgs.stdenv.targetPlatform.isWindows && ghc.enableTerminfo or true) ''
                 deps+=" terminfo"
                 ''
+                # Similar issue for Win32:filepath build-depends (hidden behind `if impl(ghc >= 8.0)`)
+                + pkgs.lib.optionalString (name == "Win32" && pkgs.stdenv.targetPlatform.isWindows) ''
+                deps+=" filepath"
+                ''
                 }
                 DEPS_${varname name}="$(tr '\n' ' ' <<< "$deps")"
                 VER_${varname name}="$(jq -r '.version' $json_cabal_file)"


### PR DESCRIPTION
The dependency is missed because a `terminfo` cabal flag is used.