### PR TITLE
Bug fixes (Windows coverage, native-musl iserv-dyn, aarch64 fPIC, darwin c++abi gate)

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -830,10 +830,16 @@ let
       ''))
       + (lib.optionalString doCoverage ''
         mkdir -p $out/share
+        # cabal/Setup tucks `extra-compilation-artifacts/hpc` under
+        # one of a few build-dir layouts.  The per-component tmp
+        # dir is `dist/build/<cname>/<cname>-tmp` regardless of
+        # platform — note no `<exeExt>`, so we don't use
+        # `${testExecutable}-tmp` (`<cname>.exe-tmp` on Windows is
+        # a path cabal never creates).
         if [ -d dist/build/extra-compilation-artifacts ]; then
           cp -r dist/build/extra-compilation-artifacts/hpc $out/share
-        elif [ -d ${testExecutable}-tmp/extra-compilation-artifacts ]; then
-          cp -r ${testExecutable}-tmp/extra-compilation-artifacts/hpc $out/share
+        elif [ -d dist/build/${componentId.cname}/${componentId.cname}-tmp/extra-compilation-artifacts ]; then
+          cp -r dist/build/${componentId.cname}/${componentId.cname}-tmp/extra-compilation-artifacts/hpc $out/share
         elif [ -d dist/build/${componentId.cname}/extra-compilation-artifacts ]; then
           cp -r dist/build/${componentId.cname}/extra-compilation-artifacts/hpc $out/share
         else

--- a/builder/ghc-for-component-wrapper.nix
+++ b/builder/ghc-for-component-wrapper.nix
@@ -136,6 +136,7 @@ let
   + lib.optionalString (haskellLib.isNativeMusl && builtins.compareVersions ghc.version "9.9" >0) ''
      ln -s $wrappedGhc/bin/${targetPrefix}unlit $wrappedGhc/bin/unlit
      ln -s $wrappedGhc/bin/${ghcCommand}-iserv $wrappedGhc/bin/ghc-iserv
+     ln -s $wrappedGhc/bin/${ghcCommand}-iserv-dyn $wrappedGhc/bin/ghc-iserv-dyn
      ln -s $wrappedGhc/bin/${ghcCommand}-iserv-prof $wrappedGhc/bin/ghc-iserv-prof
   ''
   # These scripts break if symlinked (they check import.meta.filename against args)

--- a/overlays/darwin.nix
+++ b/overlays/darwin.nix
@@ -14,10 +14,14 @@ _final: prev:
               # https://github.com/NixOS/nixpkgs/pull/47676
               # https://github.com/NixOS/nixpkgs/issues/45042
               x509-system.components.library.preBuild = "substituteInPlace System/X509/MacOS.hs --replace security /usr/bin/security";
-            } // pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.isDarwin)
+            } // pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.isDarwin
+              && builtins.compareVersions config.compiler.version "9.4" < 0)
             {
-              # fix broken c++ library selection for GHC < 9.4
-              # for GHC >= 9.4 the system-cxx-std-lib pseudo-package does this.
+              # Fix broken C++ library selection on darwin for GHC < 9.4.
+              # For GHC >= 9.4 the `system-cxx-std-lib` pseudo-package
+              # handles c++abi linkage automatically.  Older GHCs don't
+              # have that pseudo-package, so patch double-conversion's
+              # cabal file to ask for c++abi explicitly.
               double-conversion.components.library.preConfigure = ''
                 substituteInPlace double-conversion.cabal --replace 'extra-libraries: c++' 'extra-libraries: c++ c++abi'
               '';

--- a/overlays/linux-cross.nix
+++ b/overlays/linux-cross.nix
@@ -38,7 +38,7 @@ let
       "-pgmi" "${qemuIservWrapper}/bin/iserv-wrapper"
       "-L${gmp}/lib"
          # Required to work-around https://gitlab.haskell.org/ghc/ghc/issues/15275
-    ] ++ lib.optionals hostPlatform.isAarch64 ["-fPIC"]
+    ] ++ lib.optionals hostPlatform.isAarch64 [ "-fPIC" "-optc-fPIC" ]
       # The GHC RTS references dlopen/dlclose/dlsym/dlerror even with
       # -dynamic-system-linker disabled. Link -ldl for android.
       ++ lib.optionals hostPlatform.isAndroid ["-optl-ldl"];


### PR DESCRIPTION
Four small, independent bug fixes pulled out of #2504 (`hkm/builder-v2`) that affect the v1 builder.  Each is a separate commit.

* **`comp-builder: fix coverage installPhase hpc-dir lookup on Windows`** — the doCoverage installPhase looked for hpc artifacts at `${testExecutable}-tmp/extra-compilation-artifacts`, which expands to `<cname>.exe-tmp` on Windows hosts (a path cabal never produces).  cabal's per-component tmp dir is `<cname>/<cname>-tmp` regardless of platform; switch to that path directly.  Confirmed `tests.coverage.run` on ucrt64 builds; native still passes.

* **`ghc-for-component-wrapper: add ghc-iserv-dyn alias on native-musl ≥ 9.10`** — wrapper was missing the `ghc-iserv-dyn` unprefixed alias alongside the existing `ghc-iserv` / `ghc-iserv-prof` / `unlit` ones.  Without it, projects compiling profiled + dyn-linked components on native-musl fail at TH-eval time looking up `<topdir>/bin/ghc-iserv-dyn`.

* **`linux-cross: add -optc-fPIC alongside -fPIC on aarch64`** — pass the flag to the C compiler too so packages that compile C sources reachable through shared libs / TH plugins don't trip `relocation R_AARCH64_ADR_PREL_PG_HI21 ... can not be used when making a shared object` link failures.

* **`darwin: gate double-conversion c++abi patch to GHC < 9.4`** — from GHC 9.4 the `system-cxx-std-lib` pseudo-package handles c++abi linkage automatically, making the substituteInPlace a no-op or worse.  Gate the override on `compiler.version < 9.4`.
