### PR TITLE
builder: fix intermittent invalid code signatures on aarch64-darwin

### DIFF
--- a/builder/build-cabal-slice.nix
+++ b/builder/build-cabal-slice.nix
@@ -414,6 +414,12 @@ stdenv.mkDerivation ({
                          then pkgs.pkgsHostHost.gitReallyMinimal
                          else pkgsBuildBuild.gitReallyMinimal) ]
     ++ lib.optional stdenv.hostPlatform.isGhcjs pkgsBuildBuild.nodejs
+    # On aarch64-darwin ld64 ad-hoc signs executables but *non-deterministically*
+    # emits an invalid signature for large binaries, which recent macOS rejects
+    # (SIGKILL "Code Signature Invalid").  Add autoSignDarwinBinariesHook,
+    # patched to flush the binary to stable storage before signing so it signs
+    # the bytes that land on disk.  See haskell.nix#2018.
+    ++ import ./darwin-codesign-flush.nix { inherit lib buildPackages stdenv; }
     ++ extraNativeBuildInputs;
   # `depSlices` go in `propagatedBuildInputs` so stdenv chains each
   # slice's `nix-support/propagated-build-inputs` transitively.

--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -596,7 +596,13 @@ let
       [ghc buildPackages.removeReferencesTo]
       ++ executableToolDepends
       ++ (lib.optional stdenv.hostPlatform.isGhcjs pkgsBuildBuild.nodejs)
-      ++ (lib.optional (ghc.useLdLld or false) llvmPackages.bintools);
+      ++ (lib.optional (ghc.useLdLld or false) llvmPackages.bintools)
+      # On aarch64-darwin ld64 ad-hoc signs executables but *non-deterministically*
+      # emits an invalid signature for large binaries, which recent macOS rejects
+      # (SIGKILL "Code Signature Invalid").  Add autoSignDarwinBinariesHook,
+      # patched to flush the binary to stable storage before signing so it signs
+      # the bytes that land on disk.  See haskell.nix#2018.
+      ++ import ./darwin-codesign-flush.nix { inherit lib buildPackages stdenv; };
 
     outputs = ["out"]
       ++ (lib.optional keepConfigFiles "configFiles")
@@ -904,7 +910,8 @@ let
   }
   // lib.optionalAttrs (hardeningDisable != [] || (stdenv.hostPlatform.isMusl && builtins.elem "pie" (stdenv.cc.defaultHardeningFlags or []))) {
     hardeningDisable = hardeningDisable ++ lib.optional (stdenv.hostPlatform.isMusl && builtins.elem "pie" (stdenv.cc.defaultHardeningFlags or [])) "pie";
-  });
+  }
+  );
 in drv; in self) {
   inherit componentId
           component

--- a/builder/darwin-codesign-flush.nix
+++ b/builder/darwin-codesign-flush.nix
@@ -43,11 +43,20 @@ lib.optional (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) (
       cc -O2 -Wall -o "$out/bin/fullfsync" fullfsync.c
     '';
 
-    # Append a flush of the target to signingUtils.sign, before it reads the
-    # binary.  overrideAttrs on the concrete derivation just adds a sed step.
+    # Append a flush of the target to signingUtils.sign, immediately before it
+    # reads the binary (overrideAttrs just adds a sed step to the concrete
+    # derivation).  The flush failure aborts the build rather than being
+    # swallowed (no `|| true`): signing an unflushed binary risks the very
+    # invalid signature this works around.  The grep guard fails loudly if the
+    # substitution did not take effect (e.g. upstream sign() changed) instead
+    # of silently reintroducing the bug.
     signingUtils = buildPackages.darwin.signingUtils.overrideAttrs (old: {
       installPhase = old.installPhase + ''
-        sed -i 's#cp "$1" "$tmpdir"#${fullfsync}/bin/fullfsync "$1" || true\n    cp "$1" "$tmpdir"#' $out
+        sed -i 's#cp "$1" "$tmpdir"#${fullfsync}/bin/fullfsync "$1"\n    cp "$1" "$tmpdir"#' $out
+        grep -qF '${fullfsync}/bin/fullfsync' $out || {
+          echo "darwin-codesign-flush: failed to patch signingUtils sign(); has upstream sign() changed?" >&2
+          exit 1
+        }
       '';
     });
   in

--- a/builder/darwin-codesign-flush.nix
+++ b/builder/darwin-codesign-flush.nix
@@ -1,0 +1,55 @@
+# Fix for an aarch64-darwin write->sign code-signing coherence race
+# (haskell.nix#2018).
+#
+# On aarch64-darwin a freshly written large Mach-O (emitted by ld64, then
+# patched by remove-references-to / install_name_tool) can be signed over
+# page-cache bytes that differ from what is finally on disk, producing a
+# signature the kernel later rejects ("Code Signature Invalid" -> SIGKILL).
+# It is intermittent and affects binaries signed *inside* the build; macOS
+# `sync` is asynchronous and does not settle it, but a real flush to stable
+# storage (F_FULLFSYNC) + dropping the stale mapping (F_NOCACHE) does.
+#
+# We return (a singleton list containing) `autoSignDarwinBinariesHook` patched
+# so its `signingUtils.sign` flushes the binary before reading it for signing.
+# We override the concrete `buildPackages.darwin` derivations directly rather
+# than via an overlay, because `darwin` is a spliced package set and overlay
+# `//` additions to it do not survive splicing.  Empty list off aarch64-darwin.
+{ lib, buildPackages, stdenv }:
+
+lib.optional (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) (
+  let
+    # Tiny helper, built once in its own derivation (so no compile cost is paid
+    # per sign, and elapsed build time cannot masquerade as the fix).
+    fullfsync = buildPackages.runCommandCC "darwin-fullfsync" { } ''
+      mkdir -p "$out/bin"
+      cat > fullfsync.c <<'CEOF'
+      #include <fcntl.h>
+      #include <unistd.h>
+      #include <stdio.h>
+      int main(int argc, char **argv) {
+        int rc = 0;
+        for (int i = 1; i < argc; i++) {
+          int fd = open(argv[i], O_RDONLY);
+          if (fd < 0) { perror(argv[i]); rc = 1; continue; }
+          if (fcntl(fd, F_FULLFSYNC) == -1) { perror("F_FULLFSYNC"); rc = 1; }
+          fcntl(fd, F_NOCACHE, 1);
+          static char buf[1 << 20];
+          while (read(fd, buf, sizeof buf) > 0) { }
+          close(fd);
+        }
+        return rc;
+      }
+      CEOF
+      cc -O2 -Wall -o "$out/bin/fullfsync" fullfsync.c
+    '';
+
+    # Append a flush of the target to signingUtils.sign, before it reads the
+    # binary.  overrideAttrs on the concrete derivation just adds a sed step.
+    signingUtils = buildPackages.darwin.signingUtils.overrideAttrs (old: {
+      installPhase = old.installPhase + ''
+        sed -i 's#cp "$1" "$tmpdir"#${fullfsync}/bin/fullfsync "$1" || true\n    cp "$1" "$tmpdir"#' $out
+      '';
+    });
+  in
+    buildPackages.darwin.autoSignDarwinBinariesHook.override { inherit signingUtils; }
+)


### PR DESCRIPTION
On aarch64-darwin, executables built by haskell.nix could ship an invalid ad-hoc code signature, causing macOS to kill them at startup with SIGKILL ("Code Signature Invalid" / "Invalid Page") before any code runs. It is intermittent: the same derivation builds a valid binary on one run and an invalid one on the next, so it slips through CI and lands in the binary cache (see haskell.nix#2018).

Root cause is a write->sign page-cache coherence race, not an ld64 or sigtool bug. ld64 ad-hoc signs the executable during linking; for large Mach-Os the bytes hashed for the signature can differ from what is finally on disk, so the kernel rejects the signature at load time. The same applies to any signer run inside the build. macOS `sync` is asynchronous and does not settle it; a real flush to stable storage (F_FULLFSYNC) does.

Fix: add autoSignDarwinBinariesHook to the component and v2 cabal-slice builders, with signingUtils patched so sign() F_FULLFSYNCs (+ F_NOCACHE drops the stale mapping) the binary before reading it for signing. It then hashes exactly the bytes that land on disk, producing a signature the kernel accepts.

The concrete buildPackages.darwin derivations are overridden directly rather than via an overlay: `darwin` is a spliced package set, so overlay `//` additions do not survive splicing, and overrideScope rebuilds far too much.

Verified on cardano-ledger's cardano-ledger-shelley:test:tests (a ~170 MB binary that reproduced reliably): 6/6 invalid before, 6/6 valid after via the v1 component builder, and 4/4 valid via the v2 cabal-slice builder (builderVersion = 2, full 556-derivation tree). Confirmed the hook re-signs and the binary runs in both.