### PR TITLE
Fix postgresql-libpq-configure

### DIFF
--- a/modules/configuration-nix.nix
+++ b/modules/configuration-nix.nix
@@ -203,4 +203,7 @@ in addPackageKeys {
     pkgs.apple-sdk_11
     (pkgs.darwinMinVersionHook "11.0")
   ];
+
+  packages.postgresql-libpq-configure.components.library.libs = [ (lib.getDev pkgs.postgresql) ]
+    ++ lib.optional (pkgs.postgresql ? pg_config) [ pkgs.postgresql.pg_config ];
 }


### PR DESCRIPTION
It needs posgresql and pg_config, but does not explicitly list the dependency in the `.cabal` file.

With this change both `use-pkg-config` on and off work. Tested with:

```
nix build --impure --expr '((import ./. {}).pkgs-unstable.haskell-nix.hackage-package {compiler-nix-name="ghc9122"; name = "postgresql-libpq"; cabalProjectLocal = "package postgresql-libpq\n flags: -use-pkg-config"; }).components.library'
nix build --impure --expr '((import ./. {}).pkgs-unstable.haskell-nix.hackage-package {compiler-nix-name="ghc9122"; name = "postgresql-libpq"; cabalProjectLocal = "package postgresql-libpq\n flags: +use-pkg-config"; }).components.library'
```

Fixes #2281