### PR TITLE
patch cabal-install to pin unit-id OS via env var

### DIFF
--- a/nix-tools-static.nix
+++ b/nix-tools-static.nix
@@ -1,22 +1,22 @@
-pkgs: let baseurl = "https://github.com/input-output-hk/haskell.nix/releases/download/nix-tools-0.4.2/"; in {
+pkgs: let baseurl = "https://github.com/input-output-hk/haskell.nix/releases/download/nix-tools-0.4.3/"; in {
   aarch64-darwin = pkgs.fetchurl { 
      name = "aarch64-darwin-nix-tools-static";
      url = "${baseurl}aarch64-darwin-nix-tools-static.zip";
-     sha256 = "sha256-I4xoGM9PfPDkGnJS52nFWH/I+gccFvbHPgdplrEu5Ow=";
+     sha256 = "sha256-VIG2Z7Kx1kM80FCfmFNKcztDTRmN+QyWD7EeVb/0Xwk=";
   };
   x86_64-darwin = pkgs.fetchurl { 
      name = "x86_64-darwin-nix-tools-static";
      url = "${baseurl}x86_64-darwin-nix-tools-static.zip";
-     sha256 = "sha256-r+kPvQUVghE8tt01f0pFUMDDkXKZx3qCfoIwZ/24DDs=";
+     sha256 = "sha256-31VJFqz3gT9cO9TIerTLeqPrA5cwePYFoe+lScpkd5A=";
   };
   aarch64-linux = pkgs.fetchurl { 
      name = "aarch64-linux-nix-tools-static";
      url = "${baseurl}aarch64-linux-nix-tools-static.zip";
-     sha256 = "sha256-6C/VHdpoGdMjJO6dq1riUarJNue+u32Y3jTYkFmGQE8=";
+     sha256 = "sha256-7iqwekEi9mumGqFpl26PMx1tXXMx8n/rd1tXW4rU8vY=";
   };
   x86_64-linux = pkgs.fetchurl { 
      name = "x86_64-linux-nix-tools-static";
      url = "${baseurl}x86_64-linux-nix-tools-static.zip";
-     sha256 = "sha256-mMAX8477Ht2HIKIP7hahGAQ7zjH2xxId0B+75i06T+A=";
+     sha256 = "sha256-fdw5fCqM9Rm1PQqrwC0hypBuSxQCrwdDke47kp0vxHQ=";
   };
 }

--- a/nix-tools/static/cabal-install-patches/installed-package-id-os-override.patch
+++ b/nix-tools/static/cabal-install-patches/installed-package-id-os-override.patch
@@ -1,0 +1,61 @@
+Allow overriding the OS used by `hashedInstalledPackageId` via env var.
+
+`hashedInstalledPackageId` selects between `Long` / `Short` /
+`VeryShort` unit-id formats based on `buildOS` — i.e. the OS where
+cabal-install is currently executing.  For haskell.nix that's the
+*eval* platform of the plan-nix derivation, not the *build* platform
+where cabal will later actually do the compile.  Cross those wires
+(eval on Darwin, slice builds on Linux) and the unit-ids in plan-nix
+diverge from the unit-ids cabal computes inside the slice — every
+slice then tries to rebuild every dep from source and fails the
+expected-package check.
+
+Add `CABAL_INSTALLED_PACKAGE_ID_OS` as an override.  When set (to a
+Cabal-parseable OS name like `linux`, `osx`, `mingw32`), it replaces
+`buildOS` for the purposes of unit-id format selection.  Unset → keep
+existing behaviour.
+
+haskell.nix sets this env var to `pkgs.stdenv.buildPlatform`'s OS
+when invoking `make-install-plan`, so plan-nix unit-ids match what
+slice cabal v2-build computes on the build platform regardless of
+which system happens to evaluate the plan-nix derivation.
+
+--- a/src/Distribution/Client/PackageHash.hs
++++ b/src/Distribution/Client/PackageHash.hs
+@@ -65,6 +65,8 @@ import Distribution.Types.PkgconfigVersion (PkgconfigVersion)
+ import qualified Data.ByteString.Lazy.Char8 as LBS
+ import qualified Data.Map as Map
+ import qualified Data.Set as Set
++import System.Environment (lookupEnv)
++import System.IO.Unsafe (unsafePerformIO)
+
+ -------------------------------
+ -- Calculating package hashes
+@@ -77,10 +79,23 @@ import qualified Data.Set as Set
+ -- a different method on Windows that produces shorted package ids.
+ -- See 'hashedInstalledPackageIdLong' vs 'hashedInstalledPackageIdShort'.
+ hashedInstalledPackageId :: PackageHashInputs -> InstalledPackageId
+-hashedInstalledPackageId
+-  | buildOS == Windows = hashedInstalledPackageIdShort
+-  | buildOS == OSX = hashedInstalledPackageIdVeryShort
+-  | otherwise = hashedInstalledPackageIdLong
++hashedInstalledPackageId inputs
++  | os == Windows = hashedInstalledPackageIdShort inputs
++  | os == OSX     = hashedInstalledPackageIdVeryShort inputs
++  | otherwise     = hashedInstalledPackageIdLong inputs
++  where
++    os = effectiveInstalledPackageIdOS
++
++-- | OS used to pick the unit-id format.  Defaults to 'buildOS' (the
++-- platform cabal-install is running on).  haskell.nix overrides this
++-- via the @CABAL_INSTALLED_PACKAGE_ID_OS@ env var so that plan-nix
++-- unit-ids agree with slice-build unit-ids regardless of where the
++-- planner happens to execute.
++{-# NOINLINE effectiveInstalledPackageIdOS #-}
++effectiveInstalledPackageIdOS :: OS
++effectiveInstalledPackageIdOS = unsafePerformIO $ do
++  m <- lookupEnv "CABAL_INSTALLED_PACKAGE_ID_OS"
++  pure $ fromMaybe buildOS (m >>= simpleParsec)
+
+ -- | Calculate a 'InstalledPackageId' for a package using our nix-style
+ -- inputs hashing method.

--- a/nix-tools/static/project.nix
+++ b/nix-tools/static/project.nix
@@ -29,6 +29,20 @@ let
   };
 
 
+  # Patches `Distribution.Client.PackageHash` so `hashedInstalledPackageId`
+  # consults the `CABAL_INSTALLED_PACKAGE_ID_OS` env var.  haskell.nix
+  # sets that var when invoking `make-install-plan`, pinning the
+  # unit-id format to the *build* platform's OS so plan-nix unit-ids
+  # don't fork from slice-build unit-ids when the eval system differs
+  # from the build system (e.g. evaluating on Darwin while building
+  # x86_64-linux derivations).
+  apply-cabal-install-patches = {
+    packages.cabal-install.patches = [
+      ./cabal-install-patches/installed-package-id-os-override.patch
+    ];
+  };
+
+
   apply-dontStrip-to-nix-tools = {
     packages.nix-tools.components.exes = {
       cabal-name.dontStrip = false;
@@ -73,6 +87,7 @@ let
 
     modules = [
       apply-hnix-patches
+      apply-cabal-install-patches
       apply-dontStrip-to-nix-tools
       add-static-libs-to-darwin
     ];


### PR DESCRIPTION
`hashedInstalledPackageId` selects between Long / Short / VeryShort unit-id formats based on `buildOS` — the OS where cabal-install is currently executing.  For haskell.nix that's the *eval* platform of the plan-nix derivation, not the *build* platform where cabal will later actually do the compile.  When the two differ (e.g. evaluating on Darwin while building x86_64-linux derivations), plan-nix unit-ids diverge from the unit-ids slice cabal v2-build computes — every slice then tries to rebuild every dep from source.

Add a `CABAL_INSTALLED_PACKAGE_ID_OS` env var that overrides `buildOS` for unit-id format selection.  haskell.nix sets it to the build platform's OS when invoking `make-install-plan`.