### PR TITLE
cabal-licenses.nix: allow LicenseRef-Apache

### DIFF
--- a/lib/cabal-licenses.nix
+++ b/lib/cabal-licenses.nix
@@ -17,5 +17,13 @@ in licenses // {
       # Not setting `free` here. The license may or may not be `free`.
       # See https://github.com/input-output-hk/haskell.nix/pull/1006
     };
+  # Some packages (e.g. data-sketches) use this non-standard SPDX identifier.
+  LicenseRef-Apache = {
+      spdxId = "Apache-2.0";
+      shortName = "Apache-2.0";
+      fullName = "Apache License 2.0";
+      url = "https://spdx.org/licenses/Apache-2.0.html";
+      free = true;
+    };
   NONE = null;
 }


### PR DESCRIPTION
This fixes an evaluation warning I've had for a long time. In my case it's because the [data-sketches](https://hackage.haskell.org/package/data-sketches) package uses `LicenseRef-Apache`. This package is a dependency of [prometheus-client](https://hackage.haskell.org/package/prometheus-client) which is a dependency of [wai-middleware-prometheus](https://hackage.haskell.org/package/wai-middleware-prometheus), which I use.

The warning message took a while to track down and was

```
trace: WARNING: license "LicenseRef-Apache" not found
```