### PR TITLE
Allow using GHC with ld.lld

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -1,4 +1,4 @@
-{ pkgs, stdenv, buildPackages, pkgsBuildBuild, ghc, lib, gobject-introspection ? null, haskellLib, makeConfigFiles, haddockBuilder, ghcForComponent, hsPkgs, compiler, runCommand, libffi, gmp, windows, zlib, ncurses, nodejs, nonReinstallablePkgs }@defaults:
+{ pkgs, stdenv, buildPackages, pkgsBuildBuild, ghc, llvmPackages, lib, gobject-introspection ? null, haskellLib, makeConfigFiles, haddockBuilder, ghcForComponent, hsPkgs, compiler, runCommand, libffi, gmp, windows, zlib, ncurses, nodejs, nonReinstallablePkgs }@defaults:
 lib.makeOverridable (
 let self =
 { componentId
@@ -430,7 +430,8 @@ let
     nativeBuildInputs =
       [ghc buildPackages.removeReferencesTo]
       ++ executableToolDepends
-      ++ (lib.optional stdenv.hostPlatform.isGhcjs buildPackages.nodejs);
+      ++ (lib.optional stdenv.hostPlatform.isGhcjs buildPackages.nodejs)
+      ++ (lib.optional (ghc.useLdLld or false) llvmPackages.bintools);
 
     outputs = ["out"]
       ++ (lib.optional keepConfigFiles "configFiles")

--- a/builder/haddock-builder.nix
+++ b/builder/haddock-builder.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, lib, haskellLib, ghc, ghcForComponent, nonReinstallablePkgs, runCommand, writeText, writeScript, makeConfigFiles }:
+{ stdenv, buildPackages, lib, haskellLib, ghc, ghcForComponent, nonReinstallablePkgs, runCommand, writeText, writeScript, makeConfigFiles, llvmPackages }:
 
 { componentId
 , component
@@ -80,7 +80,8 @@ let
 
     nativeBuildInputs =
       [ ghc buildPackages.removeReferencesTo ]
-      ++ componentDrv.executableToolDepends;
+      ++ componentDrv.executableToolDepends
+      ++ (lib.optional (ghc.useLdLld or false) llvmPackages.bintools);
 
     configurePhase = ''
       mkdir -p $configFiles

--- a/builder/setup-builder.nix
+++ b/builder/setup-builder.nix
@@ -1,4 +1,4 @@
-{ pkgs, stdenv, lib, buildPackages, haskellLib, ghc, nonReinstallablePkgs, hsPkgs, makeSetupConfigFiles }@defaults:
+{ pkgs, stdenv, lib, buildPackages, haskellLib, ghc, nonReinstallablePkgs, hsPkgs, makeSetupConfigFiles, llvmPackages }@defaults:
 
 let self =
 { component, package, name, src, enableDWARF ? false, flags ? {}, revision ? null, patches ? [], defaultSetupSrc
@@ -67,7 +67,7 @@ let
         ++ builtins.concatLists component.pkgconfig
         ++ configFiles.libDeps
         ++ [ghc]; # Needs to be a build input so that the boot libraries are included
-      nativeBuildInputs = [ghc] ++ executableToolDepends;
+      nativeBuildInputs = [ghc] ++ executableToolDepends ++ (lib.optional (ghc.useLdLld or false) llvmPackages.bintools);
 
       passthru = {
         inherit (package) identifier;

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -76,7 +76,7 @@ let self =
       # don't use gold with with musl. Still seems to be
       # affected by 22266.
       && !stdenv.targetPlatform.isMusl)
-
+, useLdLld ? false
 , ghc-version ? src-spec.version
 , ghc-version-date ? null
 , ghc-commit-id ? null
@@ -94,6 +94,8 @@ assert !(enableIntegerSimple || enableNativeBignum) -> gmp != null;
 # Early check to make sure only one of these is enabled
 assert enableNativeBignum -> !enableIntegerSimple;
 assert enableIntegerSimple -> !enableNativeBignum;
+
+assert !(useLdGold && useLdLld);
 
 let
   src = src-spec.file or (fetchurl { inherit (src-spec) url sha256; });
@@ -212,6 +214,11 @@ let
         "CONF_GCC_LINKER_OPTS_STAGE1=-fuse-ld=gold"
         "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"
         "CONF_LD_LINKER_OPTS_STAGE2=-fuse-ld=gold" # See: <https://gitlab.haskell.org/ghc/ghc/-/issues/22550#note_466656>
+    ] ++ lib.optionals useLdLld [
+        "LD=${llvmPackages.bintools}/bin/ld.lld"
+        "CFLAGS=-fuse-ld=lld"
+        "CONF_GCC_LINKER_OPTS_STAGE1=-fuse-ld=lld"
+        "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=lld"
     ] ++ lib.optionals enableDWARF [
         "--enable-dwarf-unwind"
         "--with-libdw-includes=${lib.getDev elfutils}/include"
@@ -449,7 +456,10 @@ haskell-nix.haskellLib.makeCompilerDeps (stdenv.mkDerivation (rec {
     ''
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
     + ''
-        export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${lib.optionalString useLdGold ".gold"}"
+        export LD="${if useLdLld then
+                        "${targetPackages.llvmPackages.bintools}/bin/${targetPackages.llvmPackages.bintools.targetPrefix}ld.lld"
+                     else
+                       "${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${lib.optionalString useLdGold ".gold"}"}"
         export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
         export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
         export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
@@ -467,6 +477,8 @@ haskell-nix.haskellLib.makeCompilerDeps (stdenv.mkDerivation (rec {
     # set LD explicitly if we want gold even if we aren't cross compiling
     ''
         export LD="${targetCC.bintools}/bin/ld.gold"
+    '' + lib.optionalString (targetPlatform == hostPlatform && useLdLld) ''
+        export LD="${llvmPackages.bintools}/bin/ld.lld"
     '' + lib.optionalString (targetPlatform.isWindows) ''
         export DllWrap="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}dllwrap"
         export Windres="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}windres"
@@ -533,7 +545,8 @@ haskell-nix.haskellLib.makeCompilerDeps (stdenv.mkDerivation (rec {
   nativeBuildInputs = [
     perl autoconf automake m4 python3 sphinx
     ghc bootPkgs.alex bootPkgs.happy bootPkgs.hscolour
-  ] ++ lib.optional (patches != []) autoreconfHook;
+  ] ++ lib.optional (patches != []) autoreconfHook
+  ++ lib.optional useLdLld llvmPackages.bintools;
 
   # For building runtime libs
   depsBuildTarget = toolsForTarget;
@@ -684,7 +697,7 @@ haskell-nix.haskellLib.makeCompilerDeps (stdenv.mkDerivation (rec {
     '';
 
   passthru = {
-    inherit bootPkgs targetPrefix libDir llvmPackages enableShared enableTerminfo useLLVM hadrian hadrianProject;
+    inherit bootPkgs targetPrefix libDir llvmPackages enableShared enableTerminfo useLLVM useLdLld hadrian hadrianProject;
 
     # Our Cabal compiler name
     haskellCompilerName = "ghc-${version}";


### PR DESCRIPTION
We need to add llvmPackages.bintools to the nativeBuildInputs of builders when using this and we need to configure GHC to use ld.lld.

Resolves https://github.com/input-output-hk/haskell.nix/issues/2317