### PR TITLE
Remove deprecated 'pie' hardening flag for musl builds

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -896,8 +896,8 @@ let
       preBuild postBuild
       preInstall postInstall;
   }
-  // lib.optionalAttrs (hardeningDisable != [] || stdenv.hostPlatform.isMusl) {
-    hardeningDisable = hardeningDisable ++ lib.optional stdenv.hostPlatform.isMusl "pie";
+  // lib.optionalAttrs (hardeningDisable != []) {
+    inherit hardeningDisable;
   });
 in drv; in self) {
   inherit componentId

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -689,7 +689,6 @@ haskell-nix.haskellLib.makeCompilerDeps (stdenv.mkDerivation (rec {
 
   hardeningDisable = [ "format" "stackprotector" ]
                    ++ lib.optional stdenv.targetPlatform.isAarch32 "pic"
-                   ++ lib.optional stdenv.targetPlatform.isMusl "pie"
                    ++ lib.optional enableDWARF "fortify";
 
   postInstall = lib.optionalString (enableNUMA && targetPlatform.isLinux && !targetPlatform.isAarch32 && !targetPlatform.isAndroid) ''


### PR DESCRIPTION
## Summary

The `nixpkgs-unstable` revision pinned by haskell.nix ([NixOS/nixpkgs@`c1cb7d0`](https://github.com/NixOS/nixpkgs/commit/c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce)) removed `pie` from the hardening system entirely. PIE is now enabled by default in compilers and no longer managed through hardening flags. Any mention of `"pie"` in either `hardeningEnable` or `hardeningDisable` triggers a deprecation warning:

> The 'pie' hardening flag has been removed in favor of enabling PIE by default in compilers and should no longer be used. PIE can be disabled with the -no-pie compiler flag, but this is usually not necessary as most build systems pass this if needed. Usage of the 'pie' hardening flag will become an error in future.

([`make-derivation.nix` lines 635-636](https://github.com/NixOS/nixpkgs/blob/c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce/pkgs/stdenv/generic/make-derivation.nix#L635-L636))

haskell.nix adds `"pie"` to `hardeningDisable` for musl builds in two places:

- [`builder/comp-builder.nix` line 900](https://github.com/input-output-hk/haskell.nix/blob/1687fd6351aafed2d0a27328a04f1bc771818b43/builder/comp-builder.nix#L900) -- every Haskell component on musl
- [`compiler/ghc/default.nix` line 692](https://github.com/input-output-hk/haskell.nix/blob/1687fd6351aafed2d0a27328a04f1bc771818b43/compiler/ghc/default.nix#L692) -- GHC itself on musl targets

This causes ~68 deprecation warnings per evaluation for any project using `crossPlatforms` with musl64 or aarch64-multiplatform-musl.

## Why this is safe to remove

The removal is a no-op with respect to build behavior:

1. **`pie` is no longer a known hardening flag.** It was removed from `knownHardeningFlags` in [`make-derivation.nix` lines 142-162](https://github.com/NixOS/nixpkgs/blob/c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce/pkgs/stdenv/generic/make-derivation.nix#L142-L162). Listing it in `hardeningDisable` does not disable anything.

2. **The `pie)` case was removed from both `add-hardening.sh` scripts.** Even if `pie` were still propagated, neither wrapper would act on it -- no `-pie`/`-no-pie` flags are injected through the hardening system anymore.
   - [`cc-wrapper/add-hardening.sh`](https://github.com/NixOS/nixpkgs/blob/c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce/pkgs/build-support/cc-wrapper/add-hardening.sh) -- no `pie)` case
   - [`bintools-wrapper/add-hardening.sh`](https://github.com/NixOS/nixpkgs/blob/c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce/pkgs/build-support/bintools-wrapper/add-hardening.sh) -- no `pie)` case

3. **PIE is now a compiler default.** GCC and Clang enable PIE by default on supported platforms. Build systems that need to disable it pass `-no-pie` directly. The hardening system is no longer involved.

In short: `hardeningDisable = [...] ++ ["pie"]` was already a no-op -- its only observable effect was producing the deprecation warning. Removing it silences the warning without changing any build flags.

## Changes

- [`builder/comp-builder.nix`](https://github.com/input-output-hk/haskell.nix/blob/1687fd6351aafed2d0a27328a04f1bc771818b43/builder/comp-builder.nix#L899-L901): Remove the musl-specific `"pie"` append and simplify the `optionalAttrs` condition
- [`compiler/ghc/default.nix`](https://github.com/input-output-hk/haskell.nix/blob/1687fd6351aafed2d0a27328a04f1bc771818b43/compiler/ghc/default.nix#L690-L693): Remove the `++ lib.optional stdenv.targetPlatform.isMusl "pie"` line