### PR TITLE
fix(wasm): correct wasm patch version and wasi-libc reference

### DIFF
--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -344,8 +344,8 @@ in {
 
                 ++ onGhcjs (fromUntil   "9.6.7" "9.7"  ./patches/ghc/ghc-9.6-js-support-this-unit-id-10819.patch)
 
-                ++ onWasm (until                "9.13" ./patches/ghc/ghc-9.12-wasm-shared-libs.patch)
-                ++ onWasm (until                "9.13" ./patches/ghc/ghc-9.12-wasm-keep-cafs.patch)
+                ++ onWasm (fromUntil    "9.12"  "9.13" ./patches/ghc/ghc-9.12-wasm-shared-libs.patch)
+                ++ onWasm (fromUntil    "9.12"  "9.13" ./patches/ghc/ghc-9.12-wasm-keep-cafs.patch)
 
                 # See https://github.com/IntersectMBO/plutus/issues/7415#issuecomment-3531989244
                 ++ fromUntil "9.6" "9.9" ./patches/ghc/ghc-profiling-fix.patch

--- a/overlays/wasm.nix
+++ b/overlays/wasm.nix
@@ -19,8 +19,8 @@ final: prev: prev.lib.optionalAttrs prev.stdenv.targetPlatform.isWasm {
       domain = "gitlab.haskell.org";
       owner = "haskell-wasm";
       repo = "wasi-libc";
-      rev = "16aa8495f039918edb47046b277bf48b516a9776";
-      hash = "sha256-cun3q5OKjryabVhXMNjwQ0bsmz+pS1eCupRP2he+f1k=";
+      rev = "951e93b336cb0ffac3ab2874640b70ed854fdf27";
+      hash = "sha256-8thdYhX4bZuU/CbBNdcab3tUnugaEvI6RDw7im4eeec=";
       fetchSubmodules = true;
     };
     preBuild = ''
@@ -28,6 +28,7 @@ final: prev: prev.lib.optionalAttrs prev.stdenv.targetPlatform.isWasm {
       makeFlagsArray+=(
         "default"
         "libc_so"
+        "CHECK_SYMBOLS=yes"
         )
       export BUILTINS_LIB=$($CC --print-libgcc-file-name)
     '';


### PR DESCRIPTION
Changes
===

* `overlays/bootstrap.nix`: Fix version conditions for GHC 9.12 wasm patches
* `overlays/wasm.nix`: Update wasi-libc commit reference to a valid one

Problem
===

Incorrect patch application conditions.
`ghc-9.12-wasm-shared-libs.patch` and `ghc-9.12-wasm-keep-cafs.patch`
modify files like `utils/jsffi/dyld.mjs` that were added in GHC 9.12.
However, they were configured with until "9.13",
causing them to be applied to GHC 9.10 and earlier where these files don't exist,
resulting in patch failures.

Missing wasi-libc commit.
The commit 16aa8495f039918edb47046b277bf48b516a9776 no longer exists
in the gitlab.haskell.org/haskell-wasm/wasi-libc repository (likely due to a force push),
causing build failures.

Solution
===

* Changed patch conditions from until "9.13" to fromUntil "9.12" "9.13" so patches are only applied to GHC 9.12 and later.
* Updated wasi-libc reference to current master HEAD (951e93b336cb0ffac3ab2874640b70ed854fdf27).
    * New wasm-libc require `CHECK_SYMBOLS=yes`.
