### PR TITLE
Fix support for pkgsStatic

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -26,7 +26,7 @@ let
   };
 
   setup-builder = haskellLib.weakCallPackage pkgs ./setup-builder.nix {
-    ghc = (ghc.passthru.buildGHC or ghc);
+    ghc = (ghc.buildGHC or ghc);
     hsPkgs = hsPkgs.buildPackages;
     # We need to use the buildPackages stdenv to build the setup-builder.
     # in the native case, it would be the same in the cross case however
@@ -54,7 +54,7 @@ let
   # When building setup depends we need to use the build systems GHC and Packages
   makeSetupConfigFiles = haskellLib.weakCallPackage buildPackages ./make-config-files.nix {
     inherit haskellLib nonReinstallablePkgs;
-    ghc = (ghc.passthru.buildGHC or ghc);
+    ghc = (ghc.buildGHC or ghc);
   };
 
 

--- a/builder/ghc-for-component-wrapper.nix
+++ b/builder/ghc-for-component-wrapper.nix
@@ -25,7 +25,8 @@ let
   docDir         = "$wrappedGhc/share/doc/ghc/html";
   # For musl we can use haddock from the buildGHC
   haddock        = if stdenv.hostPlatform.isMusl
-    then ghc.buildGHC or ghc
+    then ghc.buildGHC or ghc # `or ghc` is here because nixpkgs GHC does not have `buildGHC`
+                             # TODO find a way to get suitable GHC and/or respect `ghc.hasHaddock`.
     else ghc;
 
   script = ''

--- a/builder/ghc-for-component-wrapper.nix
+++ b/builder/ghc-for-component-wrapper.nix
@@ -25,7 +25,7 @@ let
   docDir         = "$wrappedGhc/share/doc/ghc/html";
   # For musl we can use haddock from the buildGHC
   haddock        = if stdenv.hostPlatform.isMusl
-    then ghc.buildGHC
+    then ghc.buildGHC or ghc
     else ghc;
 
   script = ''

--- a/ci.nix
+++ b/ci.nix
@@ -82,36 +82,40 @@
     # of 'lib.systems.examples' are not understood between all versions
     let lib = nixpkgs.lib;
     in lib.optionalAttrs (nixpkgsName == "unstable"
-      && (__match ".*llvm" compiler-nix-name == null)
-      && !builtins.elem compiler-nix-name ["ghc9102"]) {
-    inherit (lib.systems.examples) ghcjs;
-  } // lib.optionalAttrs (nixpkgsName == "unstable"
-      && (__match ".*llvm" compiler-nix-name == null)
-      && ((system == "x86_64-linux"  && !builtins.elem compiler-nix-name ["ghc902" "ghc928"])
-       || (system == "x86_64-darwin" && builtins.elem compiler-nix-name []))) { # TODO add ghc versions when we have more darwin build capacity
-    inherit (lib.systems.examples) mingwW64;
-  } // lib.optionalAttrs (nixpkgsName == "unstable"
-      && (__match ".*llvm" compiler-nix-name == null)
-      && ((system == "x86_64-linux"  && !builtins.elem compiler-nix-name ["ghc8107" "ghc902" "ghc928" "ghc948"])
-       || (system == "x86_64-darwin" && builtins.elem compiler-nix-name []))) { # TODO add ghc versions when we have more darwin build capacity
-    inherit (lib.systems.examples) ucrt64;
-  } // lib.optionalAttrs (system == "x86_64-linux" && nixpkgsName == "unstable" && !builtins.elem compiler-nix-name ["ghc902" "ghc928" "ghc948"]) {
-    # Musl cross only works on linux
-    # aarch64 cross only works on linux
-    inherit (lib.systems.examples) musl64 aarch64-multiplatform;
-  } // lib.optionalAttrs (__match ".*llvm" compiler-nix-name == null && system == "x86_64-linux" && nixpkgsName == "unstable" && !builtins.elem compiler-nix-name ["ghc902" "ghc928" "ghc948"]) {
-    # Out llvm versions of GHC seem to break for musl32
-    inherit (lib.systems.examples) musl32;
-  } // lib.optionalAttrs (system == "x86_64-linux" && !builtins.elem compiler-nix-name ["ghc902" "ghc928" "ghc948"]) {
-    inherit (lib.systems.examples) aarch64-android-prebuilt;
-  } // lib.optionalAttrs (system == "x86_64-linux" && !builtins.elem compiler-nix-name ["ghc902" "ghc928" "ghc948" "ghc91320250523"]) {
-    inherit (lib.systems.examples) armv7a-android-prebuilt;
-  } // lib.optionalAttrs (system == "x86_64-linux" && nixpkgsName == "unstable" && !builtins.elem compiler-nix-name ["ghc8107" "ghc902"]) {
-    # TODO fix this for the compilers we build with hadrian (ghc >=9.4)
-    inherit (lib.systems.examples) aarch64-multiplatform-musl;
-  } // lib.optionalAttrs (system == "aarch64-linux" && nixpkgsName == "unstable" && !builtins.elem compiler-nix-name ["ghc8107" "ghc902"]) {
-    inherit (lib.systems.examples) aarch64-multiplatform-musl;
-  };
+      && __match ".*llvm" compiler-nix-name == null
+      && builtins.elem system ["aarch64-linux" "x86_64-linux"]) {
+        static = p: p.pkgsStatic;
+      } // lib.optionalAttrs (nixpkgsName == "unstable"
+          && (__match ".*llvm" compiler-nix-name == null)
+          && !builtins.elem compiler-nix-name ["ghc9102"]) {
+        inherit (lib.systems.examples) ghcjs;
+      } // lib.optionalAttrs (nixpkgsName == "unstable"
+          && (__match ".*llvm" compiler-nix-name == null)
+          && ((system == "x86_64-linux"  && !builtins.elem compiler-nix-name ["ghc902" "ghc928"])
+           || (system == "x86_64-darwin" && builtins.elem compiler-nix-name []))) { # TODO add ghc versions when we have more darwin build capacity
+        inherit (lib.systems.examples) mingwW64;
+      } // lib.optionalAttrs (nixpkgsName == "unstable"
+          && (__match ".*llvm" compiler-nix-name == null)
+          && ((system == "x86_64-linux"  && !builtins.elem compiler-nix-name ["ghc8107" "ghc902" "ghc928" "ghc948"])
+           || (system == "x86_64-darwin" && builtins.elem compiler-nix-name []))) { # TODO add ghc versions when we have more darwin build capacity
+        inherit (lib.systems.examples) ucrt64;
+      } // lib.optionalAttrs (system == "x86_64-linux" && nixpkgsName == "unstable" && !builtins.elem compiler-nix-name ["ghc902" "ghc928" "ghc948"]) {
+        # Musl cross only works on linux
+        # aarch64 cross only works on linux
+        inherit (lib.systems.examples) musl64 aarch64-multiplatform;
+      } // lib.optionalAttrs (__match ".*llvm" compiler-nix-name == null && system == "x86_64-linux" && nixpkgsName == "unstable" && !builtins.elem compiler-nix-name ["ghc902" "ghc928" "ghc948"]) {
+        # Out llvm versions of GHC seem to break for musl32
+        inherit (lib.systems.examples) musl32;
+      } // lib.optionalAttrs (system == "x86_64-linux" && !builtins.elem compiler-nix-name ["ghc902" "ghc928" "ghc948"]) {
+        inherit (lib.systems.examples) aarch64-android-prebuilt;
+      } // lib.optionalAttrs (system == "x86_64-linux" && !builtins.elem compiler-nix-name ["ghc902" "ghc928" "ghc948" "ghc91320250523"]) {
+        inherit (lib.systems.examples) armv7a-android-prebuilt;
+      } // lib.optionalAttrs (system == "x86_64-linux" && nixpkgsName == "unstable" && !builtins.elem compiler-nix-name ["ghc8107" "ghc902"]) {
+        # TODO fix this for the compilers we build with hadrian (ghc >=9.4)
+        inherit (lib.systems.examples) aarch64-multiplatform-musl;
+      } // lib.optionalAttrs (system == "aarch64-linux" && nixpkgsName == "unstable" && !builtins.elem compiler-nix-name ["ghc8107" "ghc902"]) {
+        inherit (lib.systems.examples) aarch64-multiplatform-musl;
+      };
   isDisabled = d: d.meta.disabled or false;
 in
 dimension "Nixpkgs version" nixpkgsVersions (nixpkgsName: pinnedNixpkgsSrc:
@@ -140,8 +144,10 @@ dimension "Nixpkgs version" nixpkgsVersions (nixpkgsName: pinnedNixpkgsSrc:
       }
       //
       dimension "Cross system" (crossSystems nixpkgsName evalPackages compiler-nix-name) (crossSystemName: crossSystem:
-        # Cross builds
-        let pkgs = import pinnedNixpkgsSrc (nixpkgsArgs // { inherit system crossSystem; });
+        let pkgs =
+              if builtins.isAttrs crossSystem
+                then import pinnedNixpkgsSrc (nixpkgsArgs // { inherit system crossSystem; })
+                else crossSystem (import pinnedNixpkgsSrc (nixpkgsArgs // { inherit system; }));
             build = import ./build.nix { inherit pkgs evalPackages ifdLevel compiler-nix-name haskellNix; };
         in pkgs.recurseIntoAttrs (pkgs.lib.optionalAttrs (ifdLevel >= 1) ({
             roots = pkgs.haskell-nix.roots' { inherit compiler-nix-name evalPackages; } ifdLevel // {

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -39,7 +39,7 @@ let self =
 
 , # Whether to build dynamic libs for the standard library (on the target
   # platform). Static libs are always built.
-  enableShared ? !haskell-nix.haskellLib.isCrossTarget
+  enableShared ? !haskell-nix.haskellLib.isCrossTarget && !stdenv.targetPlatform.isStatic
 
 , enableLibraryProfiling ? true
 
@@ -328,7 +328,7 @@ let
   # see https://gitlab.haskell.org/ghc/ghc/blob/master/hadrian/doc/flavours.md
   hadrianArgs = "--flavour=${
         (if targetPlatform.isGhcjs then "quick" else "default")
-          + lib.optionalString (!enableShared) "+no_dynamic_ghc"
+          + lib.optionalString (!enableShared) "+no_dynamic_libs+no_dynamic_ghc"
           + lib.optionalString useLLVM "+llvm"
           + lib.optionalString enableDWARF "+debug_info"
           + lib.optionalString ((enableNativeBignum && hadrianHasNativeBignumFlavour) || targetPlatform.isGhcjs) "+native_bignum"

--- a/test/cabal-simple/default.nix
+++ b/test/cabal-simple/default.nix
@@ -35,7 +35,7 @@ in recurseIntoAttrs {
         cabal = { cabalProjectLocal = builtins.readFile ../cabal.project.local; };
         hoogle = { cabalProjectLocal = builtins.readFile ../cabal.project.local; };
       };
-      withHoogle = true;
+      withHoogle = !stdenv.hostPlatform.isStatic;
     }).overrideAttrs (_: _: {
       meta = rec {
         platforms = lib.platforms.all;

--- a/test/cabal.project.local
+++ b/test/cabal.project.local
@@ -29,7 +29,7 @@ repository head.hackage.ghc.haskell.org
      f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
      26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
      7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-  --sha256: sha256-0cuvKmWGj5xuN3kJ6W9mv09bn6PAH4nTBK0QyEPc7Hg=
+  --sha256: sha256-6w1dAY7syB11aqT7T3mi/vOupdwL9GT2ztRZJBBG/u8=
 
 repository ghcjs-overlay
   url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/ffb32dce467b9a4d27be759fdd2740a6edd09d0b

--- a/test/coverage/default.nix
+++ b/test/coverage/default.nix
@@ -23,6 +23,7 @@ let
 
   exeExt = stdenv.hostPlatform.extensions.executable;
   crossSuffix = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) "-${stdenv.hostPlatform.config}";
+  crossSuffix' = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform.isStatic) "-static-${stdenv.hostPlatform.config}";
 
 in recurseIntoAttrs ({
   # Does not work on ghcjs because it needs zlib.
@@ -91,7 +92,7 @@ in recurseIntoAttrs ({
         dirExists "$pkga_basedir/html/pkga-0.1.0.0"
   
         pkgb_basedir="${project.hsPkgs.pkgb.coverageReport}/share/hpc/vanilla"
-        testTix="$pkgb_basedir/tix/pkgb-test-tests${crossSuffix}-0.1.0.0-check${crossSuffix}/tests${exeExt}.tix"
+        testTix="$pkgb_basedir/tix/pkgb-test-tests${crossSuffix'}-0.1.0.0-check${crossSuffix}/tests${exeExt}.tix"
         libTix="$pkgb_basedir/tix/pkgb-0.1.0.0/pkgb-0.1.0.0.tix"
         fileExistsNonEmpty "$testTix"
         fileExistsNonEmpty "$libTix"
@@ -118,8 +119,8 @@ in recurseIntoAttrs ({
         dirExists "$project_basedir/tix/pkga-0.1.0.0${inplaceSuffix}"
         dirExists "$project_basedir/tix/pkgb-0.1.0.0${inplaceSuffix}"
         fileExistsNonEmpty "$project_basedir/tix/pkgb-0.1.0.0${inplaceSuffix}/pkgb-0.1.0.0${inplaceSuffix}.tix"
-        dirExists "$project_basedir/tix/pkgb-test-tests${crossSuffix}-0.1.0.0-check${crossSuffix}"
-        fileExistsNonEmpty "$project_basedir/tix/pkgb-test-tests${crossSuffix}-0.1.0.0-check${crossSuffix}/tests${exeExt}.tix"
+        dirExists "$project_basedir/tix/pkgb-test-tests${crossSuffix'}-0.1.0.0-check${crossSuffix}"
+        fileExistsNonEmpty "$project_basedir/tix/pkgb-test-tests${crossSuffix'}-0.1.0.0-check${crossSuffix}/tests${exeExt}.tix"
       '';
       in ''
         ${check cabalProj "-inplace"}

--- a/test/coverage/default.nix
+++ b/test/coverage/default.nix
@@ -23,7 +23,7 @@ let
 
   exeExt = stdenv.hostPlatform.extensions.executable;
   crossSuffix = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) "-${stdenv.hostPlatform.config}";
-  crossSuffix' = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform.isStatic) "-static-${stdenv.hostPlatform.config}";
+  crossSuffix' = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform.isStatic) "-static" + crossSuffix;
 
 in recurseIntoAttrs ({
   # Does not work on ghcjs because it needs zlib.

--- a/test/modules.nix
+++ b/test/modules.nix
@@ -1,4 +1,5 @@
 [{
+  package-keys = ["HsOpenSSL" "libsodium" "double-conversion"];
   # See https://github.com/haskell-cryptography/HsOpenSSL/issues/95
   packages.HsOpenSSL.ghcOptions = ["-optc=-Wno-incompatible-pointer-types"];
 }
@@ -6,5 +7,16 @@
 ({pkgs, lib, ...}: lib.mkIf pkgs.stdenv.hostPlatform.isAndroid {
   packages.libsodium.configureFlags = [ "--c2hs-option=--cppopts=-D_Null_unspecified=" ];
   packages.libsodium.components.library.hardeningDisable = ["fortify"];
+})
+
+({pkgs, lib, ...}: lib.mkIf pkgs.stdenv.hostPlatform.isStatic {
+  packages.double-conversion.ghcOptions = [
+    # stop putting U __gxx_personality_v0 into the library!
+    "-optcxx-fno-rtti"
+    "-optcxx-fno-exceptions"
+    # stop putting U __cxa_guard_release into the library!
+    "-optcxx-std=gnu++98"
+    "-optcxx-fno-threadsafe-statics"
+  ];
 })
 ]

--- a/test/sublib-docs/default.nix
+++ b/test/sublib-docs/default.nix
@@ -14,7 +14,7 @@ let
 
 in recurseIntoAttrs {
   # Haddock is not included with cross compilers currently
-  meta.disabled = haskellLib.isCrossHost;
+  meta.disabled = haskellLib.isCrossHost || stdenv.hostPlatform.isStatic;
   ifdInputs = {
     inherit (project) plan-nix;
   };

--- a/test/th-dlls/default.nix
+++ b/test/th-dlls/default.nix
@@ -7,6 +7,13 @@ let
   project = externalInterpreter: project' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "th-dlls";
+    # TODO figure out why TH breaks with pkgsStatic for `libsodium` and `HsOpenSSL`
+    # `libsodium` fails with the unhandled ELF relocation(RelA) type 23
+    # `HsOpenSSL` segfaults in ghcizm9zi12zi2zminplace_GHCiziObjLink_resolveObjs1_info
+    cabalProjectLocal = lib.optionalString stdenv.hostPlatform.isStatic ''
+      package th-dlls
+        flags: -libsodium -openssl
+    '';
     modules = import ../modules.nix ++ [({pkgs, ...}: lib.optionalAttrs externalInterpreter {
       packages.th-dlls.components.library.ghcOptions = [ "-fexternal-interpreter" ];
       # Static openssl seems to fail to load in iserv for musl

--- a/test/th-dlls/src/Lib.hs
+++ b/test/th-dlls/src/Lib.hs
@@ -1,14 +1,30 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Lib where
 
 import Control.Monad.IO.Class (liftIO)
-import OpenSSL (withOpenSSL)
-import OpenSSL.BN (withBN)
-import Libsodium (sodium_init)
 import Language.Haskell.TH.Syntax (Exp(..), Lit(..))
 import Data.Text as T
-import Data.Double.Conversion.Text (toShortest)
 
+#ifdef MIN_VERSION_HsOpenSSL
+import OpenSSL (withOpenSSL)
+import OpenSSL.BN (withBN)
+#endif
+
+#ifdef MIN_VERSION_libsodium
+import Libsodium (sodium_init)
+#endif
+
+#ifdef MIN_VERSION_double_conversion
+import Data.Double.Conversion.Text (toShortest)
+#endif
+
+#ifdef MIN_VERSION_HsOpenSSL
 x = $(liftIO (withOpenSSL (withBN 0 (\_ -> return (LitE (IntegerL 0))))))
+#endif
+#ifdef MIN_VERSION_libsodium
 y = $(liftIO (sodium_init >> return (LitE (IntegerL 0))))
+#endif
+#ifdef MIN_VERSION_double_conversion
 z = $(liftIO (return (LitE (IntegerL (fromIntegral (T.length (toShortest 1.0)))))))
+#endif

--- a/test/th-dlls/th-dlls.cabal
+++ b/test/th-dlls/th-dlls.cabal
@@ -6,18 +6,37 @@ author:              Hamish Mackenzie
 maintainer:          Hamish.K.Mackenzie@gmail.com
 build-type:          Simple
 
+flag libsodium
+  description:         Enable libsodium support
+  default:             True
+  manual:              True
+
+flag openssl
+  description:         Enable OpenSSL support
+  default:             True
+  manual:              True
+
+flag double-conversion
+  description:         Enable double-conversion support
+  default:             True
+  manual:              True
+
 library
-  build-depends:       base
-                     , HsOpenSSL
-                     , libsodium
-                     , template-haskell
-                     , text
-                     , double-conversion
-                     , unix-time
-                     , th-orphans
-                     , ghc-prim
-                     , math-functions
-                     , erf
+  build-depends:
+      base
+    , template-haskell
+    , text
+    , unix-time
+    , th-orphans
+    , ghc-prim
+    , math-functions
+    , erf
+  if flag(openssl)
+    build-depends: HsOpenSSL
+  if flag(libsodium)
+    build-depends: libsodium
+  if flag(double-conversion)
+    build-depends: double-conversion
   exposed-modules:     Lib
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
This PR ensures that `pkgsStatic` can be used with both the `haskell.nix` GHC and the `nixpkgs` GHC.

Examples:

```bash
nix-build -E '((import ./. {}).pkgs.pkgsStatic.haskell-nix.tool "ghc9122" "hello" {})'
nix-build -E '((import ./. {}).pkgs.pkgsStatic.haskell-nix.tool "ghc9122" "hello" { compilerSelection = p: p.haskell.compiler; })'
```

Fixes #2421