### PR TITLE
overlays: helpful error when a package component is missing

### DIFF
--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -761,7 +761,10 @@ final: prev: {
                             else
                               let ctype = builtins.elemAt m 0;
                                   cname = builtins.elemAt m 1;
-                                  group = components.${haskellLib.prefixComponent.${ctype}};
+                                  # Default to {} so a package with no exes/tests/etc. group
+                                  # still reaches the helpful throw below rather than a raw
+                                  # "attribute '<group>' missing".
+                                  group = components.${haskellLib.prefixComponent.${ctype}} or {};
                               in group.${cname} or (throw ''
                                 Package ${packageName} has no component ${componentName}.
                                 Available ${ctype} components: ${

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -758,7 +758,21 @@ final: prev: {
                             "Invalid package component name ${componentName}.  Expected it to start with one of lib: flib: exe: test: or bench:";
                           if builtins.elemAt m 0 == "lib" && builtins.elemAt m 1 == packageName
                             then components.library
-                            else components.${haskellLib.prefixComponent.${builtins.elemAt m 0}}.${builtins.elemAt m 1};
+                            else
+                              let ctype = builtins.elemAt m 0;
+                                  cname = builtins.elemAt m 1;
+                                  group = components.${haskellLib.prefixComponent.${ctype}};
+                              in group.${cname} or (throw ''
+                                Package ${packageName} has no component ${componentName}.
+                                Available ${ctype} components: ${
+                                  if group == {} then "(none)"
+                                  else final.lib.concatStringsSep ", " (builtins.attrNames group)}.
+                                A missing component is often caused by an automatic Cabal flag being turned off by the solver (for example cabal-plan's `exe` flag, which drops exe:cabal-plan), or by the component not existing for this GHC.
+                                If it is a disabled flag, force it back on with cabalProjectLocal, e.g.
+                                    cabalProjectLocal = "package ${packageName}\n  flags: +<flag>";
+                                For a tool this goes in the tool's module, e.g.
+                                    tools.${packageName} = { version = "<version>"; cabalProjectLocal = "package ${packageName}\n  flags: +<flag>"; };
+                                Otherwise pin a version of ${packageName} that solves cleanly for this GHC.'');
 
                       coverageReport = haskellLib.coverageReport ({
                         name = package.identifier.id;


### PR DESCRIPTION
When a requested component does not exist, `getComponent "exe:foo"` (used by the `tool`/`tools` feature and by `getComponent` generally) threw a bare `attribute 'foo' missing` from Nix, with a stack trace pointing into `overlays/haskell.nix` rather than at the users project.

The most common cause is the cabal solver disabling an *automatic* flag that guards an executable. `cabal-plan` is the canonical example: its `exe` flag exists specifically so the solver can drop `exe:cabal-plan` (and its build-deps) when it prefers to. With a newer `index-state` that started happening, `cabal-plan` resolved library-only, and asking for `exe:cabal-plan` blew up with the unhelpful attribute error.

This replaces the raw attribute lookup with an explicit `throw` that:

- names the package and the component that was requested,
- lists the components that *do* exist for that package,
- explains the automatic-flag cause, and
- gives the concrete `cabalProjectLocal` / `tools.<pkg>` recipe to force the flag back on.

Example new message:

```
error: Package cabal-plan has no component exe:cabal-plan.
Available exe components: (none).
A missing component is often caused by an automatic Cabal flag being turned off
by the solver (for example cabal-plan's `exe` flag, which drops exe:cabal-plan),
or by the component not existing for this GHC.
If it is a disabled flag, force it back on with cabalProjectLocal, e.g.
    cabalProjectLocal = "package cabal-plan\n  flags: +<flag>";
For a tool this goes in the tool's module, e.g.
    tools.cabal-plan = { version = "<version>"; cabalProjectLocal = "package cabal-plan\n  flags: +<flag>"; };
Otherwise pin a version of cabal-plan that solves cleanly for this GHC.
```

Note that forcing the flag on may instead surface a solver *failure* — that is the better outcome, because the solver error then explains the actual dependency conflict that made cabal disable the flag in the first place.

Verified on `ghc984` with the default index-state: without the flag the new message fires (`Available exe components: (none)`); adding `cabalProjectLocal = "package cabal-plan\n  flags: +exe"` resolves `exe:cabal-plan` again.

Fixes #2519.