### PR TITLE
ghc: keep -std=... out of the settings "C compiler command" field

### DIFF
--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -718,6 +718,24 @@ haskell-nix.haskellLib.makeCompilerDeps (stdenv.mkDerivation (rec {
       fi
     done
   '' + ''
+    # GHC's configure is regenerated here via autoreconfHook using the host
+    # autoconf. Since autoconf 2.72, AC_PROG_CC appends the newest C standard
+    # flag the compiler accepts (e.g. -std=gnu23 with clang 21) to $CC, and GHC
+    # bakes $CC verbatim into the "C compiler command" / "C++ compiler command"
+    # / "Haskell CPP command" settings fields. GHC then tries to exec a binary
+    # literally named "cc -std=gnu23" and fails with "could not execute". Move
+    # the std flag out of each command field into its matching flags field.
+    for settingsFile in "$out/lib/settings" "$out/lib/ghc-"*"/lib/settings"; do
+      [ -f "$settingsFile" ] || continue
+      perl -0777 -i -pe '
+        for my $base ("C compiler", "C++ compiler", "Haskell CPP") {
+          my $std = "";
+          s/(\Q"$base command"\E,\s*"[^"]*?) (-std=\S+?)"/$std=$2;"$1\""/ge;
+          s/(\Q"$base flags"\E,\s*")/"$1$std "/e if $std ne "";
+        }
+      ' "$settingsFile"
+    done
+  '' + ''
     # Install the bash completion file.
     install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/${targetPrefix}ghc
 

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -717,14 +717,22 @@ haskell-nix.haskellLib.makeCompilerDeps (stdenv.mkDerivation (rec {
         "$out/bin/${targetPrefix}ghc-pkg" recache
       fi
     done
-  '' + ''
-    # GHC's configure is regenerated here via autoreconfHook using the host
-    # autoconf. Since autoconf 2.72, AC_PROG_CC appends the newest C standard
-    # flag the compiler accepts (e.g. -std=gnu23 with clang 21) to $CC, and GHC
-    # bakes $CC verbatim into the "C compiler command" / "C++ compiler command"
-    # / "Haskell CPP command" settings fields. GHC then tries to exec a binary
-    # literally named "cc -std=gnu23" and fails with "could not execute". Move
-    # the std flag out of each command field into its matching flags field.
+  ''
+  # GHC's configure is regenerated here via autoreconfHook using the host
+  # autoconf. As of autoconf 2.72.90, AC_PROG_CC prefers C23 if available, so it
+  # appends the newest C standard flag the compiler accepts (e.g. -std=gnu23 with
+  # clang 21, which supports but does not default to C23) to $CC. GHC then bakes
+  # $CC verbatim into the "C compiler command" / "C++ compiler command" /
+  # "Haskell CPP command" settings fields, tries to exec a binary literally named
+  # "cc -std=gnu23", and fails with "could not execute". Move the std flag out of
+  # each command field into its matching flags field.
+  #
+  # Earlier autoconf (<= 2.72) only prefers C11, which clang already defaults to,
+  # so no flag is appended and the settings fields are unaffected. The gate keeps
+  # existing GHC derivations byte-for-byte identical on those.
+  # autoconf NEWS (2.72.90, 2026-02-03):
+  # https://raw.githubusercontent.com/autotools-mirror/autoconf/master/NEWS
+  + lib.optionalString (builtins.compareVersions autoconf.version "2.72.90" >= 0) ''
     for settingsFile in "$out/lib/settings" "$out/lib/ghc-"*"/lib/settings"; do
       [ -f "$settingsFile" ] || continue
       perl -0777 -i -pe '


### PR DESCRIPTION
## Problem

On `aarch64-darwin` with a recent nixpkgs (e.g. `nixos-26.05`, which ships **autoconf 2.73** and **clang 21**), building any Haskell package with a haskell.nix-built GHC fails at the first `configurePhase`:

```
ghc-9.8.4: could not execute: /nix/store/...-clang-wrapper-21.1.8/bin/cc -std=gnu23
```

The full `nix log` ends exactly at `cc -std=gnu23` with no errno — GHC is trying to `exec` a binary whose path is literally `…/cc -std=gnu23` (program + flag glued together), which does not exist.

## Root cause

The generated GHC `settings` file has the C-standard flag baked into the **command** field instead of the **flags** field:

```
("C compiler command", "…/clang-wrapper-21.1.8/bin/cc -std=gnu23")   ← flag glued onto command
("C compiler flags",   "--target=arm64-apple-darwin  -Qunused-arguments")
("Haskell CPP command", "…/clang-wrapper-21.1.8/bin/cc -std=gnu23")   ← same
```

haskell.nix regenerates GHC's `configure` via `autoreconfHook` using the host autoconf. Since autoconf 2.72, `AC_PROG_CC` probes for and **appends** the newest C standard the compiler accepts (clang 21 ⇒ `-std=gnu23`) to `$CC`. GHC's `configure.ac` then does `SettingsCCompilerCommand="$CC"`, so the flag ends up in the command field.

nixpkgs' own GHC is unaffected because it uses GHC's **pre-generated** `configure` (no autoreconf), so `-std=…` never contaminates the command field. Same clang-21 cc-wrapper store path, opposite outcome:

| field | nixpkgs GHC 9.8.4 | haskell.nix GHC 9.8.4 (before this PR) |
|---|---|---|
| `C compiler command` | `…/cc` ✅ | `…/cc -std=gnu23` ❌ |
| `Haskell CPP command` | `…/cc` ✅ | `…/cc -std=gnu23` ❌ |

## Fix

A `postInstall` step that moves any auto-appended `-std=…` out of the `C compiler` / `C++ compiler` / `Haskell CPP` **command** fields into their matching **flags** fields. This mirrors the existing Windows `dllwrap`/`windres` settings fixup a few lines above in the same file. It is a no-op when no `-std=` is present, so it is safe on all platforms / GHC versions / older nixpkgs.

## Minimal repro (no extra repo needed)

```nix
# flake.nix
{
  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
  inputs.haskellNix.url = "github:input-output-hk/haskell.nix";
  outputs = { nixpkgs, haskellNix, ... }:
    let
      system = "aarch64-darwin";
      pkgs = import nixpkgs {
        inherit system;
        overlays = [ haskellNix.overlay ];
        config = haskellNix.config // { allowUnfree = true; };
      };
    in {
      packages.${system}.default =
        (pkgs.haskell-nix.nix-tools-set { compiler-nix-name = "ghc984"; }).exes.stack-to-nix;
    };
}
```
`nix build .#default` on aarch64-darwin fails on `assoc-1.1.1` before this change.

## Verification

Built the patched GHC from source on an M1 (macOS, nixos-26.05): the GHC `settings` command fields are now clean, and the repro above builds the entire `nix-tools` closure (incl. `assoc-1.1.1`, the previous failure point) through to `stack-to-nix`, exit 0.