### PR TITLE
fix(wasm): wasm-opt flags for libffi-wasm

### DIFF
--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -163,7 +163,7 @@ let
       llvm-ar -r $out/lib/libffi.a cbits/*.o
 
       wasm32-unknown-wasi-clang -Wall -Wextra -mcpu=mvp -Oz -DNDEBUG -Icbits -fPIC -fvisibility=default -shared -Wl,--keep-section=target_features,--strip-debug cbits/*.c -o libffi.so
-      wasm-opt --low-memory-unused -Os libffi.so -o $out/lib/libffi.so
+      wasm-opt --low-memory-unused --debuginfo -Os libffi.so -o $out/lib/libffi.so
     '';
 
   lib-wasm = pkgsBuildBuild.symlinkJoin {


### PR DESCRIPTION
- Remove contradictory -O4 -Oz flags (only the last one takes effect)
- Remove expensive optimization passes (--converge, --gufa, --flatten, --rereloop) that cause slow build times
- Remove --debuginfo as source is compiled without debug info for release build
- Use -Os for balanced size/speed optimization
