### PR TITLE
Add upper bound on iserv-proxy:network

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1750543273,
-        "narHash": "sha256-WaswH0Y+Fmupvv8AkIlQBlUy/IdD3Inx9PDuE+5iRYY=",
+        "lastModified": 1755040634,
+        "narHash": "sha256-8W7uHpAIG8HhO3ig5OGHqvwduoye6q6dlrea1IrP2eI=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "a53c57c9a8d22a66a2f0c4c969e806da03f08c28",
+        "rev": "1383d199a2c64f522979005d112b4fbdee38dd92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates flake.lock to get https://github.com/stable-haskell/iserv-proxy/commit/1383d199a2c64f522979005d112b4fbdee38dd92

See https://github.com/haskell/network/issues/604