### PR TITLE
modules: default to single output on darwin (haskell.nix#2018)

### DIFF
--- a/modules/component-options.nix
+++ b/modules/component-options.nix
@@ -139,7 +139,24 @@
 
     enableSeparateDataOutput = lib.mkOption {
       type = lib.types.bool;
-      default = true;
+      # haskell.nix#2018: default to a single output on darwin.
+      #
+      # With a separate `data` output the executable (and any signed dylib)
+      # embeds a reference to its sibling `$data` output via the generated
+      # `Paths_*` module. When that `data` output already exists in the store,
+      # Nix cannot build over the immutable path, so it builds `$out` against a
+      # *scratch* `data` path and then — after the builder has exited — rewrites
+      # the scratch store hash to the final one inside the already-signed Mach-O
+      # (`registerOutputs` / `rewriteStrings`, logged "rewriting hashes ...;
+      # cross fingers"), *without* re-signing. On aarch64-darwin, where ad-hoc
+      # signatures are mandatory, that stale signature is invalid and macOS
+      # SIGKILLs the binary at launch.
+      #
+      # Defaulting to a single output makes `Paths_*` use `$out/share` — a
+      # self-reference, which Nix does not rewrite in normal/incremental builds —
+      # so the signature stays valid. Set explicitly to re-enable the separate
+      # output where the closure separation is worth more than this safety.
+      default = !pkgs.stdenv.buildPlatform.isDarwin;
     };
 
     enableLibraryForGhci = lib.mkOption {


### PR DESCRIPTION
A separate $data output makes the executable (and signed dylibs) embed a reference to the sibling $data output via Paths_*. When $data already exists in the store, Nix builds $out against a scratch $data path and rewrites the scratch hash to the final hash inside the already-signed Mach-O after the builder exits (registerOutputs/rewriteStrings, "cross fingers"), without re-signing. On aarch64-darwin, where ad-hoc signatures are mandatory, the resulting stale signature is invalid and macOS SIGKILLs the binary at launch.

Defaulting enableSeparateDataOutput to false on darwin makes Paths_* a self-reference ($out/share), which Nix does not rewrite in normal builds, so the signature stays valid. Override per-component to re-enable.