### PR TITLE
Quick fixes: shell-for null name, hie output, includeDirs, haddock ghcOptions/hydra, CRLF parsing

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -681,6 +681,13 @@ let
       (lib.optionalString stdenv.hostPlatform.isWindows ''
         export pkgsHostTargetAsString="''${pkgsHostTarget[@]}"
       '') +
+      # GHC only creates the -hiedir when it actually writes a .hie file, so a
+      # component with no compiled modules would leave the `hie` output missing
+      # and fail the derivation.  Create it up front so an empty HIE output is
+      # a valid result (see #1242).
+      (lib.optionalString writeHieFiles ''
+        mkdir -p $hie
+      '') +
       # The following could be refactored but would lead to many rebuilds
 
       # In case of content addressed components we need avoid parallel building (passing -j1)

--- a/builder/haddock-builder.nix
+++ b/builder/haddock-builder.nix
@@ -122,6 +122,10 @@ let
         ${lib.optionalString doHoogle "--hoogle"} \
         ${lib.optionalString hyperlinkSource "--hyperlink-source"} \
         ${lib.optionalString quickjump "--quickjump"} \
+        ${# Pass the component's ghcOptions on to the GHC invocations haddock
+          # makes, so haddock sees the same language extensions/options the
+          # build used (see #2129).
+          lib.concatStringsSep " " (map (o: "--haddock-option=--optghc=${o}") component.ghcOptions)} \
         ${lib.concatStringsSep " " setupHaddockFlags}
       }
       runHook postHaddock
@@ -144,6 +148,12 @@ let
            mkdir -p "$docdir"
 
            cp -R "$html" "$docdir"/html
+
+           # Advertise the haddock output to hydra so it appears in the build
+           # products (and is browsable in the hydra UI), mirroring what the
+           # coverage builder does for reports (see #2029).
+           mkdir -p $doc/nix-support
+           echo "doc haddock $docdir/html" >> $doc/nix-support/hydra-build-products
         fi
 
         ${ghc.targetPrefix}ghc-pkg -v0 init $out/package.conf.d

--- a/builder/haddock-builder.nix
+++ b/builder/haddock-builder.nix
@@ -124,8 +124,12 @@ let
         ${lib.optionalString quickjump "--quickjump"} \
         ${# Pass the component's ghcOptions on to the GHC invocations haddock
           # makes, so haddock sees the same language extensions/options the
-          # build used (see #2129).
-          lib.concatStringsSep " " (map (o: "--haddock-option=--optghc=${o}") component.ghcOptions)} \
+          # build used (see #2129).  Split each option string into words (as
+          # cabal does for its own `--ghc-options`) so each flag becomes its
+          # own `--optghc`, and shell-escape every argument so options
+          # containing whitespace or shell-special characters survive intact.
+          lib.escapeShellArgs (map (o: "--haddock-option=--optghc=${o}")
+            (lib.filter (o: o != "") (lib.concatMap (lib.splitString " ") component.ghcOptions)))} \
         ${lib.concatStringsSep " " setupHaddockFlags}
       }
       runHook postHaddock

--- a/builder/make-config-files.nix
+++ b/builder/make-config-files.nix
@@ -69,7 +69,9 @@ let
     ${lib.concatStringsSep "\n" (lib.mapAttrsToList flagsAndConfig {
       "extra-lib-dirs" = map (p: "${lib.getLib p}/lib") (lib.flatten component.libs);
       "extra-include-dirs" = map (p: "${lib.getDev p}/include") (lib.flatten component.libs)
-        ++ map toString component.includeDirs;
+        # `includeDirs` is absent from synthetic components (e.g. the dummy
+        # component `shell-for` builds), so default it (see #679).
+        ++ map toString (component.includeDirs or []);
       "extra-framework-dirs" = lib.optionals (stdenv.hostPlatform.isDarwin)
         (map (p: "${p}/Library/Frameworks") component.frameworks);
     })}

--- a/builder/make-config-files.nix
+++ b/builder/make-config-files.nix
@@ -68,7 +68,8 @@ let
 
     ${lib.concatStringsSep "\n" (lib.mapAttrsToList flagsAndConfig {
       "extra-lib-dirs" = map (p: "${lib.getLib p}/lib") (lib.flatten component.libs);
-      "extra-include-dirs" = map (p: "${lib.getDev p}/include") (lib.flatten component.libs);
+      "extra-include-dirs" = map (p: "${lib.getDev p}/include") (lib.flatten component.libs)
+        ++ map toString component.includeDirs;
       "extra-framework-dirs" = lib.optionals (stdenv.hostPlatform.isDarwin)
         (map (p: "${p}/Library/Frameworks") component.frameworks);
     })}

--- a/builder/shell-for.nix
+++ b/builder/shell-for.nix
@@ -58,7 +58,10 @@ let
         (haskellLib.flatLibDepends {depends = directlySelectedComponents;}));
 
   isSelectedComponent =
-    comp: selectedComponentsBitmap."${((haskellLib.dependToLib comp).name or null)}" or false;
+    # `.name` can be absent for some dependency configs; fall back to "" so the
+    # attribute lookup yields the `or false` branch instead of failing with
+    # "cannot coerce null to a string" (see #1985).
+    comp: selectedComponentsBitmap."${((haskellLib.dependToLib comp).name or "")}" or false;
   selectedComponentsBitmap =
     lib.mapAttrs
       (_: x: (builtins.any isSelectedComponent x.config.depends))

--- a/lib/cabal-project-parser.nix
+++ b/lib/cabal-project-parser.nix
@@ -1,5 +1,14 @@
 { pkgs }:
 let
+  # Strip carriage returns so a cabal.project checked out with CRLF line
+  # endings parses the same as one with LF endings.  Without this every
+  # `splitString "\n"` below leaves a trailing "\r" on each line, silently
+  # corrupting extracted values (locations, tags, subdirs, sha256 comments)
+  # and block boundaries (see #1090).  Note: this drops string context, so
+  # callers that need it (e.g. builtins.split's context trick) must derive it
+  # from the original, un-normalised argument.
+  normalizeCRLF = builtins.replaceStrings [ "\r\n" ] [ "\n" ];
+
   span = pred: list:
     let n = pkgs.lib.lists.foldr (x: acc: if pred x then acc + 1 else 0) 0 list;
     in { fst = pkgs.lib.lists.take n list; snd = pkgs.lib.lists.drop n list; };
@@ -10,7 +19,7 @@ let
         indexState = pkgs.lib.lists.concatLists (
           pkgs.lib.lists.filter (l: l != null)
             (builtins.map (l: builtins.match "^index-state: *(.*)" l)
-              (pkgs.lib.splitString "\n" rawCabalProject)));
+              (pkgs.lib.splitString "\n" (normalizeCRLF rawCabalProject))));
       in
         pkgs.lib.lists.head (indexState ++ [ null ]);
 
@@ -124,10 +133,11 @@ let
 
   parseSourceRepositoryPackages = cabalProjectFileName: sha256map: source-repo-override: projectFile:
     let
-      splitResult = builtins.split "\n( *)source-repository-package\n" ("\n" + projectFile);
+      splitResult = builtins.split "\n( *)source-repository-package\n" ("\n" + normalizeCRLF projectFile);
       # builtins.split strips string context. Use substring to create a zero-length
       # string with the original context, then prepend it to carry context through
       # via concatenation (which doesn't validate paths like appendContext does).
+      # (Derived from the un-normalised projectFile so the context is preserved.)
       contextStr = builtins.substring 0 0 projectFile;
       # Construct a list of strings with just the indentation amounts for each map
       indentations = builtins.concatLists (builtins.filter builtins.isList splitResult);
@@ -220,7 +230,7 @@ let
   parseRepositories = evalPackages: cabalProjectFileName: sha256map: inputMap: nix-tools: projectFile:
     let
       # This will leave the name of repository in the first line of each block
-      blocks = pkgs.lib.splitString "\nrepository " ("\n" + projectFile);
+      blocks = pkgs.lib.splitString "\nrepository " ("\n" + normalizeCRLF projectFile);
       repoBlocks = builtins.map (parseRepositoryBlock evalPackages cabalProjectFileName sha256map inputMap nix-tools) (pkgs.lib.lists.drop 1 blocks);
     in {
       extra-hackages = pkgs.lib.lists.map (block: block.hackage) repoBlocks;

--- a/test/unit.nix
+++ b/test/unit.nix
@@ -167,6 +167,34 @@ lib.runTests {
       expected = true;
     };
 
+  # #1090: a cabal.project with CRLF line endings must parse identically to one
+  # with LF endings (no stray "\r" left on extracted values).
+  testParseIndexStateCRLF = {
+    expr = haskellLib.parseIndexState (builtins.replaceStrings [ "\n" ] [ "\r\n" ] ''
+      index-state: 2021-07-20T00:00:00Z
+      packages: ./*.cabal
+    '');
+    expected = "2021-07-20T00:00:00Z";
+  };
+
+  testParseSourceRepoPackagesCRLF =
+    let
+      lf = ''
+        packages: ./*.cabal
+
+        source-repository-package
+          type: git
+          location: https://github.com/input-output-hk/haskell.nix.git
+          tag: 487eea1c249537d34c27f6143dff2b9d5586c657
+          --sha256: 077j5j3j86qy1wnabjlrg4dmqy1fv037dyq3xb8ch4ickpxxs123
+      '';
+      crlf = builtins.replaceStrings [ "\n" ] [ "\r\n" ] lf;
+      sourceRepos = f: __toJSON (haskellLib.parseSourceRepositoryPackages "cabal.project" {} {} f).sourceRepos;
+    in {
+      expr = sourceRepos crlf;
+      expected = sourceRepos lf;
+    };
+
   testParseRepositoryBlock =
     let
       # The Cabal2Nix output in hackage-to-nix is imported into a lambda


### PR DESCRIPTION
## Summary

A bundle of six small, independent bug-fixes surfaced during a sweep of the open
issue backlog. Each is self-contained and touches a different part of the nix
code, so they review and revert independently.

| Issue | Fix | File |
| --- | --- | --- |
| #1985 | `(...).name or null` → `or ""` so an absent `name` yields the `or false` branch instead of `cannot coerce null to a string` | `builder/shell-for.nix` |
| #1242 | create the `hie` output up front (`mkdir -p $hie`) so a module-less component with `writeHieFiles = true` doesn't fail with "failed to produce output" | `builder/comp-builder.nix` |
| #679  | actually consume the declared-but-ignored `includeDirs` component option (append it to `extra-include-dirs`) | `builder/make-config-files.nix` |
| #2129 | thread the component's `ghcOptions` into haddock's GHC invocations via `--haddock-option=--optghc=…` | `builder/haddock-builder.nix` |
| #2029 | emit `nix-support/hydra-build-products` for the haddock `doc` output, so hydra lists/serves it | `builder/haddock-builder.nix` |
| #1090 | normalise CRLF (`\r\n` → `\n`) before line-splitting in the cabal.project parser, so a CRLF checkout parses identically to LF | `lib/cabal-project-parser.nix` |

Each commit uses `Fixes #NNNN`, so merging closes all six issues.

## Tests

* **#1090** has a dedicated pure-eval regression test in `test/unit.nix`
  (`testParseIndexStateCRLF`, `testParseSourceRepoPackagesCRLF`): it feeds a
  CRLF-ified project file through the parser and asserts the result matches the
  LF case. Runs under the existing `unit.tests` suite.
* The other five are builder-level changes whose natural regression tests are
  build-based `test/` projects (each requires a full GHC build and is gated by
  the compiler-matrix CI rather than a fast local eval). I've left those out of
  this PR to keep it small and reviewable; happy to add them if you'd like — the
  shapes I have in mind:
  * #1242 — a library with no exposed/other modules built with `writeHieFiles = true`.
  * #679 — a C-FFI package whose header is supplied only via `includeDirs`.
  * #2129 — a library needing a language extension supplied only via `ghcOptions`, with `doHaddock = true`.
  * #2029 — assert the `doc` output of an existing haddock test contains `nix-support/hydra-build-products`.

## Verification done

All six were checked against `master` to confirm the bug is live (exact
`file:line` for each is in the commit messages), and every edited file
`nix-instantiate --parse`s cleanly. The `unit.tests` suite passes with the new
CRLF tests.

## Notes

* #1985 fixes the user-visible symptom; the deeper question of *why* a dependency
  config can lack `.name` is the (separate, unreproducible) #1717 — the fallback
  here is safe regardless.
* #1090 uses `replaceStrings ["\r\n"] ["\n"]` (handles the reported CRLF case);
  lone classic-Mac `\r` is not normalised.

---

Closes #1985.
Closes #1242.
Closes #679.
Closes #2129.
Closes #2029.
Closes #1090.
