### PR TITLE
Update nixpkgs-unstable and nixpkgs-2511, fix deprecation warnings

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -896,8 +896,8 @@ let
       preBuild postBuild
       preInstall postInstall;
   }
-  // lib.optionalAttrs (hardeningDisable != []) {
-    inherit hardeningDisable;
+  // lib.optionalAttrs (hardeningDisable != [] || (stdenv.hostPlatform.isMusl && builtins.elem "pie" (stdenv.cc.defaultHardeningFlags or []))) {
+    hardeningDisable = hardeningDisable ++ lib.optional (stdenv.hostPlatform.isMusl && builtins.elem "pie" (stdenv.cc.defaultHardeningFlags or [])) "pie";
   });
 in drv; in self) {
   inherit componentId

--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -896,8 +896,8 @@ let
       preBuild postBuild
       preInstall postInstall;
   }
-  // lib.optionalAttrs (hardeningDisable != [] || stdenv.hostPlatform.isMusl) {
-    hardeningDisable = hardeningDisable ++ lib.optional stdenv.hostPlatform.isMusl "pie";
+  // lib.optionalAttrs (hardeningDisable != []) {
+    inherit hardeningDisable;
   });
 in drv; in self) {
   inherit componentId

--- a/builder/default.nix
+++ b/builder/default.nix
@@ -43,7 +43,7 @@ let
     inherit lib ghc haskellLib;
     inherit (pkgs) stdenv;
     inherit (buildPackages.buildPackages) runCommand makeWrapper;
-    inherit (buildPackages.buildPackages.xorg) lndir;
+    lndir = buildPackages.buildPackages.lndir or buildPackages.buildPackages.xorg.lndir;
   };
 
   # Builds a derivation which contains a ghc package-db of

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -49,8 +49,14 @@ let self =
 , enableIPE ? false
 
 , enableTerminfo ? !stdenv.targetPlatform.isAndroid &&
+    # Before https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13932,
+    # hadrian can't build terminfo correctly for cross-compilation (it
+    # passes the same --with-curses-libraries to both stage0 and stage1,
+    # but they need different ncurses for their respective platforms).
+    (builtins.compareVersions ghc-version "9.15" >= 0
+      || (stdenv.buildPlatform.config == stdenv.hostPlatform.config && stdenv.hostPlatform.config == stdenv.targetPlatform.config))
     # Terminfo does not work on older ghc cross arm and windows compilers
-     (!haskell-nix.haskellLib.isCrossTarget || !(stdenv.targetPlatform.isAarch32 || stdenv.targetPlatform.isAarch64 || stdenv.targetPlatform.isWindows) || builtins.compareVersions ghc-version "8.10" >= 0)
+    && (!haskell-nix.haskellLib.isCrossTarget || !(stdenv.targetPlatform.isAarch32 || stdenv.targetPlatform.isAarch64 || stdenv.targetPlatform.isWindows) || builtins.compareVersions ghc-version "8.10" >= 0)
 
 , # Whether to build in NUMA support
   enableNUMA ? true
@@ -251,7 +257,7 @@ let
   # `--with` flags for libraries needed for RTS linker
   configureFlags = [
         "--datadir=$doc/share/doc/ghc"
-    ] ++ lib.optionals (!targetPlatform.isGhcjs && !targetPlatform.isWasm && !targetPlatform.isAndroid) ["--with-curses-includes=${lib.getDev targetPackages.ncurses}/include" "--with-curses-libraries=${lib.getLib targetPackages.ncurses}/lib"
+    ] ++ lib.optionals (enableTerminfo && !targetPlatform.isGhcjs && !targetPlatform.isWasm && !targetPlatform.isAndroid) ["--with-curses-includes=${lib.getDev targetPackages.ncurses}/include" "--with-curses-libraries=${lib.getLib targetPackages.ncurses}/lib"
     ] ++ lib.optionals (targetLibffi != null && !targetPlatform.isGhcjs && !targetPlatform.isWasm) ["--with-system-libffi" "--with-ffi-includes=${lib.getDev targetLibffi}/include" "--with-ffi-libraries=${lib.getLib targetLibffi}/lib"
     ] ++ lib.optionals (targetPlatform.isWasm) [
         "--with-system-libffi"
@@ -292,7 +298,9 @@ let
     ;
 
   # Splicer will pull out correct variations
-  libDeps = platform: lib.optionals (enableTerminfo && !targetPlatform.isGhcjs && !targetPlatform.isWasm && !targetPlatform.isAndroid) [ (lib.getLib targetPackages.ncurses) (lib.getDev targetPackages.ncurses) ]
+  # Always include ncurses in libDeps because hadrian builds terminfo
+  # unconditionally for stage0 regardless of enableTerminfo.
+  libDeps = platform: lib.optionals (!targetPlatform.isGhcjs && !targetPlatform.isWasm && !targetPlatform.isAndroid) [ (lib.getLib targetPackages.ncurses) (lib.getDev targetPackages.ncurses) ]
     ++ lib.optional (!targetPlatform.isGhcjs) targetLibffi
     ++ lib.optional (!enableIntegerSimple && !targetPlatform.isGhcjs && !targetPlatform.isWasm) gmp
     ++ lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows && !targetPlatform.isWasm) libiconv

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -689,7 +689,6 @@ haskell-nix.haskellLib.makeCompilerDeps (stdenv.mkDerivation (rec {
 
   hardeningDisable = [ "format" "stackprotector" ]
                    ++ lib.optional stdenv.targetPlatform.isAarch32 "pic"
-                   ++ lib.optional stdenv.targetPlatform.isMusl "pie"
                    ++ lib.optional enableDWARF "fortify";
 
   postInstall = lib.optionalString (enableNUMA && targetPlatform.isLinux && !targetPlatform.isAarch32 && !targetPlatform.isAndroid) ''

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -689,6 +689,7 @@ haskell-nix.haskellLib.makeCompilerDeps (stdenv.mkDerivation (rec {
 
   hardeningDisable = [ "format" "stackprotector" ]
                    ++ lib.optional stdenv.targetPlatform.isAarch32 "pic"
+                   ++ lib.optional (stdenv.targetPlatform.isMusl && builtins.elem "pie" (targetCC.defaultHardeningFlags or [])) "pie"
                    ++ lib.optional enableDWARF "fortify";
 
   postInstall = lib.optionalString (enableNUMA && targetPlatform.isLinux && !targetPlatform.isAarch32 && !targetPlatform.isAndroid) ''

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -499,14 +499,18 @@ haskell-nix.haskellLib.makeCompilerDeps (stdenv.mkDerivation (rec {
     '' + (
       # Including AR and RANLIB here breaks tests.js-template-haskell for GHC <9.12
       # `LLVM ERROR: malformed uleb128, extends past end`
-      if builtins.compareVersions ghc-version "9.12" >= 0
+      let emnm =
+        if builtins.pathExists (targetCC + "/share/emscripten/emnm")
+        then "${targetCC}/share/emscripten/emnm"
+        else "${targetCC}/share/emscripten/tools/emnm.py";
+      in if builtins.compareVersions ghc-version "9.12" >= 0
         then ''
           export AR="${targetCC}/bin/emar"
-          export NM="${targetCC}/share/emscripten/emnm"
+          export NM="${emnm}"
           export RANLIB="${targetCC}/bin/emranlib"
         ''
         else ''
-          export NM="${targetCC}/share/emscripten/emnm"
+          export NM="${emnm}"
         ''
     ) + ''
         export EM_CACHE=$(mktemp -d)

--- a/compiler/ghc/source-dist.nix
+++ b/compiler/ghc/source-dist.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
 
     name = "ghc-source-dist";
 
-    buildInputs = [ ghc alex happy hscolour ] ++ (with pkgs; [ automake bash git cacert python3 autoconf xorg.lndir ]);
+    buildInputs = [ ghc alex happy hscolour ] ++ (with pkgs; [ automake bash git cacert python3 autoconf (pkgs.lndir or xorg.lndir) ]);
 
     inherit src;
 

--- a/compiler/ghcjs/ghcjs.nix
+++ b/compiler/ghcjs/ghcjs.nix
@@ -205,7 +205,7 @@ let
       in pkgs.stdenv.mkDerivation {
         name = "${compilerName}-${ghcVersion}-bundle";
         src = booted-ghcjs;
-        nativeBuildInputs = [ pkgs.makeWrapper pkgs.xorg.lndir ];
+        nativeBuildInputs = [ pkgs.makeWrapper (pkgs.lndir or pkgs.xorg.lndir) ];
         dontConfigure = true;
         dontInstall = true;
         dontPatchShebangs = true;

--- a/flake.lock
+++ b/flake.lock
@@ -484,11 +484,11 @@
     },
     "nixpkgs-2511": {
       "locked": {
-        "lastModified": 1764572236,
-        "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
+        "lastModified": 1775749320,
+        "narHash": "sha256-msT6frWJSQ2WR+0cpk+KPcZdLTLagUIsJwQwIX9JNSo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0924ea1889b366de6bb0018a9db70b2c43a15f8",
+        "rev": "74b87959b2d16f59f54d8559cf3cf26b9d907949",
         "type": "github"
       },
       "original": {
@@ -500,11 +500,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1764587062,
-        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "github"
       },
       "original": {

--- a/lib/call-stack-to-nix.nix
+++ b/lib/call-stack-to-nix.nix
@@ -48,7 +48,7 @@ let
   } // evalPackages.lib.optionalAttrs (checkMaterialization != null) {
     inherit checkMaterialization;
   }) (runCommand (if name == null then "stack-to-nix-pkgs" else name + "-stack-to-nix-pkgs") {
-    nativeBuildInputs = [ nix-tools evalPackages.nix-prefetch-git evalPackages.cacert evalPackages.xorg.lndir ];
+    nativeBuildInputs = [ nix-tools evalPackages.nix-prefetch-git evalPackages.cacert (evalPackages.lndir or evalPackages.xorg.lndir) ];
     # Needed or stack-to-nix will die on unicode inputs
     LOCALE_ARCHIVE = evalPackages.lib.optionalString (evalPackages.stdenv.hostPlatform.libc == "glibc") "${evalPackages.glibcLocales}/lib/locale/locale-archive";
     LANG = "en_US.UTF-8";

--- a/lib/check.nix
+++ b/lib/check.nix
@@ -39,7 +39,7 @@ in stdenv.mkDerivation ((
   meta = builtins.removeAttrs drv.meta ["mainProgram"];
 
   nativeBuildInputs = drv.nativeBuildInputs
-    ++ [pkgsBuildBuild.xorg.lndir]
+    ++ [(pkgsBuildBuild.lndir or pkgsBuildBuild.xorg.lndir)]
     ++ lib.optional (stdenv.hostPlatform.isGhcjs) pkgsBuildBuild.nodejs;
 
   inherit (component) doCheck doCrossCheck;

--- a/lib/ghcjs-project.nix
+++ b/lib/ghcjs-project.nix
@@ -84,7 +84,7 @@ let
             # TODO reinstate the pin of find a work around for ghcjs to send TH splice in chunks.
             nodejs-18_x
             makeWrapper
-            xorg.lndir
+            (pkgs.buildPackages.lndir or xorg.lndir)
             gmp
             (pkgs.buildPackages.pkg-config or pkgconfig)
         ]

--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -15,6 +15,94 @@ pkgs:
           (name: optionals (x ? ${name})
             (let p = __tryEval (x.${name}); in optional p.success p.value))
           names));
+
+    # Prefer the new package name when available, fall back to old name
+    # for backwards compatibility with older nixpkgs.
+    prefer = new: old: if pkgs ? ${new} then new else old;
+
+    # Compatibility set for the deprecated xorg.* package set.
+    # New nixpkgs promotes xorg packages to top-level with new names.
+    # This set maps old xorg attribute names to the new top-level packages,
+    # falling back to pkgs.xorg for older nixpkgs.
+    xorgCompat = let
+      xorg = pkgs.xorg or {};
+      renames = {
+      fontutil = "font-util";
+      libFS = "libfs";
+      libICE = "libice";
+      libSM = "libsm";
+      libWindowsWM = "libwindowswm";
+      libX11 = "libx11";
+      libXScrnSaver = "libxscrnsaver";
+      libXTrap = "libxtrap";
+      libXau = "libxau";
+      libXaw = "libxaw";
+      libXaw3d = "libxaw3d";
+      libXcomposite = "libxcomposite";
+      libXcursor = "libxcursor";
+      libXdamage = "libxdamage";
+      libXdmcp = "libxdmcp";
+      libXext = "libxext";
+      libXfixes = "libxfixes";
+      libXfont = "libxfont_1";
+      libXfont2 = "libxfont_2";
+      libXft = "libxft";
+      libXi = "libxi";
+      libXinerama = "libxinerama";
+      libXmu = "libxmu";
+      libXp = "libxp";
+      libXpm = "libxpm";
+      libXpresent = "libxpresent";
+      libXrandr = "libxrandr";
+      libXrender = "libxrender";
+      libXres = "libxres";
+      libXt = "libxt";
+      libXtst = "libxtst";
+      libXv = "libxv";
+      libXvMC = "libxvmc";
+      libXxf86dga = "libxxf86dga";
+      libXxf86misc = "libxxf86misc";
+      libXxf86vm = "libxxf86vm";
+      libdmx = "libdmx";
+      libfontenc = "libfontenc";
+      libpciaccess = "libpciaccess";
+      libpthreadstubs = "libpthread-stubs";
+      libxcb = "libxcb";
+      libxcvt = "libxcvt";
+      libxkbfile = "libxkbfile";
+      libxshmfence = "libxshmfence";
+      lndir = "lndir";
+      pixman = "pixman";
+      utilmacros = "util-macros";
+      xbitmaps = "xbitmaps";
+      xcbproto = "xcb-proto";
+      xcbutil = "libxcb-util";
+      xcbutilcursor = "libxcb-cursor";
+      xcbutilerrors = "libxcb-errors";
+      xcbutilimage = "libxcb-image";
+      xcbutilkeysyms = "libxcb-keysyms";
+      xcbutilrenderutil = "libxcb-render-util";
+      xcbutilwm = "libxcb-wm";
+      xf86inputevdev = "xf86-input-evdev";
+      xf86inputjoystick = "xf86-input-joystick";
+      xf86inputlibinput = "xf86-input-libinput";
+      xf86inputmouse = "xf86-input-mouse";
+      xf86inputsynaptics = "xf86-input-synaptics";
+      xkbcomp = "xkbcomp";
+      xkeyboardconfig = "xkeyboard-config";
+      xlibsWrapper = "xlibsWrapper";
+      xorgproto = "xorgproto";
+      xorgserver = "xorg-server";
+      xorgsgmldoctools = "xorg-sgml-doctools";
+      xtrans = "xtrans";
+      };
+    in xorg // builtins.listToAttrs (builtins.concatMap (entry:
+      let old = entry.name; new = entry.value; in
+      if pkgs ? ${new} then [{ name = old; value = pkgs.${new}; }]
+      else if xorg ? ${old} then [{ name = old; value = xorg.${old}; }]
+      else []
+    ) (lib.mapAttrsToList lib.nameValuePair renames));
+
   in lookupAttrsIn pkgs ({
     # Based on https://github.com/NixOS/cabal2nix/blob/11c68fdc79461fb74fa1dfe2217c3709168ad752/src/Distribution/Nixpkgs/Haskell/FromCabal/Name.hs#L23
 
@@ -1174,7 +1262,7 @@ pkgs:
 #    "osi" = [ "clp" ];
     "osi-clp" = [ "clp" ];
 #    "osi-unittests" = [ "clp" ];
-    "libclucene-core" = [ "clucene_core_2" ];
+    "libclucene-core" = [ (prefer "clucene-core_2" "clucene_core_2") ];
     "clustalo" = [ "clustal-omega" ];
     "cally-1.0" = [ "clutter" ];
     "clutter-1.0" = [ "clutter" ];
@@ -1422,7 +1510,7 @@ pkgs:
     "enca" = [ "enca" ];
 #    "enchant-2" = [ "enchant" ];
 #    "enchant" = [ "enchant1" ];
-    "enchant-2" = [ "enchant2" ];
+    "enchant-2" = [ (prefer "enchant_2" "enchant2") ];
     "libenet" = [ "enet" ];
     "ecore-audio" = [ "enlightenment" ];
     "ecore-con" = [ "enlightenment" ];
@@ -1517,7 +1605,7 @@ pkgs:
 #    "gamin" = [ "fam" ];
     "farstream-0.2" = [ "farstream" ];
     "fast-cpp-csv-parser" = [ "fast-cpp-csv-parser" ];
-    "libfastjson" = [ "fastJson" ];
+    "libfastjson" = [ (prefer "libfastjson" "fastJson") ];
     "fasttext" = [ "fasttext" ];
     "FAudio" = [ "faudio" ];
     "fcft" = [ "fcft" ];
@@ -1723,7 +1811,7 @@ pkgs:
     "glew" = [ "glew" ];
 #    "glew" = [ "glew-egl" ];
 #    "glew" = [ "glew110" ];
-    "glewmx" = [ "glew110" ];
+    "glewmx" = [ (prefer "glew_1_10" "glew110") ];
 #    "glfw3" = [ "glfw" ];
 #    "glfw3" = [ "glfw-wayland" ];
     "libglfw" = [ "glfw2" ];
@@ -1936,9 +2024,9 @@ pkgs:
     "gobject-introspection-no-export-1.0" = [ "gobject-introspection" ];
     "libgoffice-0.10" = [ "goffice" ];
     "gom-1.0" = [ "gom" ];
-    "goocanvas" = [ "goocanvas" ];
-    "goocanvas-2.0" = [ "goocanvas2" ];
-    "goocanvas-3.0" = [ "goocanvas3" ];
+    "goocanvas" = [ (prefer "goocanvas_1" "goocanvas") ];
+    "goocanvas-2.0" = [ (prefer "goocanvas_2" "goocanvas2") ];
+    "goocanvas-3.0" = [ (prefer "goocanvas_3" "goocanvas3") ];
     "goocanvasmm-2.0" = [ "goocanvasmm2" ];
     "googleapis" = [ "google-cloud-cpp" ];
     "google_cloud_cpp_api_annotations_protos" = [ "google-cloud-cpp" ];
@@ -2208,7 +2296,7 @@ pkgs:
     "gwengui-gtk3" = [ "gwenhywfar" ];
     "gwengui-qt5" = [ "gwenhywfar" ];
     "gwenhywfar" = [ "gwenhywfar" ];
-    "g-wrap-2.0-guile" = [ "gwrap" ];
+    "g-wrap-2.0-guile" = [ (prefer "g-wrap" "gwrap") ];
     "gwyddion" = [ "gwyddion" ];
     "libh2o-evloop" = [ "h2o" ];
     "libh2o" = [ "h2o" ];
@@ -2455,7 +2543,7 @@ pkgs:
     "libdnssec" = [ "knot-dns" ];
     "libknot" = [ "knot-dns" ];
     "libzscanner" = [ "knot-dns" ];
-    "libkres" = [ "knot-resolver" ];
+    "libkres" = [ (prefer "knot-resolver_5" "knot-resolver") ];
 #    "gssrpc" = [ "krb5" ];
 #    "kadm-client" = [ "krb5" ];
 #    "kadm-server" = [ "krb5" ];
@@ -2891,7 +2979,7 @@ pkgs:
 #    "cblas" = [ "liblapack" ];
     "lapacke" = [ "liblapack" ];
     "lapack" = [ "liblapack" ];
-    "libclastfm" = [ "liblastfmSF" ];
+    "libclastfm" = [ (prefer "liblastfm-vambrose" "liblastfmSF") ];
     "liblcf" = [ "liblcf" ];
     "libliftoff" = [ "libliftoff" ];
     "liblo" = [ "liblo" ];
@@ -5285,9 +5373,9 @@ pkgs:
     "unibilium" = [ "unibilium" ];
     "unicorn" = [ "unicorn" ];
     "UnitTest++" = [ "unittest-cpp" ];
-    "odbccr" = [ "unixODBC" ];
-    "odbcinst" = [ "unixODBC" ];
-    "odbc" = [ "unixODBC" ];
+    "odbccr" = [ (prefer "unixodbc" "unixODBC") ];
+    "odbcinst" = [ (prefer "unixodbc" "unixODBC") ];
+    "odbc" = [ (prefer "unixodbc" "unixODBC") ];
     "libcw" = [ "unixcw" ];
     "libunshield" = [ "unshield" ];
     "upower-glib" = [ "upower" ];
@@ -5468,7 +5556,7 @@ pkgs:
     "wolfssl" = [ "wolfssl" ];
 #    "libobs" = [ "wrapOBS" ];
     "wv-1.0" = [ "wv" ];
-    "libwxsvg" = [ "wxSVG" ];
+    "libwxsvg" = [ (prefer "wxsvg" "wxSVG") ];
     "wxsqlite3" = [ "wxsqlite3" ];
     "x264" = [ "x264" ];
     "x265" = [ "x265" ];
@@ -5574,7 +5662,7 @@ pkgs:
     "zziplib" = [ "zziplib" ];
     "zzipmmapped" = [ "zziplib" ];
 } // pkgs.haskell-nix.extraPkgconfigMappings) //
-  lookupAttrsIn pkgs.xorg {
+  lookupAttrsIn xorgCompat {
     # Adding xlibsWrapper since it was used here beofre.
     # Putting libX11 first though so it can be used to get the version
     # in out dummy pkc-config (see ../overlays/cabal-pkg-config.nix)

--- a/lib/system-nixpkgs-map.nix
+++ b/lib/system-nixpkgs-map.nix
@@ -12,7 +12,7 @@ let
     # Find the versions of mcfgthreads used by stdenv.cc
     (pkgs.threadsCrossFor or (_x: { package = pkgs.windows.mcfgthreads; }) pkgs.stdenv.cc.version).package
     # If we just use `pkgs.buildPackages.gcc.cc` here it breaks the `th-dlls` test. TODO figure out why exactly.
-    (pkgs.buildPackages.runCommand "gcc-only" { nativeBuildInputs = [ pkgs.buildPackages.xorg.lndir ]; } ''
+    (pkgs.buildPackages.runCommand "gcc-only" { nativeBuildInputs = [ (pkgs.buildPackages.lndir or pkgs.buildPackages.xorg.lndir) ]; } ''
       mkdir $out
       lndir ${pkgs.buildPackages.gcc.cc} $out
     '')
@@ -45,15 +45,15 @@ in
   GLEW = [ glew ];
   GLU = [ libGLU ];
   alut = [ freealut ];
-  X11 = with xorg; [ libX11 ];
-  Xrandr = [ xorg.libXrandr ];
-  Xrender = [ xorg.libXrender ];
-  Xss = [ xorg.libXScrnSaver ];
-  Xext = [ xorg.libXext ];
-  Xi = [ xorg.libXi ];
-  Xxf86vm = [ xorg.libXxf86vm ];
-  Xcursor = [ xorg.libXcursor ];
-  Xinerama = [ xorg.libXinerama ];
+  X11 = [ (pkgs.libx11 or xorg.libX11) ];
+  Xrandr = [ (pkgs.libxrandr or xorg.libXrandr) ];
+  Xrender = [ (pkgs.libxrender or xorg.libXrender) ];
+  Xss = [ (pkgs.libxscrnsaver or xorg.libXScrnSaver) ];
+  Xext = [ (pkgs.libxext or xorg.libXext) ];
+  Xi = [ (pkgs.libxi or xorg.libXi) ];
+  Xxf86vm = [ (pkgs.libxxf86vm or xorg.libXxf86vm) ];
+  Xcursor = [ (pkgs.libxcursor or xorg.libXcursor) ];
+  Xinerama = [ (pkgs.libxinerama or xorg.libXinerama) ];
   mysqlclient = [ mysql ];
   Imlib2 = [ imlib2 ];
   asound = [ alsaLib ];
@@ -106,7 +106,7 @@ in
   tensorflow = [ libtensorflow ];
   # odbc package requires unixODBC packages to be installed in order to successfully
   # compile C sources (https://github.com/fpco/odbc/blob/master/cbits/odbc.c)
-  odbc = [ unixODBC ];
+  odbc = [ (pkgs.unixodbc or unixODBC) ];
   opencv = [ opencv3 ];
   phonenumber = [ libphonenumber ];
   icuuc = [ icu ];

--- a/modules/configuration-nix.nix
+++ b/modules/configuration-nix.nix
@@ -24,8 +24,8 @@ in addPackageKeys {
   # The `extra-libraries` field in `X11.cabal` does not include Xss and Xinerama
   # see https://github.com/input-output-hk/haskell.nix/pull/988
   packages.X11.components.library.libs = [
-    pkgs.xorg.libXScrnSaver
-    pkgs.xorg.libXinerama
+    (pkgs.libxscrnsaver or pkgs.xorg.libXScrnSaver)
+    (pkgs.libxinerama or pkgs.xorg.libXinerama)
   ];
 
   # odbc needs this package to provide odbcss.h on Linux and macOS, see
@@ -151,11 +151,11 @@ in addPackageKeys {
   ];
 
   packages.bindings-GLFW.components.library.libs = [
-    pkgs.xorg.libXext
+    (pkgs.libxext or pkgs.xorg.libXext)
   ];
 
   packages.GLFW-b.components.library.libs = [
-    pkgs.xorg.libXi
+    (pkgs.libxi or pkgs.xorg.libXi)
   ];
 
   packages.closed.components.tests.readme.build-tools = [

--- a/overlays/android.nix
+++ b/overlays/android.nix
@@ -43,7 +43,7 @@ final: prev: {
     hardeningDisable = [ "fortify" "stackprotector" "format" ];
     configureFlags = old.configureFlags ++ [ "--disable-shared" ];
   });
-  zlib = prev.zlib.override { shared = false; static = true; };
+  zlib = prev.zlib.override { shared = false; };
   # kernel tls (ktls) doesn't work with the android kernel. And will complain
   # about lots of implicitly declared functions and undeclared identifiers,
   # because the android (linux) kernel doesn't expose those.

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -186,6 +186,7 @@ in {
                 ++ onGhcjs (fromUntil "9.6.1" "9.6.3" ./patches/ghc/ghc-9.6-JS-implement-TH-support.patch)
                 ++ onGhcjs (fromUntil "9.6.3" "9.6.7" ./patches/ghc/ghc-9.6.3-JS-implement-TH-support.patch)
                 ++ onGhcjs (fromUntil "9.6.7" "9.8"   ./patches/ghc/ghc-9.6.7-JS-implement-TH-support.patch)
+                ++ fromUntil "9.6.1"  "9.10"   ./patches/ghc/ghc-hp2ps-stdlib.patch
                 ++ fromUntil "9.8.1"  "9.8.2"  ./patches/ghc/ghc-9.8-cabal-c-soures-fix.patch
                 ++ fromUntil "9.6.3"  "9.6.5"  ./patches/ghc/ghc-9.6.3-Cabal-9384.patch
                 ++ fromUntil "9.8.1"  "9.8.3"    ./patches/ghc/ghc-9.6.3-Cabal-9384.patch

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -1340,7 +1340,7 @@ in {
                 ghcVersion = "8.10.7";
                 compiler-nix-name = "ghc8107";
             }; in let targetPrefix = "js-unknown-ghcjs-"; in final.runCommand "${targetPrefix}ghc-8.10.7" {
-                nativeBuildInputs = [ final.xorg.lndir ];
+                nativeBuildInputs = [ (final.lndir or final.xorg.lndir) ];
                 passthru = {
                     inherit targetPrefix;
                     version = "8.10.7";

--- a/overlays/bootstrap.nix
+++ b/overlays/bootstrap.nix
@@ -186,7 +186,11 @@ in {
                 ++ onGhcjs (fromUntil "9.6.1" "9.6.3" ./patches/ghc/ghc-9.6-JS-implement-TH-support.patch)
                 ++ onGhcjs (fromUntil "9.6.3" "9.6.7" ./patches/ghc/ghc-9.6.3-JS-implement-TH-support.patch)
                 ++ onGhcjs (fromUntil "9.6.7" "9.8"   ./patches/ghc/ghc-9.6.7-JS-implement-TH-support.patch)
-                ++ fromUntil "9.6.1"  "9.10"   ./patches/ghc/ghc-hp2ps-stdlib.patch
+                # hp2ps uses K&R-style extern void* malloc() without <stdlib.h>.
+                # GCC 15 treats this as zero-args, causing build failure.
+                # Fixed in 9.10.2 (proper prototype) and 9.12.4+ (<stdlib.h>).
+                ++ until               "9.10.2" ./patches/ghc/ghc-hp2ps-stdlib.patch
+                ++ fromUntil "9.12.1"  "9.12.3" ./patches/ghc/ghc-hp2ps-stdlib.patch
                 ++ fromUntil "9.8.1"  "9.8.2"  ./patches/ghc/ghc-9.8-cabal-c-soures-fix.patch
                 ++ fromUntil "9.6.3"  "9.6.5"  ./patches/ghc/ghc-9.6.3-Cabal-9384.patch
                 ++ fromUntil "9.8.1"  "9.8.3"    ./patches/ghc/ghc-9.6.3-Cabal-9384.patch

--- a/overlays/ghc-packages.nix
+++ b/overlays/ghc-packages.nix
@@ -130,14 +130,14 @@ in rec {
           let nix24srcFix = src: src // { filterPath = { path, ... }: path; };
           # Add in the generated files needed by ghc-boot
           in if subDir == "libraries/ghc-boot"
-            then nix24srcFix (final.buildPackages.runCommand "ghc-boot-src" { nativeBuildInputs = [final.buildPackages.xorg.lndir]; } ''
+            then nix24srcFix (final.buildPackages.runCommand "ghc-boot-src" { nativeBuildInputs = [(final.buildPackages.lndir or final.buildPackages.xorg.lndir)]; } ''
               mkdir $out
               lndir -silent ${ghc.passthru.configured-src}/${subDir} $out
               lndir -silent ${ghc.generated}/libraries/ghc-boot/dist-install/build/GHC $out/GHC
             '') // { srcForCabal2Nix = ghc.passthru.configured-src + "/${subDir}"; }
           else if subDir == "compiler"
             then final.haskell-nix.haskellLib.cleanSourceWith {
-              src = nix24srcFix (final.buildPackages.runCommand "ghc-src" { nativeBuildInputs = [final.buildPackages.xorg.lndir]; } ''
+              src = nix24srcFix (final.buildPackages.runCommand "ghc-src" { nativeBuildInputs = [(final.buildPackages.lndir or final.buildPackages.xorg.lndir)]; } ''
                 mkdir $out
                 lndir -silent ${ghc.passthru.configured-src} $out
                 if [[ -f ${ghc.generated}/libraries/ghc-boot/dist-install/build/GHC/Version.hs ]]; then

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -403,7 +403,7 @@ final: prev: {
               # -----------------------+---------------+------------+
               #
               final.runCommand "dot-cabal" {
-                nativeBuildInputs = [ nix-tools.exes.cabal final.xorg.lndir ] ++ cabal-issue-8352-workaround;
+                nativeBuildInputs = [ nix-tools.exes.cabal (final.lndir or final.xorg.lndir) ] ++ cabal-issue-8352-workaround;
               } ''
                 # prepopulate hackage
                 mkdir -p $out/packages/hackage.haskell.org

--- a/overlays/mingw_w64.nix
+++ b/overlays/mingw_w64.nix
@@ -57,7 +57,7 @@ let
         unset pkgsHostTargetAsString
         unset LINK_DLL_FOLDERS
         WINEDLLOVERRIDES="winemac.drv=d" WINEDEBUG=warn-all,fixme-all,-menubuilder,-mscoree,-ole,-secur32,-winediag WINEPREFIX=$TMP \
-          ${iserv-proxy}/bin/iserv-proxy $@ --pipe ${wine}/bin/wine64 $REMOTE_ISERV/${interpreter.exeName} tmp --stdio ${no-load-call} $ISERV_ARGS
+          ${iserv-proxy}/bin/iserv-proxy $@ --pipe ${lib.getExe wine} $REMOTE_ISERV/${interpreter.exeName} tmp --stdio ${no-load-call} $ISERV_ARGS
       '';
 
   wineIservWrapper = symlinkJoin { name = "iserv-wrapper"; paths = [ (wineIservWrapperScript false) (wineIservWrapperScript true) ]; };
@@ -93,7 +93,7 @@ let
       fi
     done
     export Path
-    ${wine}/bin/wine64 $@
+    ${lib.getExe wine} $@
   '';
   testWrapper = ["${wineTestWrapper}/bin/test-wrapper"];
 

--- a/overlays/musl.nix
+++ b/overlays/musl.nix
@@ -18,8 +18,8 @@ final: prev: prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl ({
         # `isMusl` does not always mean `isStatic`, so setting `enableStatic` to true here.
         enableStatic = true;
       });
-  gmp = prev.gmp.override { withStatic = true; };
-  ncurses = prev.ncurses.override { enableStatic = true; };
+  gmp = (prev.gmp.override { withStatic = true; }).overrideAttrs (_: prev.lib.optionalAttrs (prev.stdenv.hostPlatform != prev.stdenv.buildPlatform) { doCheck = false; });
+  ncurses = (prev.ncurses.override { enableStatic = true; }).overrideAttrs (_: prev.lib.optionalAttrs (prev.stdenv.hostPlatform != prev.stdenv.buildPlatform) { dontCheckForBrokenSymlinks = true; });
   libsodium = prev.libsodium.overrideAttrs (_: { dontDisableStatic = true; });
   zstd = prev.zstd.override { static = true; };
   xz = prev.xz.override { enableStatic = true; };
@@ -57,6 +57,8 @@ final: prev: prev.lib.optionalAttrs prev.stdenv.hostPlatform.isMusl ({
 
   # Fails on cross compile
   nix = prev.nix.overrideAttrs (_: { doInstallCheck = false; });
+  # Cross-compiled test binaries can't run on the build host
+  libffi = prev.libffi.overrideAttrs (_: prev.lib.optionalAttrs (prev.stdenv.hostPlatform != prev.stdenv.buildPlatform) { doCheck = false; });
 } // prev.lib.optionalAttrs (prev.lib.versionAtLeast prev.lib.trivial.release "20.03") {
   # Fix infinite recursion between openssh and fetchcvs
   openssh = prev.openssh.override { withFIDO = false; };

--- a/overlays/patches/ghc/ghc-hp2ps-stdlib.patch
+++ b/overlays/patches/ghc/ghc-hp2ps-stdlib.patch
@@ -1,0 +1,22 @@
+--- a/utils/hp2ps/Utilities.c
++++ b/utils/hp2ps/Utilities.c
+@@ -2,9 +2,8 @@
+ #include <stdio.h>
+ #include <string.h>
+ #include "Error.h"
++#include <stdlib.h>
+
+-extern void* malloc();
+-
+ char*
+ Basename(char *name)
+ {
+@@ -89,8 +88,6 @@
+ xrealloc(void *p, size_t n)
+ {
+     void *r;
+-    extern void *realloc();
+-
+     r = realloc(p, n);
+     if (!r) {
+ 	/*NOTREACHED*/

--- a/overlays/patches/wine-add-dll-directory-11.patch
+++ b/overlays/patches/wine-add-dll-directory-11.patch
@@ -1,0 +1,11 @@
+--- a/dlls/ntdll/loader.c
++++ b/dlls/ntdll/loader.c
+@@ -4713,7 +4713,7 @@
+     struct dll_dir_entry *ptr;
+     RTL_PATH_TYPE type = RtlDetermineDosPathNameType_U( dir->Buffer );
+
+-    if (type != RtlPathTypeRooted && type != RtlPathTypeDriveAbsolute && type != RtlPathTypeUncAbsolute)
++    if (type != RtlPathTypeRooted && type != RtlPathTypeDriveAbsolute && type != RtlPathTypeUncAbsolute && type != RtlPathTypeLocalDevice)
+         return STATUS_INVALID_PARAMETER;
+
+     status = RtlDosPathNameToNtPathName_U_WithStatus( dir->Buffer, &nt_name, NULL, NULL );

--- a/overlays/wasm.nix
+++ b/overlays/wasm.nix
@@ -1,4 +1,23 @@
 final: prev: prev.lib.optionalAttrs prev.stdenv.targetPlatform.isWasm {
+  # Remove lit's max-time.py self-test. It hangs in the nix build sandbox
+  # due to a Python multiprocessing.Pool deadlock (`_help_stuff_finish`
+  # acquires `inqueue._rlock` without releasing it) combined with a leaked
+  # signal mask that leaves SIGTERM blocked in the worker, so `pool.terminate()`
+  # can't kill it. nix-shell builds complete fine; only nix-build hangs.
+  llvmPackages_21 =
+    let
+      f = llvmFinal: llvmPrev: {
+        libllvm = llvmPrev.libllvm.overrideAttrs (old: {
+          postPatch = (old.postPatch or "") + ''
+            rm utils/lit/tests/max-time.py
+          '';
+        });
+      };
+      # Preserve `.override` after `overrideScope`; see nixpkgs#447012.
+      override = args: (prev.llvmPackages_21.override args).overrideScope f;
+    in prev.lib.makeOverridable
+      (prev.lib.mirrorFunctionArgs prev.llvmPackages_21.override override)
+      { };
   llvmPackages = final.llvmPackages_21.override {
     patchesFn = p: p // { "llvm/gnu-install-dirs.patch" = [{path = ./patches/wasm;}]; };
     monorepoSrc =

--- a/overlays/windows.nix
+++ b/overlays/windows.nix
@@ -42,7 +42,7 @@ final: prev:
         import ./mingw_w64.nix {
           inherit (final.stdenv) hostPlatform;
           inherit (final.pkgsBuildBuild) lib writeShellScriptBin;
-          wine = final.pkgsBuildBuild.winePackages.minimal;
+          wine = final.pkgsBuildBuild.wine64Packages.minimal;
           inherit (final.windows) mingw_w64_pthreads;
           inherit (final) gmp;
           inherit (final.pkgsBuildBuild) symlinkJoin;

--- a/overlays/wine.nix
+++ b/overlays/wine.nix
@@ -5,7 +5,9 @@ _final: prev: {
       patches = oldAttrs.patches or []
         ++ [(if builtins.compareVersions prev.winePackages.minimal.version "10.0" < 0
           then ./patches/wine-add-dll-directory.patch
-          else ./patches/wine-add-dll-directory-10.patch)];
+          else if builtins.compareVersions prev.winePackages.minimal.version "11.0" < 0
+          then ./patches/wine-add-dll-directory-10.patch
+          else ./patches/wine-add-dll-directory-11.patch)];
       # Avoid dependency on X11
       configureFlags = oldAttrs.configureFlags or [] ++ [ "--without-x" ];
     });

--- a/overlays/wine.nix
+++ b/overlays/wine.nix
@@ -12,4 +12,17 @@ _final: prev: {
       configureFlags = oldAttrs.configureFlags or [] ++ [ "--without-x" ];
     });
   };
+  wine64Packages = prev.wine64Packages // {
+    minimal = prev.wine64Packages.minimal.overrideAttrs (oldAttrs: {
+      # Fix issue with UNC device file paths
+      patches = oldAttrs.patches or []
+        ++ [(if builtins.compareVersions prev.wine64Packages.minimal.version "10.0" < 0
+          then ./patches/wine-add-dll-directory.patch
+          else if builtins.compareVersions prev.wine64Packages.minimal.version "11.0" < 0
+          then ./patches/wine-add-dll-directory-10.patch
+          else ./patches/wine-add-dll-directory-11.patch)];
+      # Avoid dependency on X11
+      configureFlags = oldAttrs.configureFlags or [] ++ [ "--without-x" ];
+    });
+  };
 }


### PR DESCRIPTION
Update nixpkgs-unstable and nixpkgs-2511 pins and fix the resulting evaluation warnings for deprecated package names. Uses backwards-compatible fallback patterns so older nixpkgs still works:

- Replace xorg.* references with (pkgs.newName or pkgs.xorg.oldName)
- Add xorgCompat set in pkgconf-nixpkgs-map.nix to map deprecated xorg attribute names to their new top-level equivalents
- Update renamed packages (enchant2, unixODBC, goocanvas, etc.) using a prefer helper that selects the new name when available