### PR TITLE
pkgconf map: add WebKitGTK 6.0 entries (webkitgtk-6.0, javascriptcoregtk-6.0, web-process-extension)

### DIFF
--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -5521,6 +5521,9 @@ pkgs:
     "javascriptcoregtk-4.1" = [ "webkitgtk_4_1" ];
     "webkit2gtk-4.1" = [ "webkitgtk_4_1" ];
     "webkit2gtk-web-extension-4.1" = [ "webkitgtk_4_1" ];
+    "javascriptcoregtk-6.0" = [ "webkitgtk_6_0" ];
+    "webkitgtk-6.0" = [ "webkitgtk_6_0" ];
+    "webkitgtk-web-process-extension-6.0" = [ "webkitgtk_6_0" ];
     "webrtc-audio-processing" = [ "webrtc-audio-processing" ];
 #    "webrtc-audio-processing" = [ "webrtc-audio-processing_0_3" ];
     "weechat" = [ "weechat-unwrapped" ];


### PR DESCRIPTION
nixpkgs removed webkitgtk_4_0; the GTK4-era bindings (gi-webkit 6.x, gi-javascriptcore6, gi-webkitwebprocessextension) use the 6.0 pkg-config names, which were missing from the map, so cabal solving rejected them (allPkgConfigWrapper synthesizes the solver's pkg-config db from this map).