### PR TITLE
Pick up profiling / coverage / debug-info from plan.json's configure-args

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -82,7 +82,7 @@
 
 # Debug
 , enableDebugRTS ? false
-, enableDWARF ? false
+, enableDWARF ? component.enableDWARF
 
 # This will only work with a custom TSan way enabled custom compiler
 , enableTSanRTS ? false

--- a/modules/component-options.nix
+++ b/modules/component-options.nix
@@ -152,6 +152,20 @@
       default = false;
     };
 
+    enableDWARF = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Compile the component with DWARF debug info (`-g`).
+        Populated automatically from `--enable-debug-info` entries in
+        plan.json's configure-args (see
+        `modules/install-plan/configure-args.nix`) so a
+        `cabal.project` `debug-info:` stanza flows through without
+        per-component module overrides.  When true, comp-builder
+        swaps in the `.dwarf` GHC variant and passes `-g3` to ghc.
+      '';
+    };
+
     profilingDetail = lib.mkOption {
       type = lib.types.nullOr haskellLib.types.uniqueStr;
       default = "default";

--- a/modules/install-plan/configure-args.nix
+++ b/modules/install-plan/configure-args.nix
@@ -30,9 +30,24 @@
         in isProgOption && !isGhcOption
       ) args;
 
+      # Translate `--enable-X` toggles cabal-install records in
+      # plan.json's `configure-args` back into haskell.nix module
+      # options.  comp-builder reads these straight off each
+      # component config — picking them up here lets a project set
+      # e.g. `package <pkg>\n  profiling: True` /
+      # `debug-info: 2` in cabal.project and have the builder
+      # honour it without also needing module-level toggles.
+      hasEnableFlag = name: lib.elem ("--enable-${name}") args;
+      enableFlags =
+        lib.optionalAttrs (hasEnableFlag "profiling")         { enableProfiling        = true; }
+        // lib.optionalAttrs (hasEnableFlag "library-profiling") { enableLibraryProfiling = true; }
+        // lib.optionalAttrs (hasEnableFlag "coverage")        { doCoverage             = true; }
+        // lib.optionalAttrs (hasEnableFlag "debug-info")      { enableDWARF            = true; };
+
       value =
         lib.optionalAttrs (ghcOptions != []) { inherit ghcOptions; }
-        // lib.optionalAttrs (otherFlags != []) { configureFlags = otherFlags; };
+        // lib.optionalAttrs (otherFlags != []) { configureFlags = otherFlags; }
+        // enableFlags;
     in lib.optional (value != {}) {
       name = p.id;
       inherit value;


### PR DESCRIPTION
Picks up `cabal.project` `profiling:` / `library-profiling:` / `coverage:` / `debug-info:` stanzas from plan.json's per-unit `configure-args` and applies them to the corresponding haskell.nix module options.  Lets a project enable any of these via cabal.project without also needing a module-level toggle.

Three pieces:

1. **`modules/component-options.nix`** — surface `enableDWARF` as a per-component option (matches the existing `enableProfiling`).
2. **`builder/comp-builder.nix`** — read the default from `component.enableDWARF` instead of hard-coding `false`.  The existing branches that swap in the `.dwarf` GHC variant and pass `-g3` to ghc then trigger automatically.
3. **`modules/install-plan/configure-args.nix`** — map `--enable-{profiling,library-profiling,coverage,debug-info}` from plan.json into `enableProfiling` / `enableLibraryProfiling` / `doCoverage` / `enableDWARF`.

Pulled out of #2504 (`hkm/builder-v2`).