### PR TITLE
Fixes for reinstallable lib:ghc build-tools, freetype pkg-config version, and wasm test filesystem access

### DIFF
--- a/modules/cabal-project.nix
+++ b/modules/cabal-project.nix
@@ -242,11 +242,21 @@ in {
     (lib.mkIf config.useLocalGhcLib (
     let
       ghc = (config.compilerSelection pkgs.buildPackages).${config.compiler-nix-name};
-      ghcSrc = (pkgs.buildPackages.symlinkJoin {
+      ghcFullSrc = pkgs.buildPackages.symlinkJoin {
         name = ghc.name + "-full-src";
         paths = [ ghc.configured-src ghc.generated ];
-      }) + "/compiler";
+      };
+      ghcSrc = ghcFullSrc + "/compiler";
       ghcMinRepoUrl = "file://${ghcSrc}";
+      # `lib:ghc`'s `build-tool-depends` (when the `build-tool-depends`
+      # flag is on) names `genprimopcode` and `deriveConstants`, which
+      # live in the GHC source tree (not on hackage).  Expose them as
+      # reinstallable source-repository-packages too, so cabal can
+      # satisfy those exe build-tool goals from the same tree.
+      genprimopcodeSrc = ghcFullSrc + "/utils/genprimopcode";
+      deriveConstantsSrc = ghcFullSrc + "/utils/deriveConstants";
+      genprimopcodeUrl = "file://${genprimopcodeSrc}";
+      deriveConstantsUrl = "file://${deriveConstantsSrc}";
     in {
       # When `useLocalGhcLib = true`, expose the GHC compiler tree
       # (configured + generated) as a `source-repository-package` in
@@ -283,6 +293,16 @@ in {
           location: ${ghcMinRepoUrl}
           subdir: .
           tag: minimal
+        source-repository-package
+          type: git
+          location: ${genprimopcodeUrl}
+          subdir: .
+          tag: minimal
+        source-repository-package
+          type: git
+          location: ${deriveConstantsUrl}
+          subdir: .
+          tag: minimal
         allow-boot-library-installs: True
       '';
       # Key by `<url>/<ref>` (the first lookup form in
@@ -294,6 +314,8 @@ in {
       # to store paths.
       inputMap = {
         ${builtins.unsafeDiscardStringContext "${ghcMinRepoUrl}/minimal"} = ghcSrc;
+        ${builtins.unsafeDiscardStringContext "${genprimopcodeUrl}/minimal"} = genprimopcodeSrc;
+        ${builtins.unsafeDiscardStringContext "${deriveConstantsUrl}/minimal"} = deriveConstantsSrc;
       };
     }
     ))

--- a/modules/configuration-nix.nix
+++ b/modules/configuration-nix.nix
@@ -57,17 +57,6 @@ in addPackageKeys {
     (fromUntil "3.4.0.0" "3.5" ../overlays/patches/Cabal/Cabal-3.4-speedup-solver-when-tests-enabled-7490.patch)
   ];
 
-  # Avoid dependency on genprimopcode and deriveConstants (cabal does not put these in the plan,
-  # most likely because it finds them in the PATH).
-  # See https://github.com/input-output-hk/haskell.nix/issues/1808
-  #
-  # We now expose genprimopcode and deriveConstants from ghc directly (this is not in line with
-  # with upstream ghc) to be able to re-build lib:ghc.
-  packages.ghc.components.library.build-tools = lib.mkForce (
-    lib.optionals (__compareVersions config.hsPkgs.ghc.identifier.version "9.4.1" > 0) [
-      (config.hsPkgs.buildPackages.alex.components.exes.alex or (pkgs.haskell-nix.tool config.compiler.nix-name "alex" {}))
-      (config.hsPkgs.buildPackages.happy.components.exes.happy or (pkgs.haskell-nix.tool config.compiler.nix-name "happy" {}))
-    ]);
   # Remove dependency on hsc2hs (hsc2hs should be in ghc derivation)
   packages.mintty.components.library.build-tools = lib.mkForce [];
 

--- a/overlays/cabal-pkg-config.nix
+++ b/overlays/cabal-pkg-config.nix
@@ -12,6 +12,48 @@ final: prev:
     };
   });
 
+  # FreeType's `freetype2.pc` advertises a libtool/ABI version (e.g. `26.2.20`)
+  # that is deliberately decoupled from the release `.version` (e.g. `2.13.3`):
+  # see FreeType's `docs/VERSIONS.TXT`.  `pkg-config --modversion freetype2`
+  # returns the libtool number, so plan-to-nix must report the same value or
+  # the v2 slice's UnitId (which folds the resolved `freetype2` version into
+  # `pkgHashPkgConfigDeps`) forks — taking every transitive consumer
+  # (gi-freetype2 -> gi-harfbuzz -> gi-pango -> gi-gdk3 -> gi-gtk3 -> ...) with
+  # it.  The mapping is an arbitrary per-release table (no formula), so we
+  # encode the known rows and fall back to `.version` for unknown releases.
+  # Adding `passthru.pc-version` does not change freetype's derivation, so this
+  # neither rebuilds freetype nor forces it to build during planning.
+  # The `pkgconf-pc-version` test verifies this matches `pkg-config --modversion`.
+  freetype = prev.freetype.overrideAttrs (old: {
+    passthru = (old.passthru or {}) // {
+      pc-version =
+        let
+          # release version -> libtool/`.pc` version, from FreeType's
+          # `docs/VERSIONS.TXT`.  Add new rows here when bumping freetype.
+          pcVersions = {
+            "2.11.0" = "24.0.18";
+            "2.11.1" = "24.1.18";
+            "2.12.0" = "24.2.18";
+            "2.12.1" = "24.3.18";
+            "2.13.0" = "25.0.19";
+            "2.13.1" = "26.0.20";
+            "2.13.2" = "26.1.20";
+            "2.13.3" = "26.2.20";
+            "2.14.0" = "26.3.20";
+            "2.14.1" = "26.4.20";
+            "2.14.2" = "26.5.20";
+            "2.14.3" = "26.6.20";
+          };
+        in pcVersions.${prev.freetype.version} or (prev.lib.warn ''
+          haskell.nix: no freetype `pc-version` for ${prev.freetype.version}; using the
+          release version, which freetype2.pc usually disagrees with (e.g. 2.13.3 -> 26.2.20).
+          Add a row to overlays/cabal-pkg-config.nix (see the libtool column in
+          https://gitlab.freedesktop.org/freetype/freetype/-/raw/master/docs/VERSIONS.TXT):
+              "${prev.freetype.version}" = "<`pkg-config --modversion freetype2`>";
+        '' prev.freetype.version);
+    };
+  });
+
   # This is a wrapper for `cabal configure` use only.
   #
   # When creating a plan for building a project cabal first

--- a/overlays/wasm.nix
+++ b/overlays/wasm.nix
@@ -88,6 +88,12 @@ final: prev: prev.lib.optionalAttrs prev.stdenv.targetPlatform.isWasm {
         # Grant the wasm guest access to the Nix store so tests can read e.g.
         # their data-files (Paths_*.getDataFileName) under <pkg>-data/share/...;
         # without a --dir preopen WASI gives the module no filesystem access.
+        # `--dir .` likewise lets tests read source-relative files (golden
+        # files / fixtures) from the directory the check runs in.
+        #
+        # NB: wasmtime neither forwards host env vars to the guest nor follows
+        # absolute symlinks, so data-file tests under the v2 check can't run on
+        # wasm and are disabled there (see test/check-datadir/default.nix).
         testWrapper = ["HOME=$(mktemp -d)" (pkgs.pkgsBuildBuild.wasmtime + "/bin/wasmtime") "--dir" "/nix/store" "--dir" "."];
         package-keys = ["clock"];
         packages.clock.ghcOptions = ["-optc-Wno-int-conversion"];

--- a/overlays/wasm.nix
+++ b/overlays/wasm.nix
@@ -62,6 +62,26 @@ final: prev: prev.lib.optionalAttrs prev.stdenv.targetPlatform.isWasm {
     nativeBuildInputs = old.nativeBuildInputs or [] ++ [ final.buildPackages.lld ];
   });
 
+  # zlib doesn't cross-compile cleanly to wasm out of the box:
+  #  * gzguts.h only `#include <errno.h>` when NO_STRERROR is unset, but
+  #    gzread.c / gzwrite.c use errno / EAGAIN / EWOULDBLOCK unconditionally.
+  #    zlib's configure probes strerror by compiling *and running* a test,
+  #    which can't run when cross-compiling to wasm, so it defines NO_STRERROR
+  #    (even though wasi-libc has strerror) and the gz* sources fail to build
+  #    with "use of undeclared identifier 'errno'".  -> always include errno.h.
+  #  * zlib sets NIX_LDFLAGS = "--undefined-version" whenever the linker is lld
+  #    (to counter lld 16+'s --no-undefined-version default for its shared-lib
+  #    version script).  wasm-ld is lld-based but rejects that flag, and we
+  #    build static anyway, so drop it.
+  zlib = prev.zlib.overrideAttrs (old: {
+    postPatch = (old.postPatch or "") + ''
+      substituteInPlace gzguts.h \
+        --replace-fail '/* get errno and strerror definition */' '/* get errno and strerror definition */
+#include <errno.h>'
+    '';
+    env = (old.env or {}) // { NIX_LDFLAGS = ""; };
+  });
+
   haskell-nix = prev.haskell-nix // ({
     defaultModules = prev.haskell-nix.defaultModules ++ [
       ({ pkgs, ... }: {

--- a/overlays/wasm.nix
+++ b/overlays/wasm.nix
@@ -65,7 +65,10 @@ final: prev: prev.lib.optionalAttrs prev.stdenv.targetPlatform.isWasm {
   haskell-nix = prev.haskell-nix // ({
     defaultModules = prev.haskell-nix.defaultModules ++ [
       ({ pkgs, ... }: {
-        testWrapper = ["HOME=$(mktemp -d)" (pkgs.pkgsBuildBuild.wasmtime + "/bin/wasmtime")];
+        # Grant the wasm guest access to the Nix store so tests can read e.g.
+        # their data-files (Paths_*.getDataFileName) under <pkg>-data/share/...;
+        # without a --dir preopen WASI gives the module no filesystem access.
+        testWrapper = ["HOME=$(mktemp -d)" (pkgs.pkgsBuildBuild.wasmtime + "/bin/wasmtime") "--dir" "/nix/store" "--dir" "."];
         package-keys = ["clock"];
         packages.clock.ghcOptions = ["-optc-Wno-int-conversion"];
       })

--- a/test/check-datadir/default.nix
+++ b/test/check-datadir/default.nix
@@ -3,7 +3,7 @@
 # the builder makes the package data-dir available to tests — in particular
 # under builderVersion = 2, where the check runs the installed binary directly
 # and `lib/check.nix` must set `<pkg>_datadir`.
-{ lib, project', testSrc, compiler-nix-name, evalPackages }:
+{ lib, stdenv, project', testSrc, compiler-nix-name, evalPackages }:
 
 let
   mkProject = builderVersion: project' {
@@ -14,12 +14,19 @@ let
   project = mkProject 1;
   projectV2 = mkProject 2;
 
-in lib.recurseIntoAttrs {
+in lib.recurseIntoAttrs ({
   ifdInputs = {
     inherit (project) plan-nix;
     plan-nix-v2 = projectV2.plan-nix;
   };
 
   run = project.hsPkgs.check-datadir.checks.test;
-  run-v2 = projectV2.hsPkgs.check-datadir.checks.test;
 }
+# The v2 check stages data-files as absolute /nix/store symlinks and points
+# Cabal at them via the `<pkg>_datadir` env var.  wasmtime neither forwards
+# host env vars to the wasm guest nor follows absolute symlinks (no CLI option
+# for either), so this check can't run on wasm.  (The v1 `run` works because
+# its data-files are real files in a `-data` output.)  See overlays/wasm.nix.
+// lib.optionalAttrs (!stdenv.hostPlatform.isWasm) {
+  run-v2 = projectV2.hsPkgs.check-datadir.checks.test;
+})

--- a/test/check-datadir/default.nix
+++ b/test/check-datadir/default.nix
@@ -21,11 +21,17 @@ in lib.recurseIntoAttrs ({
   };
 
   run = project.hsPkgs.check-datadir.checks.test;
+
+  # The test spawns a build-tool-depends exe (readProcess) and reads its
+  # data-files / a source-relative file — this can't be reproduced when the test
+  # binary runs under an emulator (Windows/wine, Android), which can't reliably
+  # spawn the build-tool.  Disable the whole test there.
+  meta.disabled = stdenv.hostPlatform.isWindows || stdenv.hostPlatform.isAndroid;
 }
 # The v2 check stages data-files as absolute /nix/store symlinks and points
-# Cabal at them via the `<pkg>_datadir` env var.  wasmtime neither forwards
+# Cabal at them via the `<pkg>_datadir` env var, but wasmtime neither forwards
 # host env vars to the wasm guest nor follows absolute symlinks (no CLI option
-# for either), so this check can't run on wasm.  (The v1 `run` works because
+# for either), so this check can't run on wasm.  (The v1 `run` works on wasm:
 # its data-files are real files in a `-data` output.)  See overlays/wasm.nix.
 // lib.optionalAttrs (!stdenv.hostPlatform.isWasm) {
   run-v2 = projectV2.hsPkgs.check-datadir.checks.test;

--- a/test/check-datadir/test/Main.hs
+++ b/test/check-datadir/test/Main.hs
@@ -1,9 +1,10 @@
 module Main (main) where
 
-import Control.Monad (unless)
+import Control.Monad (unless, when)
 import Data.List (isInfixOf)
 import Paths_check_datadir (getDataFileName)
 import System.Exit (exitFailure)
+import System.Info (arch)
 import System.Process (readProcess)
 
 -- Exercises the parts of a `cabal v2-test` environment that the
@@ -13,6 +14,8 @@ import System.Process (readProcess)
 --   1. `data-files` via `getDataFileName` — needs `<pkg>_datadir`.
 --   2. a source-relative file — needs the check to run in the package source.
 --   3. a `build-tool-depends` exe — needs it on `PATH`.
+--      (skipped on wasm: WASI has no process spawning, so readProcess can't
+--      run a build-tool — see overlays/wasm.nix testWrapper.)
 --
 -- Each fails with "does not exist" if the corresponding piece is missing.
 main :: IO ()
@@ -24,8 +27,9 @@ main = do
   golden <- readFile "golden.txt"
   expect "source-relative file" ("golden ok" `isInfixOf` golden)
 
-  toolOut <- readProcess "check-datadir-tool" [] ""
-  expect "build-tool on PATH" ("tool ran" `isInfixOf` toolOut)
+  when (arch /= "wasm32") $ do
+    toolOut <- readProcess "check-datadir-tool" [] ""
+    expect "build-tool on PATH" ("tool ran" `isInfixOf` toolOut)
 
   putStrLn "all check-datadir checks OK"
   where

--- a/test/pkgconf-pc-version/default.nix
+++ b/test/pkgconf-pc-version/default.nix
@@ -51,10 +51,21 @@ let
   hostBuildsSystemd =
     stdenv.hostPlatform.libc == "glibc"
     && !stdenv.hostPlatform.isStatic;
-  wantedNames =
-    if hostBuildsSystemd
-    then pcVersionNames
-    else lib.subtractLists systemdPkgConfigNames pcVersionNames;
+
+  # freetype carries a `pc-version` too, but its build (zlib / libpng / brotli
+  # …) doesn't cross-compile to wasm, musl or android.  Its `.pc` `Version:` is
+  # platform-independent, so checking it on glibc / darwin / windows is enough;
+  # drop it on the others so we don't force a broken cross build.
+  freetypePkgConfigNames = [ "freetype2" ];
+  hostBuildsFreetype =
+    !stdenv.hostPlatform.isWasm
+    && stdenv.hostPlatform.libc != "musl"
+    && !stdenv.hostPlatform.isAndroid;
+
+  wantedNames = lib.subtractLists
+    (lib.optionals (!hostBuildsSystemd) systemdPkgConfigNames
+     ++ lib.optionals (!hostBuildsFreetype) freetypePkgConfigNames)
+    pcVersionNames;
 
   # Resolve just those names against the *target* pkgs — forcing only a
   # handful of entries, never the whole map.


### PR DESCRIPTION
Three independent fixes surfaced while building a large real-world project (leksah) against haskell.nix across GHC 9.6 – 9.14 and the `wasm32-wasi` cross-target. Each stands alone and could be split into its own PR if preferred.

1. **`useLocalGhcLib`: expose `genprimopcode`/`deriveConstants` so `lib:ghc` is reinstallable**
2. **`cabal-pkg-config`: report freetype's pkg-config (libtool) version to the v2 slice builder**
3. **wasm: give the test runner filesystem access (and skip the subprocess check on wasm)**

---

### 1. Reinstallable `lib:ghc` build-tools

When `build-tool-depends` is enabled, `lib:ghc` names `genprimopcode` and `deriveConstants` as exe build-tools. These live in the GHC source tree (not on hackage), so cabal could previously only satisfy them by chance, finding them on `PATH`. We now expose them — alongside the existing `compiler/` subdir — as reinstallable `source-repository-package`s from the GHC source tree (wired through `inputMap`), so cabal resolves the goals normally.

This removes the need for the `packages.ghc.components.library.build-tools = mkForce [ alex happy ]` override, which is dropped from `configuration-nix.nix`.

### 2. freetype pkg-config version

FreeType's `freetype2.pc` advertises a libtool/ABI version (e.g. `26.2.20`) that is deliberately decoupled from the release `.version` (e.g. `2.13.3`) — see freetype's `docs/VERSIONS.TXT`. Since `pkg-config --modversion freetype2` returns the libtool number, plan-to-nix must report the same value; otherwise the v2 slice's `UnitId` (which folds the resolved `freetype2` version into `pkgHashPkgConfigDeps`) forks, dragging every transitive consumer with it (`gi-freetype2` → `gi-harfbuzz` → `gi-pango` → `gi-gdk3` → `gi-gtk3` → …).

Adds a `passthru.pc-version` table (the known release → libtool rows from `VERSIONS.TXT`), falling back to `.version` with a warning for unknown releases. This does not alter freetype's derivation, so it neither rebuilds nor forces a build of freetype during planning.

### 3. wasm test runner filesystem access

The wasm `testWrapper` ran `wasmtime <test>` with no `--dir`, so WASI granted the module zero filesystem access. Any test reading its data-files (`getDataFileName`, under `<pkg>-data/share/…`) or a source-relative file failed with a misleading `does not exist`. We now preopen `/nix/store` and `.`.

The `check-datadir` test additionally exercises a `build-tool-depends` exe via `readProcess`, which WASI cannot do (no process spawning — the call fails with `unsupported operation`, from `wasi-libc`, independent of the runtime). That one check is now guarded to non-wasm targets; the datadir and source-relative-file checks still run under wasm.
