### PR TITLE
Log to stderr instead of stdout from hix run. Fix indentation.

### DIFF
--- a/hix/default.nix
+++ b/hix/default.nix
@@ -86,11 +86,11 @@ let
         HIX_FLAKE="$(mktemp -d)/flake.nix"
         sed 's|EVAL_SYSTEM|${pkgs.stdenv.hostPlatform.system}|' < ${hixProject}/flake.nix > $HIX_FLAKE
         if ! cmp $HIX_FLAKE $FLAKE/flake.nix &>/dev/null; then
-            if [ -e $FLAKE/flake.lock ]; then
-            echo "Updating $FLAKE/flake.nix and deleting old $FLAKE/flake.lock"
+          if [ -e $FLAKE/flake.lock ]; then
+            >&2 echo "Updating $FLAKE/flake.nix and deleting old $FLAKE/flake.lock"
             rm $FLAKE/flake.lock
           else
-            echo "Updating $FLAKE/flake.nix"
+            >&2 echo "Updating $FLAKE/flake.nix"
           fi
           cp $HIX_FLAKE $FLAKE/flake.nix
           chmod +w $FLAKE/flake.nix


### PR DESCRIPTION
I only recently found out about `hix` but I am already a big fan: `hix run` fills a gap in Haskell tooling as neither cabal nor stack have a way to download a package, build it and run an executable from it in one go AFAIK.

This feature makes it very handy in scripting, but unfortunately its usefulness is hindered by the fact that it logs to stdout.

This patch makes it log to stderr, making it easier to use `hix run` in shell pipelines.

To demonstrate the issue please download the attached bash script (attached as txt because github doesn't allow attaching files with the `.sh` extension) and make it executable or feed it to bash.

WARNING: the script deletes your `~/.hix/github:informatikr` directory and all of its contents.

The reason why it deletes that directory is because `hix run` doesn't log anything when it does not make any changes inside it, so it will only log on the first time it is invoked with the same arguments but not on subsequent invokations.

The script also runs the reproduction code 10 times because (for some reason that is beyond me) *sometimes* those logs already end up in stderr instead of stdout.

Before running the script, it's recommended to ensure that a definitive answer is given to nix for all the questions asked by haskell.nix flake config.

Before the fix (the % reported will change on each run, YMMV):

```bash
ste@eppere ~ $ ./reproduce.txt github:input-output-hk/haskell.nix#hix
success rate: 50%
```

After the fix:

```bash
ste@eppere ~ $ ./reproduce.txt github:demaledetti/haskell.nix/hix-run-no-stdout#hix
success rate: 100%
```
