### PR TITLE
pkg-config: add pc-version to fix builderVersion=2 UnitId fork for pkgconfig-depends packages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,29 @@
 This file contains a summary of changes to Haskell.nix and `nix-tools`
 that will impact users.
 
+## June 9, 2026
+
+Derivations in the pkgconf → nixpkgs map (`lib/pkgconf-nixpkgs-map.nix`)
+may now carry a `pc-version` attribute, which `allPkgConfigWrapper`
+reports for `pkg-config --modversion` in preference to the derivation
+`.version`.
+
+This fixes a `builderVersion = 2` UnitId fork for packages whose `.pc`
+`Version:` field differs from the nixpkgs derivation `.version`.  The
+motivating case is `systemd`: `libsystemd.pc` reports only the major
+version (e.g. `258` / `259`) while the derivation `.version` carries a
+patch component (`258.5` / `259.3`).  plan-to-nix's `allPkgConfigWrapper`
+reported the `.version`, while the real `pkg-config` a v2 build slice runs
+reports the `.pc` value; cabal folds the resolved pkgconfig-dep version
+into `pkgHashPkgConfigDeps`, so a `pkgconfig-depends`-using package (e.g.
+`libsystemd-journal`) got a different UnitId in the slice than plan-nix
+recorded, failing the slice's expected-package check.
+
+`systemd` is now overridden to set `pc-version` to its major version
+(matching the `.pc`).  The `pkgconf-pc-version` test verifies that every
+`pc-version` package agrees with what the real `pkg-config --modversion`
+returns.
+
 ## May 23, 2026
 
 **Breaking change:** `cabalProjectLocal` and `cabalProjectFreeze`

--- a/overlays/cabal-pkg-config.nix
+++ b/overlays/cabal-pkg-config.nix
@@ -1,5 +1,17 @@
 final: prev:
 {
+  # systemd's `libsystemd.pc` reports only the major version (e.g. `259`),
+  # whereas the derivation `.version` is e.g. `259.3`.  Set `pc-version` so
+  # `allPkgConfigWrapper` (used by plan-to-nix) reports the same value the
+  # real `pkg-config` returns inside a v2 build slice, keeping the resolved
+  # `libsystemd` version — and therefore the slice's UnitId — in agreement.
+  # The `pkgconf-pc-version` test verifies this matches `pkg-config --modversion`.
+  systemd = prev.systemd.overrideAttrs (old: {
+    passthru = (old.passthru or {}) // {
+      pc-version = prev.lib.versions.major prev.systemd.version;
+    };
+  });
+
   # This is a wrapper for `cabal configure` use only.
   #
   # When creating a plan for building a project cabal first
@@ -29,10 +41,18 @@ final: prev:
   # overrides here.
   allPkgConfigWrapper =
     let
-      # Try getting the `.version` attribute or failing that look in the
-      # `.name`.  Some packages like `icu` have the correct version in
+      # Prefer an explicit `pc-version` when the derivation carries one:
+      # some packages' `.pc` `Version:` field differs from the derivation
+      # `.version` (e.g. systemd's libsystemd.pc reports `259` while the
+      # derivation `.version` is `259.3`).  The real `pkg-config` the v2
+      # build slice runs reads the `.pc` field, so plan-to-nix must report
+      # the same value here or the slice's UnitId (which folds the resolved
+      # pkgconfig-dep version into `pkgHashPkgConfigDeps`) will fork.
+      #
+      # Failing that, try the `.version` attribute, or failing that look in
+      # the `.name`.  Some packages like `icu` have the correct version in
       # `.name` but no `.version`.
-      getVersion = p: p.version or (builtins.parseDrvName (p.name or "")).version;
+      getVersion = p: p.pc-version or p.version or (builtins.parseDrvName (p.name or "")).version;
       pkgconfigPkgs =
         final.lib.filterAttrs (_name: p: __length p > 0 && getVersion (__head p) != "")
           (import ../lib/pkgconf-nixpkgs-map.nix final);

--- a/test/default.nix
+++ b/test/default.nix
@@ -180,6 +180,7 @@ let
   allTests = {
     cabal-simple = callTest ./cabal-simple { inherit util; };
     dummy-ghc-info = callTest ./dummy-ghc-info {};
+    pkgconf-pc-version = callTest ./pkgconf-pc-version {};
     cabal-simple-debug = callTest ./cabal-simple-debug { inherit util; };
     cabal-simple-prof = callTest ./cabal-simple-prof { inherit util; };
     cabal-sublib = callTest ./cabal-sublib { inherit util; };

--- a/test/pkgconf-pc-version/default.nix
+++ b/test/pkgconf-pc-version/default.nix
@@ -41,14 +41,15 @@ let
     (import ../../lib/pkgconf-nixpkgs-map.nix evalPackages));
 
   # The packages behind today's `pc-version` modules are all systemd, which
-  # only builds on non-static glibc Linux.  Drop those modules on other
-  # targets so we neither build nor even *force* the systemd derivation there
-  # (it recurses in the musl/static stdenv adapter).  Extend both lists if a
-  # future `pc-version` package has similarly limited platform support.
+  # only builds on non-static glibc Linux — not musl, not android (bionic),
+  # not Windows / wasm.  Gate on the libc (rather than enumerating those) and
+  # drop these modules elsewhere, so we neither build nor even *force* the
+  # systemd derivation on an unsupported target (it recurses in the musl /
+  # static stdenv adapter).  Extend both if a future `pc-version` package has
+  # similarly limited platform support.
   systemdPkgConfigNames = [ "libsystemd" "systemd" "systemd-journal" "libudev" "udev" ];
   hostBuildsSystemd =
-    stdenv.hostPlatform.isLinux
-    && !stdenv.hostPlatform.isMusl
+    stdenv.hostPlatform.libc == "glibc"
     && !stdenv.hostPlatform.isStatic;
   wantedNames =
     if hostBuildsSystemd

--- a/test/pkgconf-pc-version/default.nix
+++ b/test/pkgconf-pc-version/default.nix
@@ -1,0 +1,121 @@
+# Verify that every derivation in the pkgconf -> nixpkgs map that carries
+# a `pc-version` attribute actually agrees with what the real `pkg-config`
+# reports via `--modversion`.
+#
+# Why this matters: `allPkgConfigWrapper` (used at plan-to-nix time) reports
+# pkgconfig module versions from the nixpkgs derivation rather than from the
+# real `.pc` file (so plan-to-nix needn't realise every pkgconfig package).
+# For most packages the derivation `.version` matches the `.pc` `Version:`
+# field, but for some (e.g. systemd: `.version` 259.3 vs libsystemd.pc 259)
+# it does not — so those carry an explicit `pc-version`.  A v2 build slice
+# runs the *real* `pkg-config`, which reads the `.pc` field; if the two
+# disagree the slice's UnitId forks from plan-nix's (the resolved pkgconfig
+# dep version is folded into `pkgHashPkgConfigDeps`).
+#
+# This test pins `pc-version` to reality: for each `pc-version` package whose
+# module is present, `pkg-config --modversion <module>` must equal the
+# `pc-version` we advertise.  It checks the package set for the *target*
+# (`pkgs`), matching what a v2 slice resolves, but reads the `.pc` with the
+# build platform's pkg-config (the `Version:` field is plain text) so it also
+# works on cross targets.
+{ lib, pkgs, buildPackages, evalPackages, compiler-nix-name
+, testSrc ? null  # `callTest` passes this; we don't need a source dir.
+}:
+
+let
+  inherit (pkgs) stdenv;
+
+  # The real pkg-config (not allPkgConfigWrapper / cabalPkgConfigWrapper),
+  # which reads the `Version:` field from the actual `.pc` files.  We use the
+  # build platform's so the test runs on cross targets too.
+  realPkgConfig = buildPackages.pkg-config;
+
+  # Discover which pkg-config modules carry a `pc-version`, scanning the map
+  # against `evalPackages` — the glibc build-build platform `allPkgConfigWrapper`
+  # itself reads the map from.  We must NOT scan the map against an exotic
+  # *target* (musl / static / wasm): forcing every mapped derivation there can
+  # overflow the evaluator on unrelated packages (e.g. weechat in the static
+  # adapter).  evalPackages is the same on every jobset, so this is stable.
+  pcVersionNames = lib.attrNames (lib.filterAttrs
+    (_name: drvs: drvs != [] && (builtins.head drvs) ? pc-version)
+    (import ../../lib/pkgconf-nixpkgs-map.nix evalPackages));
+
+  # The packages behind today's `pc-version` modules are all systemd, which
+  # only builds on non-static glibc Linux.  Drop those modules on other
+  # targets so we neither build nor even *force* the systemd derivation there
+  # (it recurses in the musl/static stdenv adapter).  Extend both lists if a
+  # future `pc-version` package has similarly limited platform support.
+  systemdPkgConfigNames = [ "libsystemd" "systemd" "systemd-journal" "libudev" "udev" ];
+  hostBuildsSystemd =
+    stdenv.hostPlatform.isLinux
+    && !stdenv.hostPlatform.isMusl
+    && !stdenv.hostPlatform.isStatic;
+  wantedNames =
+    if hostBuildsSystemd
+    then pcVersionNames
+    else lib.subtractLists systemdPkgConfigNames pcVersionNames;
+
+  # Resolve just those names against the *target* pkgs — forcing only a
+  # handful of entries, never the whole map.
+  targetMap = import ../../lib/pkgconf-nixpkgs-map.nix pkgs;
+  checks = lib.concatMap
+    (name:
+      let drvs = targetMap.${name} or [];
+          drv = builtins.head drvs;
+      in lib.optional (drvs != [] && drv ? pc-version) {
+        inherit name drv;
+        pcVersion = drv.pc-version;
+      })
+    wantedNames;
+
+  # Expose every candidate's .pc so the real pkg-config can find the module.
+  pkgConfigPath = lib.concatMapStringsSep ":"
+    (c: "${lib.getDev c.drv}/lib/pkgconfig:${lib.getDev c.drv}/share/pkgconfig")
+    checks;
+
+  checkLines = lib.concatMapStringsSep "\n" (c: ''
+    if pkg-config --exists ${lib.escapeShellArg c.name}; then
+      actual=$(pkg-config --modversion ${lib.escapeShellArg c.name})
+      expected=${lib.escapeShellArg c.pcVersion}
+      if [ "$actual" != "$expected" ]; then
+        echo "MISMATCH: ${c.name}: pc-version=$expected but pkg-config --modversion=$actual" >&2
+        fail=1
+      else
+        echo "OK: ${c.name}: $actual" >&2
+      fi
+    else
+      # The map key has no corresponding `.pc` (it's an alias for another
+      # module name provided by the same package); nothing to check.
+      echo "SKIP: ${c.name}: module not provided by ${c.drv.name}" >&2
+    fi
+  '') checks;
+
+in buildPackages.runCommand "pkgconf-pc-version-test"
+  {
+    nativeBuildInputs = [ realPkgConfig ];
+    # Nothing to check on this target (no buildable `pc-version` package) —
+    # disable rather than build an empty no-op.
+    meta.disabled = checks == [];
+    passthru = {
+      # The pkgconfig module names exercised on this target — handy for
+      # eyeballing the gating per jobset.
+      checkedModules = map (c: c.name) checks;
+    };
+  }
+  ''
+    set -euo pipefail
+    export PKG_CONFIG_PATH=${pkgConfigPath}
+    fail=0
+
+    echo "checking ${toString (builtins.length checks)} pc-version package(s)" >&2
+    ${checkLines}
+
+    if [ "$fail" != 0 ]; then
+      echo "" >&2
+      echo "A pc-version override disagrees with pkg-config --modversion." >&2
+      echo "Fix the offending pc-version in overlays/cabal-pkg-config.nix." >&2
+      exit 1
+    fi
+
+    touch $out
+  ''


### PR DESCRIPTION
## Problem

With `builderVersion = 2`, a per-component slice runs the real `cabal v2-build`, which invokes the real `pkg-config`. cabal folds the resolved `pkgconfig-depends` version into the component's UnitId (`pkgHashPkgConfigDeps`). At plan-to-nix time, however, cabal runs against `allPkgConfigWrapper`, which reports `pkg-config --modversion` from the nixpkgs derivation's `.version` attribute — not from the real `.pc` file.

For most packages those agree, but for `systemd` they don't: `libsystemd.pc` reports only the major version (`258` on 25.11, `259` on unstable) while the derivation `.version` carries a patch component (`258.5` / `259.3`). So plan-nix records `libsystemd-258.5` while the slice computes `libsystemd-258`, and the UnitId forks. Any `pkgconfig-depends`-using package hits this; the one that surfaced it is `libsystemd-journal` (e.g. via `iohk-monitoring`'s systemd scribe), which fails the slice's expected-package check:

```
ERROR: slice produced unit-ids that don't match plan-nix.json:
  Expected (from plan-nix):  libsystemd-journal-1.4.6.0-091e6a46…
  Actual   (in this slice):  libsystemd-journal-1.4.6.0-c28430c6…
```

## Fix

Let a derivation advertise an explicit `pc-version` that `allPkgConfigWrapper` reports in preference to `.version`, so plan-to-nix and the slice agree.

- `overlays/cabal-pkg-config.nix`: `getVersion` now prefers `pc-version` over `.version` (then the old `.name`-parse fallback).
- Override `systemd` to set `pc-version = lib.versions.major version`, matching every `.pc` it ships (`libsystemd`/`systemd`/`libudev`/`udev`, all major-only). systemd-derived packages (`systemdMinimal`, `systemd-minimal-libs`) inherit it via `.override`, so `libudev`/`udev` are covered on package sets where they resolve to systemd (e.g. 25.11).

## Test

`test/pkgconf-pc-version` asserts that every `pc-version` package agrees with the real `pkg-config --modversion`:

- Discovers `pc-version` modules by scanning the pkgconf map against `evalPackages` (the glibc build-build platform `allPkgConfigWrapper` itself reads from). Scanning the map against an exotic **target** (musl/static/wasm) would force every mapped derivation and overflows the evaluator on unrelated packages (e.g. `weechat` in the musl/static stdenv adapter), so we never do that.
- Resolves only those module names against the target `pkgs` and reads the `.pc` with the build platform's `pkg-config` (the `Version:` field is plain text), so it also works on cross targets.
- `meta.disabled = checks == []`, so it's disabled where no `pc-version` package is buildable (musl/static/wasm/windows) and runs on native + glibc cross.

## Notes / out of scope

- `libudev-zero` (the `libudev`/`udev` provider on nixpkgs-unstable) has the same class of mismatch (`.version 1.0.3` vs `.pc 251`), but it's unstable-only (on 25.11 `udev` is systemd-derived and already covered) and latent (nothing depends on `pkgconfig-depends: libudev`). Left for a follow-up.
- The `systemd-journal` pkgconf map entry has no corresponding `.pc` (it predates `libsystemd` subsuming the standalone journal lib); the test SKIPs it. Left as-is.
