### PR TITLE
Support all the env vars used by the nixpkgs `ghc-paths` patch

### DIFF
--- a/builder/ghc-for-component-wrapper.nix
+++ b/builder/ghc-for-component-wrapper.nix
@@ -22,7 +22,7 @@ let
 
   inherit (configFiles) targetPrefix ghcCommand ghcCommandCaps packageCfgDir;
   libDir         = "$wrappedGhc/${configFiles.libDir}";
-  docDir         = "$wrappedGhc/share/doc/ghc/html";
+  docDir         = "$wrappedGhc/${configFiles.docDir}";
   # For musl we can use haddock from the buildGHC
   haddock        = if stdenv.hostPlatform.isMusl
     then ghc.buildGHC or ghc # `or ghc` is here because nixpkgs GHC does not have `buildGHC`

--- a/builder/make-config-files.nix
+++ b/builder/make-config-files.nix
@@ -44,11 +44,12 @@ let
   ghcCommand'    = if isGhcjs then "ghcjs" else "ghc";
   ghcCommand     = "${ghc.targetPrefix}${ghcCommand'}";
   ghcCommandCaps = lib.toUpper ghcCommand';
+  # nixpkgs versions of `ghc` do not have a `.libDir` or `.docDir`.  So these
+  # defaults are for them.
   libDir         = ghc.libDir or
-    # nixpkgs versions of `ghc` do not have a `.libDir`.  So this
-    # default is for them.
     ("lib/${ghcCommand}-${ghc.version}"
       + lib.optionalString (__compareVersions ghc.version "9.6.1" >= 0) "/lib");
+  docDir         = ghc.docDir or "share/doc/ghc/html";
   packageCfgDir  = "${libDir}/package.conf.d";
 
   # Fused single-pass: dependToLib → profiled → dwarf → chooseDrv.
@@ -241,7 +242,7 @@ let
       propagatedBuildInputs = libDeps;
       passthru = {
         inherit (ghc) targetPrefix;
-        inherit script libDeps ghcCommand ghcCommandCaps libDir packageCfgDir component;
+        inherit script libDeps ghcCommand ghcCommandCaps libDir docDir packageCfgDir component;
       };
     } (''
     mkdir -p $out
@@ -250,7 +251,7 @@ let
   '');
 in {
   inherit (ghc) targetPrefix;
-  inherit script libDeps drv ghcCommand ghcCommandCaps libDir packageCfgDir component;
+  inherit script libDeps drv ghcCommand ghcCommandCaps libDir docDir packageCfgDir component;
   # Use ''${pkgroot} relative paths so that we can relocate the package database
   # along with referenced packages and still have it work on systems with
   # or without nix installed.

--- a/builder/shell-for.nix
+++ b/builder/shell-for.nix
@@ -207,7 +207,10 @@ in
 
     # This helps tools like `ghcide` (that use the ghc api) to find
     # the correct global package DB.
-    NIX_GHC_LIBDIR = ghcEnv.drv + "/" + configFiles.libDir;
+    NIX_GHC = "${ghcEnv.drv}/bin/${configFiles.ghcCommand}";
+    NIX_GHCPKG = "${ghcEnv.drv}/bin/${configFiles.ghcCommand}-pkg";
+    NIX_GHC_LIBDIR = "${ghcEnv.drv}/${configFiles.libDir}";
+    NIX_GHC_DOCDIR = "${ghcEnv.drv}/${configFiles.docDir}";
 
     passthru = (mkDrvArgs.passthru or {}) // {
       ghc = ghcEnv.drv;

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -459,6 +459,7 @@ let
       then "lib"
       else "lib/${targetPrefix}ghc-${ghc-version}" + lib.optionalString (useHadrian) "/lib";
   packageConfDir = "${libDir}/package.conf.d";
+  docDir = "share/doc/ghc/html";
 
   # This work around comes from nixpkgs/pkgs/development/compilers/ghc
   #

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -583,7 +583,7 @@ in {
         value = lib.makeSearchPath "lib/pkgconfig" shell.buildInputs;
       }
     ] ++ lib.mapAttrsToList lib.nameValuePair ({
-      inherit (shell) NIX_GHC_LIBDIR;
+      inherit (shell) NIX_GHC NIX_GHCPKG NIX_GHC_LIBDIR NIX_GHC_DOCDIR;
     # CABAL_CONFIG is only set if the shell was built with exactDeps=true
     } // lib.optionalAttrs (shell ? CABAL_CONFIG) {
       inherit (shell) CABAL_CONFIG;


### PR DESCRIPTION
`NIX_GHC` is needed for `doctest` in particular.

The full list of vars that the patched version of `ghc-paths` in `nixpkgs` uses is:

* `NIX_GHC_LIBDIR`
* `NIX_GHC_DOCDIR`
* `NIX_GHC`
* `NIX_GHCPKG`
