### PR TITLE
plan modules: expose `identifier.unit-id` and `package-ids-by-name`

### DIFF
--- a/modules/install-plan/override-package-by-name.nix
+++ b/modules/install-plan/override-package-by-name.nix
@@ -3,6 +3,16 @@
 {pkgs, config, options, ...}: {
   use-package-keys = true;
   package-keys = map (p: p.pkg-name) config.plan-json.install-plan ++ map (p: p.id) config.plan-json.install-plan;
+  # A canonical pkg-name can appear in the install plan under
+  # several ids (haskell.nix's per-instance UnitIDs — multiple
+  # instances that differ only in their dep UnitIDs, or a multi-
+  # component package split across per-component entries).  Group
+  # the install-plan ids by their pkg-name so consumers can look
+  # each up at `config.packages.${id}` instead of guessing by name.
+  package-ids-by-name = pkgs.lib.foldl'
+    (acc: p: acc // { ${p.pkg-name} = (acc.${p.pkg-name} or []) ++ [ p.id ]; })
+    {}
+    config.plan-json.install-plan;
   packages = pkgs.lib.listToAttrs (map (p: {
       name = p.id;
       value = pkgs.lib.modules.mkAliasDefinitions (options.packages.${p.pkg-name});

--- a/modules/install-plan/override-package-by-name.nix
+++ b/modules/install-plan/override-package-by-name.nix
@@ -13,6 +13,12 @@
     (acc: p: acc // { ${p.pkg-name} = (acc.${p.pkg-name} or []) ++ [ p.id ]; })
     {}
     config.plan-json.install-plan;
+  # The install plan keyed by plan id — a name → entry index over
+  # `plan-json.install-plan` for O(log N) lookup of a specific
+  # plan entry by its haskell.nix per-instance UnitID instead of
+  # the linear scan a `lib.findFirst` over the list would do.
+  plan-json-by-id = pkgs.lib.listToAttrs
+    (map (p: { name = p.id; value = p; }) config.plan-json.install-plan);
   packages = pkgs.lib.listToAttrs (map (p: {
       name = p.id;
       value = pkgs.lib.modules.mkAliasDefinitions (options.packages.${p.pkg-name});

--- a/modules/install-plan/planned.nix
+++ b/modules/install-plan/planned.nix
@@ -38,6 +38,27 @@ let
 in {
   packages = lib.listToAttrs (map (p: {
     name = p.id;
-    value.components = plannedComponents p;
+    value = {
+      components = plannedComponents p;
+      # Populate the package's `identifier` so consumers that read
+      # `package.identifier.name` / `.version` (e.g. hspkg-builder's
+      # `homeDependIds`) don't throw on these plan-id-keyed entries.
+      # The canonical-name-keyed entry already has a real identifier
+      # via `load-cabal-plan.nix`; this adds it for the per-plan-id
+      # ones too.
+      #
+      # `unit-id` is plan.json's per-entry `id` — for Simple-build
+      # packages this is the cabal-install unit-id of *this specific
+      # component* (one entry per lib / sublib / exe / test / bench).
+      # For Custom-build packages plan.json emits a single entry for
+      # the whole package and shares the id across components.
+      package = {
+        identifier = {
+          name = p.pkg-name or p.id;
+          version = p.pkg-version or "0";
+          unit-id = p.id;
+        };
+      };
+    };
   }) config.plan-json.install-plan);
 }

--- a/modules/package.nix
+++ b/modules/package.nix
@@ -51,6 +51,15 @@ in
         defaultText = "\${config.package.identifier.name}-\${config.package.identifier.version}";
       };
 
+      # cabal-install unit-id from plan.json's per-entry `id`.
+      # Set by `modules/install-plan/planned.nix` for plan-id-keyed
+      # packages.  Null when not derived from a plan.json entry
+      # (e.g. setup deps before plan resolution).
+      identifier.unit-id = lib.mkOption {
+        type = types.nullOr types.str;
+        default = null;
+      };
+
       license = lib.mkOption {
         type = types.str;
       };

--- a/modules/plan.nix
+++ b/modules/plan.nix
@@ -53,6 +53,14 @@ in
       type = attrsOf (listOf str);
       default = {};
     };
+    # `plan-json.install-plan` indexed by plan id, so consumers
+    # can look a single plan entry up by its id with attrset
+    # lookup (O(log N)) rather than scanning the install-plan
+    # list linearly.
+    plan-json-by-id = mkOption {
+      type = attrsOf unspecified;
+      default = {};
+    };
     packages = if !config.use-package-keys
       then mkOption {
         type = attrsOf package;

--- a/modules/plan.nix
+++ b/modules/plan.nix
@@ -40,6 +40,19 @@ in
       type = listOf str;
       default = [];
     };
+    # Map from canonical pkg-name to the list of plan ids
+    # (haskell.nix's per-instance UnitIDs) under that name.  A given
+    # name can have multiple ids — e.g. when the plan holds several
+    # instances that differ only in their dep UnitIDs, or when a
+    # multi-component package is split into per-component entries.
+    # Consumers looking for "all configurations of this canonical
+    # package" should iterate through these ids and read from
+    # `config.packages.${id}` so lookups are unambiguous without
+    # relying on name-only matches against `config.packages`.
+    package-ids-by-name = mkOption {
+      type = attrsOf (listOf str);
+      default = {};
+    };
     packages = if !config.use-package-keys
       then mkOption {
         type = attrsOf package;


### PR DESCRIPTION
Pure additions for consumers that need to look up packages by plan-id rather than canonical name.

* `package.identifier.unit-id` (modules/package.nix): a new optional field carrying plan.json's per-entry `id` (defaults to null when not derived from a plan entry).
* `modules/install-plan/planned.nix`: when constructing the per-plan-id package entries, populate `package.identifier` with `name` / `version` / `unit-id`.  Without this, reading `package.identifier.{name,version}` on a plan-id-keyed entry threw — the canonical-name-keyed entry already gets a real identifier via `load-cabal-plan.nix`, but the per-plan-id ones (used when one canonical name has multiple plan instances) did not.
* `package-ids-by-name` (modules/plan.nix + install-plan/override-package-by-name.nix): a name → [id] index over `plan-json.install-plan`.  A canonical pkg-name can appear under several plan ids (per-instance UnitIDs that differ only in their dep UnitIDs, or a multi-component package split across per-component entries); consumers can now iterate the ids unambiguously instead of name-matching against `config.packages`.