### PR TITLE
wasm: disable tail-call flag for now

### DIFF
--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -397,7 +397,7 @@ let
         " '*.*.ghc.*.opts += -fPIC' '*.*.cc.*.opts += -fPIC'"
       # C options for wasm
       + lib.optionalString targetPlatform.isWasm (
-          " 'stage1.*.ghc.*.opts += -optc-Wno-error=int-conversion -optc-O3 -optc-mcpu=lime1 -optc-mreference-types -optc-msimd128 -optc-mtail-call -optc-DXXH_NO_XXH3'"
+          " 'stage1.*.ghc.*.opts += -optc-Wno-error=int-conversion -optc-O3 -optc-mcpu=lime1 -optc-mreference-types -optc-msimd128 -optc-DXXH_NO_XXH3'"
         + " 'stage1.*.ghc.cpp.opts += -optc-fno-exceptions'")
       # `-fexternal-dynamic-refs` causes `undefined reference` errors when building GHC cross compiler for windows
       + lib.optionalString (enableRelocatedStaticLibs && targetPlatform.isx86_64 && !targetPlatform.isWindows)
@@ -626,7 +626,6 @@ haskell-nix.haskellLib.makeCompilerDeps (stdenv.mkDerivation (rec {
                  if builtins.compareVersions ghc-version "9.13" < 0
                    then "--experimental-wasm-type-reflection"
                    else "--max-old-space-size=65536"} \
-              --no-turbo-fast-api-calls \
               --wasm-lazy-validation \
               "$SCRIPT" \
               "${lib-wasm}/lib" \


### PR DESCRIPTION
As reported and confirmed from a ghc wasm backend user (@maralorn), tail-call opcodes may cause ios webview crashes for some large haskell wasm apps, and removing tail-call opcodes fixes the crash. Given webkit only supported tail-call since 18.2, it's better to disable tail-call flag for the time being and revisit this in the future.

This patch also removes --no-turbo-fast-api-calls from the dyld script flags, since it was used to workaround
https://github.com/nodejs/node/issues/46777 when wasm module uses tail calls. It's not needed when tail calls are not used and it has a performance penalty.