### PR TITLE
templates: host the getting-started scaffold in-repo (fixes #2518)

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -128,7 +128,7 @@
 in
 dimension "Nixpkgs version" nixpkgsVersions (nixpkgsName: pinnedNixpkgsSrc:
   let evalPackages = import pinnedNixpkgsSrc (nixpkgsArgs // { system = evalSystem; });
-  in dimension "GHC version" (compilerNixNames nixpkgsName evalPackages) (compiler-nix-name: {runTests}:
+  in (dimension "GHC version" (compilerNixNames nixpkgsName evalPackages) (compiler-nix-name: {runTests}:
       let pkgs = import pinnedNixpkgsSrc (nixpkgsArgs // { inherit system; });
           build = import ./build.nix { inherit pkgs evalPackages ifdLevel compiler-nix-name haskellNix; };
           platformFilter = platformFilterGeneric pkgs system;
@@ -193,5 +193,12 @@ dimension "Nixpkgs version" nixpkgsVersions (nixpkgsName: pinnedNixpkgsSrc:
           hello = (pkgs.haskell-nix.hackage-package { name = "hello"; version = "1.0.0.2"; inherit evalPackages compiler-nix-name; }).getComponent "exe:hello";
         })
       ))
-    )
+    ))
+    # Run once (unstable, x86_64-linux): make sure the getting-started flake
+    # template stays in sync with `hix init` — see issue #2518.
+    // lib.optionalAttrs (nixpkgsName == "unstable" && system == "x86_64-linux") {
+      template-matches-hix-init = import ./test/template-matches-hix-init.nix {
+        pkgs = import pinnedNixpkgsSrc (nixpkgsArgs // { inherit system; });
+      };
+    }
   )

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -49,10 +49,9 @@ This can be tricky to get setup properly. If you're still having trouble getting
 This section assumes you choose to uses the experimental flakes features, and so that you have added `experimental-features = [ "nix-command" "flakes" ];` in your Nix configuration. You can look at [the Wiki](https://nixos.wiki/wiki/Flakes) for more instructions.
 
 The following `nix flake init` command creates a template `hello` package containing a `flake.nix` and `nix/hix.nix` file. The project can be used with
-regular `nix` tools. This template is defined in the [NixOS/templates repository](https://github.com/NixOS/templates/tree/master/haskell.nix).
+regular `nix` tools. This template is defined in the [haskell.nix repository](https://github.com/input-output-hk/haskell.nix/tree/master/templates/haskell-nix), so it always matches the current `hix init` output and supported GHC versions.
 ```bash
-nix flake init --template templates#haskell-nix --impure
-# `--impure` is required by `builtins.currentSystem`
+nix flake init --template github:input-output-hk/haskell.nix
 nix develop
 cabal build
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,19 @@
         overlay = self.overlays.combined;
         overlays = import ./overlays { sources = inputs; };
 
+        # `nix flake init --template github:input-output-hk/haskell.nix`
+        # scaffolds a new haskell.nix project (flake.nix + nix/hix.nix + a
+        # `hello` package).  Kept in-repo (rather than in NixOS/templates) so
+        # it stays in sync with the current `hix init` output and supported
+        # GHC versions.
+        templates = rec {
+          default = haskell-nix;
+          haskell-nix = {
+            path = ./templates/haskell-nix;
+            description = "A haskell.nix project: flake.nix, nix/hix.nix and a hello package.";
+          };
+        };
+
         internal = {
           nixpkgsArgs = {
             inherit config;

--- a/templates/haskell-nix/LICENSE
+++ b/templates/haskell-nix/LICENSE
@@ -1,0 +1,24 @@
+Copyright 2010, Simon Marlow
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+ 
+- Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+ 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND THE CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR THE
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/templates/haskell-nix/Setup.hs
+++ b/templates/haskell-nix/Setup.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import Distribution.Simple
+
+main :: IO ()
+main = defaultMain

--- a/templates/haskell-nix/flake.nix
+++ b/templates/haskell-nix/flake.nix
@@ -1,0 +1,47 @@
+{
+  description = "A haskell.nix project";
+  inputs.haskellNix.url = "github:input-output-hk/haskell.nix";
+  inputs.nixpkgs.follows = "haskellNix/nixpkgs-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  outputs = { self, nixpkgs, flake-utils, haskellNix }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+    in
+      flake-utils.lib.eachSystem supportedSystems (system:
+      let
+        overlays = [ haskellNix.overlay
+          (final: _prev: {
+            # This overlay adds our project to pkgs
+            hixProject =
+              final.haskell-nix.hix.project {
+                src = ./.;
+                # uncomment with your current system for `nix flake show` to work:
+                #evalSystem = "x86_64-linux";
+              };
+          })
+        ];
+        pkgs = import nixpkgs { inherit system overlays; inherit (haskellNix) config; };
+        flake = pkgs.hixProject.flake {};
+      in flake // {
+        legacyPackages = pkgs;
+
+        # `nix build .` builds the hello executable; the per-component
+        # attributes (e.g. `nix build .#hello:exe:hello`) come from `flake`.
+        packages = flake.packages // { default = flake.packages."hello:exe:hello"; };
+      });
+
+  # --- Flake Local Nix Configuration ----------------------------
+  nixConfig = {
+    # This sets the flake to use the IOG nix cache.
+    # Nix should ask for permission before using it,
+    # but remove it here if you do not want it to.
+    extra-substituters = ["https://cache.iog.io"];
+    extra-trusted-public-keys = ["hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="];
+    allow-import-from-derivation = "true";
+  };
+}

--- a/templates/haskell-nix/hello.cabal
+++ b/templates/haskell-nix/hello.cabal
@@ -1,0 +1,24 @@
+cabal-version: >= 1.10
+name: hello
+version: 1.0.0.2
+license: BSD3
+license-file: LICENSE
+copyright: (c) Simon Marlow
+author: Simon Marlow
+maintainer: Simon Marlow <marlowsd@gmail.com>
+stability: stable
+homepage: http://www.haskell.org/hello/
+synopsis: Hello World, an example package
+category: Console, Text
+build-type: Simple
+
+description:
+  This is an implementation of the classic "Hello World" program in
+  Haskell, as an example of how to create a minimal Haskell application
+  using Cabal and haskell.nix.
+
+executable hello
+  hs-source-dirs: src
+  main-is: hello.hs
+  build-depends: base >= 4.2 && < 5
+  default-language: Haskell2010

--- a/templates/haskell-nix/nix/hix.nix
+++ b/templates/haskell-nix/nix/hix.nix
@@ -1,0 +1,17 @@
+{pkgs, ...}: {
+  # name = "project-name";
+  compiler-nix-name = "ghc96"; # Version of GHC to use
+
+  # Cross compilation support:
+  # crossPlatforms = p: pkgs.lib.optionals pkgs.stdenv.hostPlatform.isx86_64 ([
+  #   p.mingwW64
+  #   p.ghcjs
+  # ] ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+  #   p.musl64
+  # ]);
+
+  # Tools to include in the development shell
+  shell.tools.cabal = "latest";
+  # shell.tools.hlint = "latest";
+  # shell.tools.haskell-language-server = "latest";
+}

--- a/templates/haskell-nix/src/hello.hs
+++ b/templates/haskell-nix/src/hello.hs
@@ -1,0 +1,4 @@
+module Main (main) where
+
+main :: IO ()
+main = putStrLn "Hello, World!"

--- a/test/template-matches-hix-init.nix
+++ b/test/template-matches-hix-init.nix
@@ -1,0 +1,43 @@
+# Guard the getting-started flake template (templates/haskell-nix) against
+# drifting from `hix init`.
+#
+# Both scaffold the same `nix/hix.nix` — the file that pins the template's GHC
+# version.  If they diverge (e.g. the supported GHC is bumped in one but not the
+# other) users following the getting-started guide can land on an unsupported
+# compiler.  That is exactly what happened with the previously-external template
+# in issue #2518.
+#
+# `hix init` also writes a `flake.nix`, but the template's `flake.nix`
+# intentionally differs (it adds a sample `hello` package and a default
+# package), so only `nix/hix.nix` is compared here.
+#
+# Cheap and platform-independent, so ci.nix runs it once (unstable nixpkgs).
+{ pkgs }:
+
+let
+  hix = import ../hix/default.nix { inherit pkgs; };
+in
+pkgs.runCommand "template-matches-hix-init"
+{
+  nativeBuildInputs = [ pkgs.coreutils pkgs.gnused pkgs.diffutils pkgs.bash ];
+  templateHixNix = ../templates/haskell-nix/nix/hix.nix;
+} ''
+  export HOME="$TMPDIR"
+  mkdir -p proj && cd proj
+
+  # Run the real `hix init`; it writes ./flake.nix and ./nix/hix.nix.
+  # Invoke via bash so we don't depend on /usr/bin/env in the build sandbox.
+  bash ${hix}/bin/hix init > hix-init.log 2>&1 \
+    || { echo "hix init failed:" >&2; cat hix-init.log >&2; exit 1; }
+
+  if ! diff -u "$templateHixNix" nix/hix.nix; then
+    echo >&2
+    echo "ERROR: templates/haskell-nix/nix/hix.nix has drifted from 'hix init'." >&2
+    echo "These must stay in sync (they pin the template GHC version) — see #2518." >&2
+    echo "Update templates/haskell-nix/nix/hix.nix to match hix/init/nix/hix.nix." >&2
+    exit 1
+  fi
+
+  echo "templates/haskell-nix/nix/hix.nix matches 'hix init' output." >&2
+  touch "$out"
+''


### PR DESCRIPTION
The getting-started guide told users to run:

```
nix flake init --template templates#haskell-nix --impure
```

`templates#haskell-nix` is the flake-registry alias for `github:NixOS/templates`, a separate repo. Its `haskell.nix/nix/hix.nix` still pins `compiler-nix-name = "ghc926"`, which is now below haskell.nix's minimum, so `nix develop` fails immediately with:

```
error: Desired GHC (9.2.6) is older than the oldest GHC haskell.nix might work with (GHC 9.6).
```

That external template had drifted from this repo's own `hix init` (already `ghc96`). Anyone following the getting-started tutorial hits a hard failure on the first command — see #2518.

Rather than keep depending on a copy that drifts out of sync, this hosts the scaffold in-repo:

- **`templates/haskell-nix/`** — `flake.nix` + `nix/hix.nix` + a `hello` package (`hello.cabal`, `src/hello.hs`, `Setup.hs`, `LICENSE`), mirroring the NixOS/templates layout but with a supported GHC (`ghc96`, matching `hix init`) and cross-compilation commented out.
- **`flake.nix`** — exposes it as `templates.{default,haskell-nix}`, so `nix flake init --template github:input-output-hk/haskell.nix` works.
- **`docs/tutorials/getting-started.md`** — points at the in-repo template, and drops `--impure` (our template uses `flake-utils.eachSystem`, not `builtins.currentSystem`).

Because the template now lives beside `hix init` in this repo, it stays in sync with the current `hix init` output and the supported GHC versions.

### Verification

```
$ nix flake init --template github:input-output-hk/haskell.nix   # (tested against the local checkout)
$ nix build .#hello:exe:hello
$ ./result/bin/hello
Hello, World!
```

Also confirmed `nix eval .#templates.haskell-nix` evaluates and `nix flake init` copies all scaffold files.

I will separately open a PR against NixOS/templates bumping its `ghc926` so the currently-documented alias also works for anyone who keeps using it.

Fixes #2518.