### PR TITLE
nix-tools: make custom stack snapshot 'name' optional (#1678)

### DIFF
--- a/nix-tools/nix-tools/lib/Stack2nix/Stack.hs
+++ b/nix-tools/nix-tools/lib/Stack2nix/Stack.hs
@@ -202,7 +202,11 @@ instance FromJSON StackSnapshot where
   parseJSON = withObject "Snapshot" $ \s -> Snapshot
     <$> (s .: "resolver" <|> s .: "snapshot")
     <*> s .:? "compiler" .!= Nothing
-    <*> s .: "name"
+    -- `name` is optional for custom snapshots (stack itself does not require
+    -- it) and stack-to-nix discards it anyway (bound as `_name` in
+    -- Stack2nix.External.Resolve.resolveSnapshot), so default it rather than
+    -- fail parsing with `key "name" not found` (see #1678, #1157).
+    <*> s .:? "name" .!= "custom-snapshot"
     <*> s .:? "packages" .!= []
     <*> s .:? "flags" .!= mempty
     <*> s .:? "ghc-options" .!= mempty

--- a/nix-tools/nix-tools/nix-tools.cabal
+++ b/nix-tools/nix-tools/nix-tools.cabal
@@ -281,3 +281,18 @@ test-suite tests
                      , cabal-install:cabal
   hs-source-dirs:      tests
   default-language:    Haskell2010
+
+-- Pure parser tests (no external programs / network), kept separate from the
+-- golden `tests` suite above so they can run standalone.
+test-suite stack-parser-tests
+  import:              warnings
+  type:                exitcode-stdio-1.0
+  main-is:             StackParserTests.hs
+  build-depends:       base
+                     , bytestring
+                     , nix-tools
+                     , tasty
+                     , tasty-hunit
+                     , yaml
+  hs-source-dirs:      tests
+  default-language:    Haskell2010

--- a/nix-tools/nix-tools/tests/StackParserTests.hs
+++ b/nix-tools/nix-tools/tests/StackParserTests.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Pure parser tests for the stack.yaml / custom-snapshot decoders in
+-- "Stack2nix.Stack".  These need no external programs or network, unlike the
+-- golden tests in "Tests.hs".
+module Main (main) where
+
+import Data.ByteString (ByteString)
+import qualified Data.Yaml as Yaml
+import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.HUnit (assertFailure, testCase, (@?=))
+
+import Stack2nix.Stack (StackSnapshot (..))
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests =
+  testGroup
+    "Stack2nix.Stack parser"
+    [ testCase "custom snapshot without a name parses (#1678)" $
+        -- stack does not require `name:` in a custom snapshot, and
+        -- stack-to-nix discards it, so a name-less snapshot must parse.
+        snapshotName "resolver: lts-18.0\n" @?== "custom-snapshot"
+    , testCase "custom snapshot keeps an explicit name" $
+        snapshotName "resolver: lts-18.0\nname: my-snapshot\n" @?== "my-snapshot"
+    ]
+  where
+    -- Decode a snapshot document and project out its (defaulted) name.
+    snapshotName :: ByteString -> IO String
+    snapshotName doc =
+      case Yaml.decodeEither' doc of
+        Left err -> assertFailure ("failed to parse snapshot: " ++ show err)
+        Right (Snapshot _ _ name _ _ _) -> pure name
+
+    -- Run the IO action and compare its result.
+    (@?==) :: (Eq a, Show a) => IO a -> a -> IO ()
+    action @?== expected = action >>= (@?= expected)

--- a/test/cabal.project.local
+++ b/test/cabal.project.local
@@ -26,7 +26,7 @@ repository head.hackage.ghc.haskell.org
      f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
      26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
      7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-  --sha256: sha256-/whyl1wolN/UJ6m404lrmUSrqMZKkbMD9CMX+6I1rMA=
+  --sha256: sha256-MnmVhCSUFAVA2BWCP8y8MwGld2HphdVBDPmBui79/5E=
 
 repository ghcjs-overlay
   url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/ffb32dce467b9a4d27be759fdd2740a6edd09d0b


### PR DESCRIPTION
## Summary

A custom stack snapshot file without a `name:` field failed to parse:

```
AesonException "Error in $: key \"name\" not found"
```

even though stack itself does not require `name` in a custom snapshot, and
stack-to-nix never uses the value — it is bound as `_name` and discarded in
`Stack2nix.External.Resolve.resolveSnapshot`.

The `FromJSON StackSnapshot` instance (`nix-tools/nix-tools/lib/Stack2nix/Stack.hs`)
now parses `name` with `.:?` and a `"custom-snapshot"` default instead of the
required `.: "name"`, so name-less custom snapshots parse. An explicit `name:`
is still read as before. This also removes the sharp edge reported in #1157
(already closed, but its thread reports exactly this: "you get a very unhelpful
error if your resolver file does not have a `name:` field").

## Tests

Added a self-contained pure parser test-suite `stack-parser-tests`
(`nix-tools/nix-tools/tests/StackParserTests.hs`) with two cases:
- a name-less custom snapshot parses and defaults the name;
- an explicit `name:` is preserved.

It is kept separate from the existing golden `tests` suite because that suite
requires external programs (`make-install-plan`, `plan-to-nix`, `cabal`) and
network at startup, whereas these are pure.

## What was verified

The fix and both test cases were verified by compiling the **real**
`Stack2nix.Stack` module together with the new `StackParserTests.hs` against
GHC 9.10 / aeson 2.2 / yaml 0.11, and running them:

- with the fix, both cases pass;
- reverting just the new `.:? "name" .!= "custom-snapshot"` line back to
  `.: "name"` makes the first case fail with exactly the error from #1678 —
  `AesonException "Error in $: key \"name\" not found"` — so it is a real
  regression test, not a tautology;
- the new test file compiles clean under `-Wall` (the only warnings emitted are
  pre-existing ones in `Stack.hs`, unrelated to this change).

Also checked against the source: `Snapshot`'s constructor arity and field order
match the test's pattern, `Name` is `String` (so the `OverloadedStrings`
default resolves correctly), and `resolveSnapshot` binds the name as `_name`
and discards it — so defaulting it cannot change behaviour.

## Caveats

haskell.nix consumes nix-tools as a **prebuilt static binary** from a GitHub
release, so this change does not affect haskell.nix builds until a new
nix-tools release is cut.

Also note that **no cabal test-suite in this project currently runs in CI**, so
the new suite is developer-runnable but not enforced: both
`nix-tools/overlay.nix` and `nix-tools/static/project.nix` configure the project
with `--disable-tests` ("tests need to fetch hackage"), so test components are
absent from the plan entirely, and the `check-nix-tools` CI job builds only
`checks.x86_64-linux.truncate-index` (a hand-written nix derivation). Wiring
pure test suites into CI would be a separate change.

Closes #1678.
