### PR TITLE
Fix variable syntax for pkg-config output

### DIFF
--- a/overlays/cabal-pkg-config.nix
+++ b/overlays/cabal-pkg-config.nix
@@ -173,7 +173,7 @@ final: prev:
       if [[ "\$1" == "--libs" && "\$2" == "--static" ]]; then
         OUTPUT=\$(mktemp)
         ERROR=\$(mktemp)
-        if $out/bin/${targetPrefix}${baseBinName}-wrapped "\$@" >output 2>\$ERROR; then
+        if $out/bin/${targetPrefix}${baseBinName}-wrapped "\$@" >\$OUTPUT 2>\$ERROR; then
           cat \$OUTPUT
         else
           echo "--error-pkg-config-static-failed=\$ERROR"


### PR DESCRIPTION
Apparent typo introduced in #1641. This causes `pkg-config --libs --static` to silently return empty output to Cabal.

This has come up when working with a Wasm version of Graphviz that only has static rather than dynamic libs. And even then, it's been seemingly harmless aside from the constant creation of an `output` file which I need to delete or Git-ignore.