### PR TITLE
Optimize evaluation performance: uniqueWithName, checkUnique, planned.nix, load-cabal-plan

### DIFF
--- a/builder/make-config-files.nix
+++ b/builder/make-config-files.nix
@@ -51,12 +51,16 @@ let
       + lib.optionalString (__compareVersions ghc.version "9.6.1" >= 0) "/lib");
   packageCfgDir  = "${libDir}/package.conf.d";
 
+  # Fused single-pass: dependToLib → profiled → dwarf → chooseDrv.
+  # Nix does not perform list fusion, so chaining four `map` calls
+  # allocates four intermediate lists.  A single `map` avoids this.
   libDeps = haskellLib.uniqueWithName (
-    map chooseDrv (
-      (if enableDWARF then (x: map (p: p.dwarf or p) x) else x: x)
-      ((if needsProfiling then (x: map (p: p.profiled or p) x) else x: x)
-      (map haskellLib.dependToLib component.depends))
-    )
+    map (d:
+      let base = haskellLib.dependToLib d;
+          prof = if needsProfiling then base.profiled or base else base;
+          dw   = if enableDWARF then prof.dwarf or prof else prof;
+      in chooseDrv dw
+    ) component.depends
   ) ++ prebuilt-depends;
   script = ''
     ${target-pkg} init $configFiles/${packageCfgDir}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -611,16 +611,33 @@ in {
   # How to run ldd when checking for static linking
   lddForTests = "${pkgs.pkgsBuildBuild.glibc.bin}/bin/ldd";
 
-  # Deduplicate a list of derivations (or other values) by `.name`.
-  # Uses `builtins.listToAttrs` (O(n log n) in C++) instead of the
-  # previous `groupBy` + `lib.unique` approach which was O(n²) when
-  # names collided.  First occurrence wins.
+  # Like `lib.unique`, but uses an item's name as a partition key so that
+  # `lib.unique` only has to scan within each name bucket -- the common case
+  # being one item per name, where this collapses to an O(n) walk.
+  #
+  # Originally written for derivations, whose `.name` already encodes
+  # name+version (e.g. `ghc984-conduit-1.3.5.0`).  haskell.nix package
+  # values don't carry `.name` -- they expose `.identifier.{name,version}`
+  # instead -- so we synthesize a key from those, with a space separator
+  # rather than the derivation `"${name}-${version}"` shape so a derivation
+  # key can never collide with a package key derived from the same words.
+  # Items with neither attribute share a single bucket (still correct via
+  # the inner `lib.unique`, just slower).
+  #
+  # Crucially, items that share a key but differ structurally must both
+  # survive -- this matches `lib.unique` semantics.  The bucket is an
+  # optimization, not a truncation.
   uniqueWithName = list:
-    builtins.attrValues (builtins.listToAttrs (
-      map (x: {
-        name = if __typeOf x == "set" then x.name or "noname" else "notset";
-        value = x;
-      }) list));
+    let
+      keyOf = x:
+        if __typeOf x != "set" then "_notset"
+        else if x ? name then x.name
+        else if x ? identifier.name
+          then "${x.identifier.name} ${x.identifier.version or ""}"
+        else "_noname";
+    in
+      lib.concatMap lib.unique
+        (builtins.attrValues (builtins.groupBy keyOf list));
 
   # Assert that each item in the list has a unique name.
   # Uses a single `groupBy` to find duplicates rather than

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -611,19 +611,28 @@ in {
   # How to run ldd when checking for static linking
   lddForTests = "${pkgs.pkgsBuildBuild.glibc.bin}/bin/ldd";
 
-  # Version of `lib.unique` that should be fast if the name attributes are unique
+  # Deduplicate a list of derivations (or other values) by `.name`.
+  # Uses `builtins.listToAttrs` (O(n log n) in C++) instead of the
+  # previous `groupBy` + `lib.unique` approach which was O(n²) when
+  # names collided.  First occurrence wins.
   uniqueWithName = list:
-    lib.concatMap lib.unique (
-      builtins.attrValues (
-        builtins.groupBy (x: if __typeOf x == "set" then x.name or "noname" else "notset") list));
+    builtins.attrValues (builtins.listToAttrs (
+      map (x: {
+        name = if __typeOf x == "set" then x.name or "noname" else "notset";
+        value = x;
+      }) list));
 
-  # Assert that each item in the list is unique
+  # Assert that each item in the list has a unique name.
+  # Uses a single `groupBy` to find duplicates rather than
+  # re-running `uniqueWithName` and comparing lengths.
   checkUnique = msg: x:
-    if __length x == __length (uniqueWithName x)
+    let grouped = builtins.groupBy
+          (x: if __typeOf x == "set" then x.name or "noname" else "notset") x;
+        dupes = lib.filterAttrs (_: v: __length v > 1) grouped;
+    in if dupes == {}
       then x
       else builtins.throw "Duplicate items found in ${msg} ${
-        __toJSON (__attrNames (lib.filterAttrs (_: v: __length v > 1) (
-          builtins.groupBy (x: if __typeOf x == "set" then x.name or "noname" else "notset") x)))
+        __toJSON (__attrNames dupes)
       }";
 
   types = import ./types.nix { inherit lib; };

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -611,46 +611,62 @@ in {
   # How to run ldd when checking for static linking
   lddForTests = "${pkgs.pkgsBuildBuild.glibc.bin}/bin/ldd";
 
-  # Like `lib.unique`, but uses an item's name as a partition key so that
-  # `lib.unique` only has to scan within each name bucket -- the common case
-  # being one item per name, where this collapses to an O(n) walk.
+  # Key used by `uniqueWithName` and `checkUnique` to partition lists.
+  # Derivations carry a name+version-encoded `.name`
+  # (e.g. `ghc984-conduit-1.3.5.0`).  haskell.nix package values don't --
+  # they expose `.identifier.{name,version}` -- so we synthesize a key
+  # with a space separator rather than the derivation `"${name}-${version}"`
+  # shape, so a derivation key can never collide with a package key derived
+  # from the same words.  Items with neither share a bucket; correctness
+  # still holds via the inner `lib.unique`, just at a slower path.
+  uniqueWithNameKey = x:
+    if __typeOf x != "set" then "_notset"
+    else if x ? name then x.name
+    else if x ? identifier.name
+      then "${x.identifier.name} ${x.identifier.version or ""}"
+    else "_noname";
+
+  # Like `lib.unique`, but uses `uniqueWithNameKey` as a partition key so
+  # `lib.unique` only has to scan within each bucket -- the common case
+  # being one item per key, where this collapses to an O(n) walk.
   #
-  # Originally written for derivations, whose `.name` already encodes
-  # name+version (e.g. `ghc984-conduit-1.3.5.0`).  haskell.nix package
-  # values don't carry `.name` -- they expose `.identifier.{name,version}`
-  # instead -- so we synthesize a key from those, with a space separator
-  # rather than the derivation `"${name}-${version}"` shape so a derivation
-  # key can never collide with a package key derived from the same words.
-  # Items with neither attribute share a single bucket (still correct via
-  # the inner `lib.unique`, just slower).
-  #
-  # Crucially, items that share a key but differ structurally must both
-  # survive -- this matches `lib.unique` semantics.  The bucket is an
+  # Items that share a key but differ structurally must both survive
+  # -- this matches `lib.unique` semantics.  The bucket is an
   # optimization, not a truncation.
   uniqueWithName = list:
-    let
-      keyOf = x:
-        if __typeOf x != "set" then "_notset"
-        else if x ? name then x.name
-        else if x ? identifier.name
-          then "${x.identifier.name} ${x.identifier.version or ""}"
-        else "_noname";
-    in
-      lib.concatMap lib.unique
-        (builtins.attrValues (builtins.groupBy keyOf list));
+    lib.concatMap lib.unique
+      (builtins.attrValues (builtins.groupBy uniqueWithNameKey list));
 
-  # Assert that each item in the list has a unique name.
-  # Uses a single `groupBy` to find duplicates rather than
-  # re-running `uniqueWithName` and comparing lengths.
+  # Check that items in `x` are "sufficiently" unique by `uniqueWithNameKey`.
+  # Errors when two items share a key AND are structurally identical -- a
+  # genuine redundant duplicate that `lib.unique` would collapse, and that
+  # almost never reflects intent.
+  # Warns (but passes) when items share a key but differ structurally --
+  # typically a list-merge accident where an explicit override appended to
+  # a default rather than replacing it (use `lib.mkForce`).  Master's
+  # `checkUnique` allowed this silently; bd93f01d3 unintentionally tightened
+  # it to an error; we keep master's tolerance but flag it for visibility.
   checkUnique = msg: x:
-    let grouped = builtins.groupBy
-          (x: if __typeOf x == "set" then x.name or "noname" else "notset") x;
-        dupes = lib.filterAttrs (_: v: __length v > 1) grouped;
-    in if dupes == {}
-      then x
-      else builtins.throw "Duplicate items found in ${msg} ${
-        __toJSON (__attrNames dupes)
-      }";
+    let
+      grouped = builtins.groupBy uniqueWithNameKey x;
+      # `lib.unique` would shrink the bucket -> structurally-identical dupes.
+      structuralDupes = lib.filterAttrs
+        (_: v: __length (lib.unique v) < __length v) grouped;
+      # >1 entries that survive `lib.unique` -> distinct items sharing a key.
+      nameOnlyDupes = lib.filterAttrs
+        (_: v: __length v > 1 && __length (lib.unique v) == __length v) grouped;
+    in
+      if structuralDupes != {}
+        then builtins.throw "Duplicate items found in ${msg} ${
+          __toJSON (__attrNames structuralDupes)
+        }"
+      else if nameOnlyDupes != {}
+        then builtins.trace
+          "warning: items in ${msg} share a name but differ structurally (likely a list-merge that should use lib.mkForce): ${
+            __toJSON (__attrNames nameOnlyDupes)
+          }"
+          x
+      else x;
 
   types = import ./types.nix { inherit lib; };
 

--- a/lib/load-cabal-plan.nix
+++ b/lib/load-cabal-plan.nix
@@ -215,7 +215,7 @@ in {
     (import ../modules/install-plan/configure-args.nix)
     (import ../modules/install-plan/non-reinstallable.nix)
     (import ../modules/install-plan/override-package-by-name.nix)
-    (import ../modules/install-plan/planned.nix { inherit getComponents; })
+    (import ../modules/install-plan/planned.nix)
     (import ../modules/install-plan/redirect.nix)
   ];
 }

--- a/lib/load-cabal-plan.nix
+++ b/lib/load-cabal-plan.nix
@@ -18,11 +18,17 @@ let
 
   # Single-pass categorization via builtins.groupBy (runs in C++, O(n log k)).
   # Replaces three separate concatMap+optional filters over the full plan.
+  # The buckets match what the previous filter expressions accepted exactly.
+  # Anything outside that set (e.g. a future cabal type/style we don't yet
+  # recognize) throws rather than being silently dropped or misclassified
+  # as a global hackage package -- silent drops were a footgun that hid
+  # genuinely unhandled plan shapes.
   partitioned = let
     grouped = builtins.groupBy (p:
       if p.type == "pre-existing" then "preExisting"
       else if p.type == "configured" && p.style == "local" then "local"
-      else "nonLocal"
+      else if p.type == "configured" && (p.style == "global" || p.style == "inplace") then "nonLocal"
+      else throw "load-cabal-plan: unexpected install-plan entry ${p.id or "<no id>"}: type=${p.type or "<unset>"} style=${p.style or "<unset>"}"
     ) plan-json.install-plan;
   in {
     preExisting = grouped.preExisting or [];

--- a/lib/load-cabal-plan.nix
+++ b/lib/load-cabal-plan.nix
@@ -15,17 +15,39 @@ let
       else callProjectResults.rawCabalProjectContext + s;
   # All the units in the plan indexed by unit ID.
   by-id = pkgs.lib.listToAttrs (map (x: { name = x.id; value = x; }) plan-json.install-plan);
-  # Find the names of all the pre-existing packages used by a list of dependencies
-  # (includes transitive dependencies)
-  lookupPreExisting = depends:
-    pkgs.lib.concatMap (d: builtins.attrNames pre-existing-depends.${d}) depends;
+
+  # Single-pass categorization via builtins.groupBy (runs in C++, O(n log k)).
+  # Replaces three separate concatMap+optional filters over the full plan.
+  partitioned = let
+    grouped = builtins.groupBy (p:
+      if p.type == "pre-existing" then "preExisting"
+      else if p.type == "configured" && p.style == "local" then "local"
+      else "nonLocal"
+    ) plan-json.install-plan;
+  in {
+    preExisting = grouped.preExisting or [];
+    nonLocal = grouped.nonLocal or [];
+    local = grouped.local or [];
+  };
+
+  # Memoized transitive pre-existing dependency lookup.
+  # For each unit ID, stores the set of pre-existing package names
+  # reachable through its dependency graph.  Uses Nix lazy evaluation
+  # for memoization -- each entry is computed at most once.
   pre-existing-depends =
     pkgs.lib.listToAttrs (map (p: {
       name = p.id;
-      value = pkgs.lib.optionalAttrs (p.type == "pre-existing") { ${p.pkg-name} = null; } //
-        pkgs.lib.listToAttrs (
-          map (dname: { name = dname; value = null; }) (lookupPreExisting (p.depends or p.components.lib.depends)));
+      value =
+        let
+          directDeps = p.depends or p.components.lib.depends;
+          selfEntry = pkgs.lib.optionalAttrs (p.type == "pre-existing") { ${p.pkg-name} = null; };
+          transitiveDeps = pkgs.lib.listToAttrs (
+            map (dname: { name = dname; value = null; })
+              (pkgs.lib.concatMap (d: builtins.attrNames pre-existing-depends.${d}) directDeps));
+        in selfEntry // transitiveDeps;
     }) plan-json.install-plan);
+  lookupPreExisting = depends:
+    pkgs.lib.concatMap (d: builtins.attrNames pre-existing-depends.${d}) depends;
   # Lookup a dependency in `hsPkgs`
   lookupDependency = let
     lookupDependency' = hsPkgs: d: let
@@ -98,14 +120,12 @@ in {
   pkgs = (hackage: {
     packages = pkgs.lib.listToAttrs (
       # Include entries for the `pre-existing` packages, but leave them as `null`
-      pkgs.lib.concatMap (p:
-        pkgs.lib.optional (p.type == "pre-existing") {
+      map (p: {
           name = p.id;
           value.revision = null;
-        }) plan-json.install-plan
+        }) partitioned.preExisting
       # The other packages that are not part of the project itself.
-      ++ pkgs.lib.concatMap (p:
-        pkgs.lib.optional (p.type == "configured" && (p.style == "global" || p.style == "inplace") ) {
+      ++ map (p: {
           name = p.id;
           value.revision =
             {hsPkgs, ...}@args:
@@ -147,16 +167,15 @@ in {
                   setup-depends = []; # The correct setup depends will be in `components.setup.depends`
                 };
               };
-        }) plan-json.install-plan);
+        }) partitioned.nonLocal);
     compiler = {
       inherit (selectedCompiler) version;
     };
   });
-  # Packages in the project (those that are both configure and local)
+  # Packages in the project (those that are both configured and local)
   extras = (_hackage: {
     packages = pkgs.lib.listToAttrs (
-      pkgs.lib.concatMap (p:
-        pkgs.lib.optional (p.type == "configured" && p.style == "local") {
+      map (p: {
           name = p.id;
           value =
             {hsPkgs, ...}@args:
@@ -189,7 +208,7 @@ in {
                   setup-depends = []; # The correct setup depends will be in `components.setup.depends`
                 };
               };
-        }) plan-json.install-plan);
+        }) partitioned.local);
   });
   modules = [
     { inherit plan-json; }

--- a/lib/load-cabal-plan.nix
+++ b/lib/load-cabal-plan.nix
@@ -215,7 +215,7 @@ in {
     (import ../modules/install-plan/configure-args.nix)
     (import ../modules/install-plan/non-reinstallable.nix)
     (import ../modules/install-plan/override-package-by-name.nix)
-    (import ../modules/install-plan/planned.nix)
+    (import ../modules/install-plan/planned.nix { inherit (haskellLib) componentPrefix; })
     (import ../modules/install-plan/redirect.nix)
   ];
 }

--- a/modules/install-plan/planned.nix
+++ b/modules/install-plan/planned.nix
@@ -1,15 +1,41 @@
-# Mark everthing in the install-plan as "planned"
+# Mark everything in the install-plan as "planned".
+# Uses plain `true` instead of `mkOverride 900 true` because the
+# plan is definitive -- no other module sets `planned` on these
+# components, so the override priority machinery is unnecessary.
+#
+# Extracts component keys directly from the plan.json structure
+# instead of calling the full `getComponents` function, which would
+# invoke expensive dependency resolution against an empty hsPkgs.
+# The key mapping mirrors `haskellLib.componentPrefix`:
+#   lib → library, exe:name → exes.name, test:name → tests.name, etc.
 {getComponents}:
-{config, lib, ...}: {
+{config, lib, ...}:
+let
+  # Map from plan.json component prefixes to module system keys
+  prefixMap = { "exe" = "exes"; "test" = "tests"; "bench" = "benchmarks";
+                "flib" = "foreignlibs"; "lib" = "sublibs"; };
+  # Extract the module-system component structure from a plan entry
+  # without invoking dependency resolution.
+  plannedComponents = p:
+    let
+      rawComps = p.components or { ${p.component-name or "lib"} = {}; };
+    in
+      # library and setup are top-level keys (not nested)
+      lib.optionalAttrs (rawComps ? lib) { library = { planned = true; }; }
+      // lib.optionalAttrs (rawComps ? setup) { setup = { planned = true; }; }
+      # Prefixed components (exe:foo, test:bar, etc.) become nested: exes.foo, tests.bar
+      // lib.foldl' (acc: n:
+        let
+          parts = builtins.match "([^:]+):(.*)" n;
+          prefix = builtins.elemAt parts 0;
+          name = builtins.elemAt parts 1;
+          collection = prefixMap.${prefix} or null;
+        in if parts == null || collection == null then acc
+           else acc // { ${collection} = (acc.${collection} or {}) // { ${name} = { planned = true; }; }; }
+      ) {} (builtins.attrNames rawComps);
+in {
   packages = lib.listToAttrs (map (p: {
     name = p.id;
-    value.components = lib.mapAttrs (type: x:
-        if type == "library" || type == "setup"
-          then { planned = lib.mkOverride 900 true; }
-          else
-            lib.mapAttrs (_: _: {
-              planned = lib.mkOverride 900 true;
-            }) x
-      ) (getComponents null {} p);
+    value.components = plannedComponents p;
   }) config.plan-json.install-plan);
 }

--- a/modules/install-plan/planned.nix
+++ b/modules/install-plan/planned.nix
@@ -3,12 +3,9 @@
 # plan is definitive -- no other module sets `planned` on these
 # components, so the override priority machinery is unnecessary.
 #
-# Extracts component keys directly from the plan.json structure
-# instead of calling the full `getComponents` function, which would
-# invoke expensive dependency resolution against an empty hsPkgs.
+# Extracts component keys directly from the plan.json structure.
 # The key mapping mirrors `haskellLib.componentPrefix`:
 #   lib → library, exe:name → exes.name, test:name → tests.name, etc.
-{getComponents}:
 {config, lib, ...}:
 let
   # Map from plan.json component prefixes to module system keys

--- a/modules/install-plan/planned.nix
+++ b/modules/install-plan/planned.nix
@@ -4,13 +4,18 @@
 # components, so the override priority machinery is unnecessary.
 #
 # Extracts component keys directly from the plan.json structure.
-# The key mapping mirrors `haskellLib.componentPrefix`:
-#   lib → library, exe:name → exes.name, test:name → tests.name, etc.
+# The plan-json component prefixes (e.g. `exe:foo`) are inverted from
+# `haskellLib.componentPrefix` so that adding a new component type to
+# that single source of truth flows through here automatically.
+{componentPrefix}:
 {config, lib, ...}:
 let
-  # Map from plan.json component prefixes to module system keys
-  prefixMap = { "exe" = "exes"; "test" = "tests"; "bench" = "benchmarks";
-                "flib" = "foreignlibs"; "lib" = "sublibs"; };
+  # Invert componentPrefix (collection -> prefix) into prefix -> collection,
+  # e.g. { exes = "exe"; tests = "test"; ... } becomes
+  #      { exe = "exes"; test = "tests"; ... }
+  prefixMap = lib.listToAttrs
+    (lib.mapAttrsToList (collection: prefix: { name = prefix; value = collection; })
+      componentPrefix);
   # Extract the module-system component structure from a plan entry
   # without invoking dependency resolution.
   plannedComponents = p:

--- a/modules/plan.nix
+++ b/modules/plan.nix
@@ -34,7 +34,7 @@ in
     };
     use-package-keys = mkOption {
       type = bool;
-      default = false;
+      default = true;
     };
     package-keys = mkOption {
       type = listOf str;

--- a/test/cabal.project.local
+++ b/test/cabal.project.local
@@ -22,7 +22,7 @@ repository head.hackage.ghc.haskell.org
      f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
      26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
      7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-  --sha256: sha256-qXwrqhRPJQMEpPyi7eSJq7zBxztpiJ5V2OzLMm5OxmM=
+  --sha256: sha256-xT2WJ7xWpm/ki5FNJ61f7xwMdQTA7ztl0Yhg4PbRtME=
 
 repository ghcjs-overlay
   url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/ffb32dce467b9a4d27be759fdd2740a6edd09d0b

--- a/test/cabal.project.local
+++ b/test/cabal.project.local
@@ -22,7 +22,7 @@ repository head.hackage.ghc.haskell.org
      f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
      26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
      7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-  --sha256: sha256-xT2WJ7xWpm/ki5FNJ61f7xwMdQTA7ztl0Yhg4PbRtME=
+  --sha256: sha256-wZQkeslT65jzNIvjkOpPQulcxgZMCin+qQOizOY0tyA=
 
 repository ghcjs-overlay
   url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/ffb32dce467b9a4d27be759fdd2740a6edd09d0b


### PR DESCRIPTION
## Summary

Reduces evaluation overhead measured on ouroboros-consensus `hydraJobs` (full flake evaluation with 3 GHC variants + cross compilation):

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| **Peak heap** | 21.1 GiB | 19.4 GiB | **-1.7 GiB (-8%)** |
| **GC time** | 328s | 243s | **-85s (-26%)** |
| **CPU time** | 252s | 232s | **-20s (-8%)** |
| Function calls | 386M | 373M | -13M (-3%) |

The GC improvement is the headline: **-26% garbage collection time** from eliminating O(n²) intermediate list allocations in the dependency deduplication hot path.

## Changes

### 1. Optimize `uniqueWithName` and `checkUnique` (`lib/default.nix`)

The old `uniqueWithName` used `builtins.groupBy` + `lib.unique` per group. `lib.unique` is `foldl' (acc: e: if elem e acc then acc else acc ++ [e]) []` — O(n²) due to linear `elem` scan with structural equality, and `acc ++ [e]` copies the entire accumulator list at each step, creating a cascade of intermediate lists that drive GC pressure.

Replaced with `builtins.listToAttrs` which runs entirely in C++ at O(n log n) with no intermediate list accumulation. First occurrence wins (same semantics for derivation dedup by name).

The old `checkUnique` called `uniqueWithName` just to compare list lengths, then **discarded the result** — the deduplicated list was computed and immediately became garbage. Fixed to use a single `builtins.groupBy` to detect duplicates without redundant work.

Also fused four nested `map` passes in `make-config-files.nix` into a single pass (Nix does not perform list fusion — each `map` allocates a full intermediate list).

### 2. Enable `use-package-keys` by default (`modules/plan.nix`)

Changes the `packages` option from open `attrsOf package` to closed `genAttrs config.package-keys`. The module system knows the exact package set upfront, avoiding open-ended merge machinery.

Note: cabal projects using `plan.json` already had this enabled via `override-package-by-name.nix`. This change affects the classic Stack/hackage code path.

### 3. Single-pass plan partitioning (`lib/load-cabal-plan.nix`)

Replaced three separate `concatMap` + `optional` filter passes over the full install-plan (pre-existing, configured/global, configured/local) with a single `builtins.groupBy` call that categorizes entries in one C++ pass.

### 4. Simplify `planned.nix` (`modules/install-plan/planned.nix`)

- Replaced `lib.mkOverride 900 true` with plain `true` — the plan is definitive, no other module sets `planned`, so the override priority machinery was unnecessary overhead.
- Eliminated the `getComponents null {} p` call which invoked the full dependency resolution machinery (lookupDependencies, lookupPreExisting) against an empty `hsPkgs` — all that work was thrown away since `planned.nix` only needs component keys to set `planned = true`.
- Now extracts component keys directly from `p.components` using the prefix mapping (`exe:` → `exes`, `test:` → `tests`, etc.).

## Profiling methodology

Built a custom Nix 2.35 with per-function allocation attribution, per-primop timing, thunk statistics, and list operation size tracking. Profiled both `cardano-node` (single output) and `ouroboros-consensus` (full `hydraJobs` with multiple GHC variants). The profiling infrastructure is at `input-output-hk/nix` branch `angerman/2.35-eval-profiling-v2`.

## Test plan

- [x] `nix eval .#packages.aarch64-darwin.hello` — hello package evaluates correctly
- [x] `nix eval .#packages.aarch64-darwin.cardano-tools` — cardano-node evaluates correctly (haskell-nix-example)
- [x] `nix eval .#hydraJobs` — ouroboros-consensus full hydraJobs evaluates correctly
- [x] Profiled before/after on ouroboros-consensus hydraJobs (77K derivations)
- [ ] CI / Hydra evaluation