### PR TITLE
stack: accept the modern `snapshot:` key as well as `resolver:`

### DIFF
--- a/lib/fetch-resolver.nix
+++ b/lib/fetch-resolver.nix
@@ -13,12 +13,17 @@ let
     rawStackYaml = builtins.readFile (srcDir + "/${stackYaml}");
 
     # Determine the resolver as it may point to another file we need
-    # to look at.
+    # to look at.  `snapshot` is the modern synonym for `resolver`
+    # (stack >= 2.15.1), so accept either key.
     resolver =
       let
+        # Each returns a single-element capture list (the value) or null.
+        matchLine = l:
+          let r = builtins.match "^resolver: *(.*)" l;
+          in if r != null then r else builtins.match "^snapshot: *(.*)" l;
         rs = pkgs.lib.lists.concatLists (
           pkgs.lib.lists.filter (l: l != null)
-            (builtins.map (l: builtins.match "^resolver: *(.*)" l)
+            (builtins.map matchLine
               (pkgs.lib.splitString "\n" rawStackYaml)));
       in
         pkgs.lib.lists.head (rs ++ [ null ]);

--- a/nix-tools/nix-tools/lib/Stack2nix/Stack.hs
+++ b/nix-tools/nix-tools/lib/Stack2nix/Stack.hs
@@ -190,7 +190,8 @@ instance FromJSON Location where
 
 instance FromJSON Stack where
   parseJSON = withObject "Stack" $ \s -> Stack
-    <$> s .: "resolver"
+    -- `snapshot` is the modern synonym for `resolver` (stack >= 2.15.1).
+    <$> (s .: "resolver" <|> s .: "snapshot")
     <*> s .:? "compiler" .!= Nothing
     <*> ((<>) <$> s .:? "packages"   .!= [LocalPath "."]
               <*> s .:? "extra-deps" .!= [])
@@ -199,7 +200,7 @@ instance FromJSON Stack where
 
 instance FromJSON StackSnapshot where
   parseJSON = withObject "Snapshot" $ \s -> Snapshot
-    <$> s .: "resolver"
+    <$> (s .: "resolver" <|> s .: "snapshot")
     <*> s .:? "compiler" .!= Nothing
     <*> s .: "name"
     <*> s .:? "packages" .!= []


### PR DESCRIPTION
Stack 2.15.1 renamed the top-level `resolver:` key in `stack.yaml` to `snapshot:` (both remain accepted, and `stack new` now emits `snapshot:`). haskell.nix only recognised `resolver:`, so a project with a `snapshot:`-only `stack.yaml` fails during project evaluation with:

```
stack-repos: AesonException "Error in $: key \"resolver\" not found"
CallStack (from HasCallStack):
  error, called at lib/StackRepos.hs:36:15 ...
```

(see #2506).

### Changes

- **`nix-tools/nix-tools/lib/Stack2nix/Stack.hs`** — accept `snapshot` as a synonym for `resolver` in both the `FromJSON Stack` and `FromJSON StackSnapshot` instances (`s .: "resolver" <|> s .: "snapshot"`). `<|>` is already imported and used by the `Location` instance.
- **`lib/fetch-resolver.nix`** — match `^snapshot:` as well as `^resolver:` when locating a resolver that points to another file.

### Verification

- `lib/fetch-resolver.nix`: evaluated on a `snapshot: lts-22.0` `stack.yaml` returns `"lts-22.0"`; a `resolver: lts-21.0` one still returns `"lts-21.0"`.
- Built `stack-repos` from this source and ran it:
  - `snapshot: lts-22.0` → succeeds (`repos.json` produced) — previously crashed with `key "resolver" not found`.
  - `resolver: lts-21.0` → still succeeds (no regression).

Fixes #2506.