### PR TITLE
foldComponents: skip null `comps.library`

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -42,7 +42,7 @@ in {
       comps = conf.components or { };
       # ensure that comps.library exists and is not null.
       libComp = acc:
-        if comps ? library then f comps.library acc else acc;
+        if (comps.library or null) != null then f comps.library acc else acc;
       subComps = acc:
         lib.foldr
           (ty: acc': foldrAttrVals f acc' (comps.${ty} or { }))


### PR DESCRIPTION
The pre-existing comment promised "ensure that comps.library exists and is not null" but the check only looked at presence (`comps ? library`).  A null library — which `lookupDependency` emits for plan entries that have no library component (exe-only packages, build-tool-only deps) — passed through and was handed to the fold's accumulator, crashing downstream consumers that read `.buildable` / `.depends` (e.g. `allComponent`'s `c.buildable` filter, `flatLibDepends` walking `c.depends`).

Tighten the guard so the fold actually skips null libraries.