### PR TITLE
Pin alfred-margaret <2.1.1.0 in hoogle for GHC <9.10

### DIFF
--- a/modules/hackage-quirks.nix
+++ b/modules/hackage-quirks.nix
@@ -23,6 +23,20 @@ in [
     }
   )
 
+  # alfred-margaret 2.1.1.0 (released 2026-04-24) uses `foldl'` from Prelude,
+  # which was only added to Prelude in base-4.20 (GHC 9.10). It is pulled in
+  # transitively when building hoogle (via hackage-revdeps).
+  ({config, lib, pkgs, ...}:
+    { _file = "haskell.nix/overlays/hackage-quirks.nix#hoogle"; } //
+    lib.mkIf (config.name == "hoogle"
+        && builtins.compareVersions
+             pkgs.buildPackages.haskell-nix.compiler.${config.compiler-nix-name}.version "9.10" < 0) {
+      cabalProjectLocal = ''
+        constraints: alfred-margaret <2.1.1.0
+      '';
+    }
+  )
+
   # Map the following into modules that use `mkIf` to check the name of the
   # hackage package in a way that is lazy enought not to cause infinite recursion
   # issues.


### PR DESCRIPTION
alfred-margaret 2.1.1.0 (2026-04-24) uses bare `foldl'` which is only in Prelude from base-4.20 (GHC 9.10) onwards, so it fails to compile under GHC 9.6 and 9.8. It is pulled in transitively by hoogle via hackage-revdeps, breaking the 42 shell-for / simple-shell test jobs.