### PR TITLE
v2 builder: pin build-tools' lib closures in slice constraints

### DIFF
--- a/builder/comp-v2-builder.nix
+++ b/builder/comp-v2-builder.nix
@@ -1919,7 +1919,8 @@ let
   planNixJsonFile = pkgs.buildPackages.writeText "plan-nix.json"
                       (builtins.toJSON planJson);
   checkAgainstPlan = buildCabalStoreSlice {
-    name = "check-${pkgName}-${componentKindLabel}-${componentName}-${pkgVersion}";
+    pname = "check-${pkgName}-${componentKindLabel}-${componentName}";
+    version = pkgVersion;
     inherit depSlices;
     ghc = sliceGhc;
     localRepo = slicingRepo;

--- a/builder/comp-v2-builder.nix
+++ b/builder/comp-v2-builder.nix
@@ -776,9 +776,28 @@ let
   # Pre-existing entries are skipped entirely (no version pin either)
   # — GHC's bundled package db already fixes them, and pinning them
   # tends to push cabal off legacy-tool PATH fallbacks for hsc2hs /
-  # alex / happy / etc.  Sourced from `libDepClosure` (lib deps
-  # only); exe-deps are left unconstrained so build-tools can resolve
-  # against their own slice's solve.
+  # alex / happy / etc.  Seeded from this slice's lib closure AND
+  # the lib closure of every transitive exe-dep (alex / happy /
+  # hsc2hs / ...): plan-nix solves the whole project as one plan,
+  # so the exe's lib deps use the same reinstall versions the lib
+  # slice's closure does.  Without the exe-seed extension cabal in
+  # the slice would freely pick GHC-bundled `-inplace` versions for
+  # the build-tool's deps when nothing in the lib slice's closure
+  # pulls those reinstalls in (e.g. zlib's lib depends only on base
+  # + bytestring, but its `build-tool-depends: hsc2hs` brings a full
+  # directory/filepath/process closure that plan-nix had reinstalled
+  # — hsc2hs's UnitId then diverges from the pre-built slice and
+  # cabal rebuilds it).  Within a single plan-nix every package has
+  # one version, so the first-wins grouping is stable across the
+  # combined closure.
+  exeUnitsInAllDeps =
+    lib.concatMap (e:
+      let p = e.entry;
+          cn = p.component-name or "";
+      in if lib.hasPrefix "exe:" cn then [ p ] else []
+    ) allDepClosure;
+  libConstraintClosure =
+    mkClosureFrom (ourPlanUnits ++ exeUnitsInAllDeps) libDepsOf;
   libConstraintPins =
     let
       grouped = lib.foldl' (acc: e:
@@ -790,7 +809,7 @@ let
               || (p.type or null) == "pre-existing"
            then acc
            else acc // { ${n} = v; }
-      ) {} libDepClosure;
+      ) {} libConstraintClosure;
     in lib.sort (a: b: a.name < b.name)
         (lib.mapAttrsToList (n: v: { name = n; version = v; }) grouped);
 

--- a/builder/shell-for-v2.nix
+++ b/builder/shell-for-v2.nix
@@ -752,9 +752,43 @@ mkShell {
     # include unconditionally — most v2 shell users want git on
     # PATH anyway, and `gitMinimal` keeps the closure small.
     ++ [ pkgs.buildPackages.gitMinimal ]
+    # `pkg-config` on PATH unconditionally.  cabal's solver probes
+    # `pkg-config <name>` whenever a package declares
+    # `pkgconfig-depends:` (e.g. `zlib +pkg-config` in this project);
+    # if it's missing cabal silently flips `+pkg-config` to
+    # `-pkg-config`, and the resulting unit-id diverges from
+    # plan-nix's (which was solved with `cabalPkgConfigWrapper`
+    # available) — cabal then rebuilds the lib from source instead
+    # of reusing the slice in the cabal store.  v1's shell got
+    # pkg-config in through each slice's pkgconfig-depends closure
+    # via stdenv propagation; v2 slices flow through the cabal store
+    # rather than via `buildInputs`, so we add it directly.  Always
+    # on, even when no selected pkg has pkgconfig-depends — keeps
+    # the unit-id stable if the user adds a pkgconfig dep later, and
+    # matches v1's "always present" feel.  `cabalPkgConfigWrapper`
+    # is the real pkg-config plus a `--libs --static` failure shim
+    # (issue #1642), not the fake `allPkgConfigWrapper` used during
+    # plan-nix evaluation.
+    ++ [ pkgs.buildPackages.cabalPkgConfigWrapper ]
     ++ nativeBuildInputs
     ++ inputsFromNativeBuildInputs;
-  buildInputs = buildInputs ++ inputsFromBuildInputs;
+  buildInputs = buildInputs
+    # Surface every selected component's and dep slice's C-side deps
+    # (`component.libs`, `component.pkgconfig`, `component.frameworks`)
+    # in the shell.  Each v2 slice exposes these as
+    # `passthru.runtimeLibs` (`comp-v2-builder.nix`, the same set
+    # that lands in the slice's own `extraBuildInputs`).  Without
+    # this, the `pkg-config` we just added to nativeBuildInputs
+    # doesn't find any of the project's pkgconfig deps — e.g.
+    # `pkg-config --exists zlib` fails because no `zlib.pc` is on
+    # `PKG_CONFIG_PATH` — and cabal's solver flips `+pkg-config`
+    # off for the affected Haskell packages, diverging the unit-ids
+    # from plan-nix.  Mirrors v1's `systemInputs` line in
+    # `shell-for.nix:108`, which collects the same set via
+    # `c.buildInputs ++ c.propagatedBuildInputs` propagation.
+    ++ lib.concatMap (s: s.passthru.runtimeLibs or [])
+         (selectedAllComps ++ depSlices)
+    ++ inputsFromBuildInputs;
   shellHook =
     cabalProjectLocalShellHook + "\n"
     + shellSyncHook + "\n"


### PR DESCRIPTION
## Summary

Two related fixes for the v2 builder, both surfaced while bringing up `nix develop` on a project with `build-tool-depends:` on `hsc2hs`.

### 1. `checkAgainstPlan` evaluation crash

`checkAgainstPlan` (the per-slice plan-divergence diagnostic) was calling `buildCabalStoreSlice` with `name =` but the slice builder requires `pname` + `version` (matching the neighbouring `baseSlice` / `docSlice` callsites). Evaluation crashed with `function 'anonymous lambda' called without required argument 'version'` the moment anything asked for the attribute, making the diagnostic unusable.

### 2. Build-tool lib closures missing from slice constraints

`libConstraintPins` walked only `libDepClosure` — the slice's own lib closure — so reinstalled libs reached only through `build-tool-depends:` never made it into the slice's `extra-packages:` / `constraints:` blocks. cabal in the slice then solved each transitive build-tool (alex / happy / hsc2hs / …) against GHC-bundled `-inplace` versions instead of the reinstalls plan-nix recorded, the tool's computed UnitId diverged from the pre-built slice composed into the starting store, and cabal rebuilt the tool from source — or, more often, the slice's dry-run check failed with "cabal planned to build packages other than X in this slice".

Concrete failure: zlib's lib closure is `{base, bytestring}` — no directory/filepath/process — but `build-tool-depends: hsc2hs:hsc2hs` brings hsc2hs in, and plan-nix had reinstalled `directory-1.3.11.0` / `filepath-1.5.5.0` / `process-1.6.29.0`. hsc2hs in the slice resolved against `directory-1.3.10.0-inplace` etc., computed `hsc2hs-0.68.10-981b6fe4`, and refused the composed `hsc2hs-0.68.10-bb34db40`.

The fix extends the closure used by `libConstraintPins` to seed from this slice's plan units AND every exe-component plan unit reached via `allDepClosure`. Each exe seed's lib closure (via `libDepsOf`) contributes its reinstalled deps to the pin set. Within a single plan-nix every package has one version, so the first-wins grouping is stable across the merged closure.

The block's own existing comment already described pinning build-tool lib closures — only the implementation hadn't caught up.