### PR TITLE
stack: keep symlinked stack.yaml targets in the source filter (#801)

### DIFF
--- a/lib/call-stack-to-nix.nix
+++ b/lib/call-stack-to-nix.nix
@@ -31,7 +31,10 @@ let
     src = src.origSrc or src;
     filter = path: type: (!(src ? filter) || src.filter path type) && (
       type == "directory" ||
-      evalPackages.lib.any (i: (evalPackages.lib.hasSuffix i path)) [ stackYaml ".cabal" "package.yaml" ]); });
+      # Keep any `.yaml` (not just `stackYaml`) so that when `stack.yaml` is a
+      # symlink to e.g. `stack-8.6.5.yaml`, the symlink target is retained too;
+      # otherwise it is filtered out and the symlink dangles (#801).
+      evalPackages.lib.any (i: (evalPackages.lib.hasSuffix i path)) [ stackYaml ".yaml" ".cabal" "package.yaml" ]); });
 
   stackToNixArgs = builtins.concatStringsSep " " [
     "--full"

--- a/lib/stack-cache-generator.nix
+++ b/lib/stack-cache-generator.nix
@@ -46,6 +46,10 @@ let
 
         in
           (relPath == stackYaml)
+          # Keep any `.yaml` so that a `stack.yaml` which is a symlink to e.g.
+          # `stack-8.6.5.yaml` still has its target present (otherwise the
+          # symlink dangles, #801).
+          || (evalPackages.lib.hasSuffix ".yaml" relPath)
           || (resolver != null && (relPath == resolver || isParent relPath resolver))
         ;
     };

--- a/test/default.nix
+++ b/test/default.nix
@@ -193,6 +193,7 @@ let
     stack-local-resolver = callTest ./stack-local-resolver {};
     stack-local-resolver-subdir = callTest ./stack-local-resolver-subdir {};
     stack-remote-resolver = callTest ./stack-remote-resolver {};
+    stack-symlink-yaml = callTest ./stack-symlink-yaml {};
     shell-for-setup-deps = callTest ./shell-for-setup-deps {};
     setup-deps = import ./setup-deps { inherit pkgs evalPackages compiler-nix-name; };
     callStackToNix = callTest ./call-stack-to-nix {};

--- a/test/stack-symlink-yaml/.gitignore
+++ b/test/stack-symlink-yaml/.gitignore
@@ -1,0 +1,2 @@
+/.stack-work/
+/*.cabal

--- a/test/stack-symlink-yaml/default.nix
+++ b/test/stack-symlink-yaml/default.nix
@@ -1,0 +1,19 @@
+{ lib, project', testSrc, compiler-nix-name, evalPackages }:
+
+let
+  project = project' {
+    src = testSrc "stack-symlink-yaml";
+    inherit evalPackages;
+  };
+  packages = project.hsPkgs;
+
+# Regression test for #801: `stack.yaml` is a symlink to `stack-real.yaml`.
+# The source filter must retain the symlink target, otherwise stack-to-nix
+# sees a dangling symlink and fails with "file does not exist".
+in lib.recurseIntoAttrs {
+  meta.disabled = compiler-nix-name != "ghc984";
+  ifdInputs = {
+    inherit (project) stack-nix;
+  };
+  inherit (packages.stack-symlink-yaml.components) library;
+}

--- a/test/stack-symlink-yaml/package.yaml
+++ b/test/stack-symlink-yaml/package.yaml
@@ -1,0 +1,7 @@
+name: stack-symlink-yaml
+
+dependencies:
+- base
+
+library:
+  source-dirs: src

--- a/test/stack-symlink-yaml/src/Lib.hs
+++ b/test/stack-symlink-yaml/src/Lib.hs
@@ -1,0 +1,6 @@
+module Lib
+    ( someFunc
+    ) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/test/stack-symlink-yaml/stack-real.yaml
+++ b/test/stack-symlink-yaml/stack-real.yaml
@@ -1,0 +1,4 @@
+resolver: lts-23.7
+
+packages:
+- .

--- a/test/stack-symlink-yaml/stack.yaml
+++ b/test/stack-symlink-yaml/stack.yaml
@@ -1,0 +1,1 @@
+stack-real.yaml


### PR DESCRIPTION
## Summary

Projects whose `stack.yaml` is a symlink to another yaml file (e.g. `stack.yaml -> stack-8.6.5.yaml`, as reported against amazonka) failed with `file does not exist`.

The source filters used to build the stack-to-nix inputs kept only paths ending in the configured `stackYaml` name, `.cabal`, or `package.yaml`:

- `lib/call-stack-to-nix.nix`
- `lib/stack-cache-generator.nix`

The symlink itself matched (its path ends in `stack.yaml`), but its **target** (`stack-8.6.5.yaml`) matched none of the suffixes, so it was filtered out — leaving a dangling symlink in the cleaned source, which then failed with the reported error.

## Fix

Widen both filters to also keep any `*.yaml`, so the symlink target is retained alongside the symlink.

## Test

Adds `test/stack-symlink-yaml`, a stack project whose `stack.yaml` is a symlink to `stack-real.yaml`, wired into `test/default.nix` (gated to `ghc984`, like the sibling stack tests).

Verified locally:
- The filter predicate keeps `stack-real.yaml` after the change and dropped it before (direct eval of the predicate).
- `nix-instantiate ... -A stack-symlink-yaml.ifdInputs.stack-nix` succeeds — the `stack-repos` cache step now resolves the symlink and the `stack-to-nix-pkgs` derivation instantiates.
- **Load-bearing check:** temporarily reverting just the `stack-cache-generator.nix` clause reproduces the exact bug — `substitute(): ERROR: file 'stack.yaml' does not exist` — and restoring it fixes it.

The full stack IFD build (fetching the resolver + building the library) was not run locally; it needs network and `ghc984` and is exercised by CI.

Closes #801.
