### PR TITLE
Patch ghcjs >= 9.12: Add 'HEAP8' to EMCC:EXPORTED_RUNTIME_METHODS

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -77,7 +77,7 @@ in {
                 from = start: final.lib.optional (versionAtLeast start);
                 until = end: final.lib.optional (versionLessThan end);
                 always = final.lib.optional true;
-                onDarwin = final.lib.optionals final.stdenv.targetPlatform.isDarwin; 
+                onDarwin = final.lib.optionals final.stdenv.targetPlatform.isDarwin;
                 onMusl = final.lib.optionals final.stdenv.targetPlatform.isMusl;
                 onWindows = final.lib.optionals final.stdenv.targetPlatform.isWindows;
                 onWindowsOrMusl = final.lib.optionals (final.stdenv.targetPlatform.isWindows || final.stdenv.targetPlatform.isMusl);
@@ -333,6 +333,7 @@ in {
                 ++ onAndroid (from      "9.6"          ./patches/ghc/ghc-9.6-COMPAT_R_ARM_PREL31.patch)
                 ++ onAndroid (from      "9.10"         ./patches/ghc/ghc-9.10-ignore-libc.patch)
 
+                ++ onGhcjs (from        "9.12"         ./patches/ghc/ghc-9.12-ghcjs-rts-mem-heap8.patch)
                 # Fix for `fatal error: 'rts/Types.h' file not found` when building `primitive`
                 ++ onGhcjs (from        "9.13"         ./patches/ghc/ghc-9.13-ghcjs-rts-types.patch)
 

--- a/overlays/patches/ghc/ghc-9.12-ghcjs-rts-mem-heap8.patch
+++ b/overlays/patches/ghc/ghc-9.12-ghcjs-rts-mem-heap8.patch
@@ -1,0 +1,11 @@
+diff --git a/rts/js/mem.js b/rts/js/mem.js
+index 4a9adf09cd..68f63afece 100644
+--- a/rts/js/mem.js
++++ b/rts/js/mem.js
+@@ -1,5 +1,5 @@
+ //#OPTIONS:CPP
+-//#OPTIONS:EMCC:EXPORTED_RUNTIME_METHODS=addFunction,removeFunction,getEmptyTableSlot
++//#OPTIONS:EMCC:EXPORTED_RUNTIME_METHODS=addFunction,removeFunction,getEmptyTableSlot,HEAP8
+ 
+ // #define GHCJS_TRACE_META 1
+ 


### PR DESCRIPTION
Fixes https://github.com/input-output-hk/haskell.nix/issues/2427