### PR TITLE
Only include --dependency for sublibs with package name prefix

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -594,7 +594,6 @@ let
               (''
               if id=$(${target-pkg-and-db} field "z-${package.identifier.name}-z-*" id --simple-output); then
                 name=$(${target-pkg-and-db} field "z-${package.identifier.name}-z-*" name --simple-output)
-                echo "--dependency=''${name#z-${package.identifier.name}-z-}=$id" >> $out/exactDep/configure-flags
                 echo "package-id $id" >> $out/envDep
                 ''
                 # Allow `package-name:sublib-name` to work in `build-depends`


### PR DESCRIPTION
This PR fixes a problem when a sublib has the same name as a package.  If a component depends on the sublib and the package the package was not found because the unqualified sublib `--dependency` hid it.

We don't think we need the sublib to be listed unqualified (without the package name prefix).