### PR TITLE
cabal2nix: add --help/-h and a usage message (#1688)

### DIFF
--- a/nix-tools/nix-tools/cabal2nix/Main.hs
+++ b/nix-tools/nix-tools/cabal2nix/Main.hs
@@ -39,8 +39,26 @@ writeDoc file doc =
      hPutDoc handle doc
      hClose handle
 
+usage :: String
+usage = unlines
+  [ "cabal-to-nix - convert a Cabal package into a Nix expression"
+  , ""
+  , "Usage:"
+  , "  cabal-to-nix <url> <sha256>     fetch the package from <url> (must start"
+  , "                                  with http) at revision/hash <sha256> and"
+  , "                                  emit Nix for the cabal file(s) it contains"
+  , "  cabal-to-nix <path> <file>      emit Nix for the cabal <file>, using <path>"
+  , "                                  as the source location"
+  , "  cabal-to-nix <path> <dir>       emit a Nix set for a pkg/version/*.cabal"
+  , "                                  directory tree rooted at <dir>"
+  , "  cabal-to-nix <file>             like '<path> <file>' with <path> = \".\""
+  , "  cabal-to-nix <dir>              like '<path> <dir>' with <path> = \".\""
+  , "  cabal-to-nix --help, -h         show this help"
+  ]
+
 main :: IO ()
 main = getArgs >>= \case
+  args | args `elem` [["--help"], ["-h"]] -> putStr usage
   [url,hash] | "http" `isPrefixOf` url ->
           let subdir = "." in
           fetch (\dir -> cabalFromPath url hash subdir $ dir </> subdir)
@@ -58,7 +76,7 @@ main = getArgs >>= \case
   [file] -> doesDirectoryExist file >>= \case
     False -> nixFromCabal "." (OnDisk file)
     True  -> print . prettyNix =<< cabalexprs file
-  _ -> die "call with cabalfile (Cabal2Nix file.cabal)."
+  _ -> die usage
   where
     nixFromCabal path cabal =
       print . prettyNix =<< cabal2nix False MinimalDetails (Just (Path path)) cabal

--- a/nix-tools/nix-tools/cabal2nix/Main.hs
+++ b/nix-tools/nix-tools/cabal2nix/Main.hs
@@ -44,9 +44,10 @@ usage = unlines
   [ "cabal-to-nix - convert a Cabal package into a Nix expression"
   , ""
   , "Usage:"
-  , "  cabal-to-nix <url> <sha256>     fetch the package from <url> (must start"
-  , "                                  with http) at revision/hash <sha256> and"
-  , "                                  emit Nix for the cabal file(s) it contains"
+  , "  cabal-to-nix <url> <rev>        fetch the package from <url> (must start"
+  , "                                  with http) at revision/ref <rev> and emit"
+  , "                                  Nix for the cabal file(s) it contains (the"
+  , "                                  sha256 is prefetched, not supplied here)"
   , "  cabal-to-nix <path> <file>      emit Nix for the cabal <file>, using <path>"
   , "                                  as the source location"
   , "  cabal-to-nix <path> <dir>       emit a Nix set for a pkg/version/*.cabal"
@@ -59,9 +60,9 @@ usage = unlines
 main :: IO ()
 main = getArgs >>= \case
   args | args `elem` [["--help"], ["-h"]] -> putStr usage
-  [url,hash] | "http" `isPrefixOf` url ->
+  [url,rev] | "http" `isPrefixOf` url ->
           let subdir = "." in
-          fetch (\dir -> cabalFromPath url hash subdir $ dir </> subdir)
+          fetch (\dir -> cabalFromPath url rev subdir $ dir </> subdir)
             (Source url mempty UnknownHash) >>= \case
             (Just (DerivationSource{..}, genBindings)) -> genBindings derivHash
             _ -> return ()

--- a/nix-tools/nix-tools/nix-tools.cabal
+++ b/nix-tools/nix-tools/nix-tools.cabal
@@ -278,6 +278,7 @@ test-suite tests
                      , tasty-golden
   build-tool-depends:  nix-tools:make-install-plan
                      , nix-tools:plan-to-nix
+                     , nix-tools:cabal-to-nix
                      , cabal-install:cabal
   hs-source-dirs:      tests
   default-language:    Haskell2010

--- a/nix-tools/nix-tools/tests/Tests.hs
+++ b/nix-tools/nix-tools/tests/Tests.hs
@@ -1,18 +1,51 @@
 import Control.Monad (when)
 import qualified Data.ByteString as BS
+import Data.List (isInfixOf)
 import Data.Maybe (isNothing)
 import System.Directory (copyFile, createDirectoryIfMissing, removeDirectoryRecursive, withCurrentDirectory)
 import System.Directory.Extra (findExecutable, listFiles)
 import System.Environment (setEnv)
+import System.Exit (ExitCode (..))
 import System.FilePath (replaceExtension, takeBaseName, takeExtensions, (</>))
 import System.IO.Extra (newTempDir)
-import System.Process (callCommand)
-import Test.Tasty (defaultMain, testGroup, withResource)
+import System.Process (callCommand, readProcessWithExitCode)
+import Test.Tasty (TestTree, defaultMain, testGroup, withResource)
 import Test.Tasty.Golden.Advanced (goldenTest2)
 import Test.Tasty.Providers
 
 main :: IO ()
-main = goldenTests >>= defaultMain
+main = do
+  golden <- goldenTests
+  -- The cli smoke tests are kept outside `goldenTests` so they don't get
+  -- wrapped in the network-dependent `cabal update` resource below.
+  defaultMain $ testGroup "nix-tools" [testGroup "cli" cliTests, golden]
+
+-- | Lightweight smoke tests for executable command-line handling that need
+-- neither the Hackage index nor golden files.
+cliTests :: [TestTree]
+cliTests =
+  [ singleTest "cabal-to-nix --help exits 0 and prints usage" $
+      ShellCheck $ do
+        (code, out, err) <- readProcessWithExitCode "cabal-to-nix" ["--help"] ""
+        return (checkHelp code (out ++ err))
+  ]
+
+-- | Assertion for the `--help` smoke test, factored out so it is pure and
+-- easy to reason about: help must exit successfully and mention the usage.
+checkHelp :: ExitCode -> String -> Maybe String
+checkHelp ExitSuccess out
+  | "Usage:" `isInfixOf` out = Nothing
+  | otherwise = Just ("--help exited 0 but output did not contain \"Usage:\":\n" ++ out)
+checkHelp (ExitFailure n) out =
+  Just ("--help exited with code " ++ show n ++ ":\n" ++ out)
+
+-- | Minimal tasty provider: run an 'IO' action returning 'Nothing' on success
+-- or 'Just' an error message on failure. Avoids pulling in tasty-hunit.
+newtype ShellCheck = ShellCheck (IO (Maybe String))
+
+instance IsTest ShellCheck where
+  run _ (ShellCheck act) _ = maybe (testPassed "") testFailed <$> act
+  testOptions = return []
 
 goldenTests :: IO TestTree
 goldenTests = do

--- a/nix-tools/nix-tools/tests/Tests.hs
+++ b/nix-tools/nix-tools/tests/Tests.hs
@@ -26,8 +26,14 @@ cliTests :: [TestTree]
 cliTests =
   [ singleTest "cabal-to-nix --help exits 0 and prints usage" $
       ShellCheck $ do
-        (code, out, err) <- readProcessWithExitCode "cabal-to-nix" ["--help"] ""
-        return (checkHelp code (out ++ err))
+        -- Preflight the executable so a missing `cabal-to-nix` on PATH becomes a
+        -- clear test failure rather than an IOException that aborts the run.
+        mexe <- findExecutable "cabal-to-nix"
+        case mexe of
+          Nothing -> return (Just "cabal-to-nix is not on PATH")
+          Just _  -> do
+            (code, out, err) <- readProcessWithExitCode "cabal-to-nix" ["--help"] ""
+            return (checkHelp code (out ++ err))
   ]
 
 -- | Assertion for the `--help` smoke test, factored out so it is pure and


### PR DESCRIPTION
## Summary

`cabal-to-nix` had no `--help`: it pattern-matched raw `getArgs`, so `cabal-to-nix --help` fell into the single-file case and failed with a file-not-found-style error (#1688). Sibling nix-tools executables (`stack-to-nix`, `plan-to-nix`) already have proper CLIs, so this one was the outlier.

- Intercept `--help`/`-h` and print a usage string describing the three accepted argument forms, exiting 0.
- Reuse that same usage text for the argument-error fallback (previously the terse `die "call with cabalfile (Cabal2Nix file.cabal)."`).

This is the minimal, low-risk change. A full `optparse-applicative` port (as the alternative in the issue) would require multi-arity positional parsing to preserve the three existing call shapes, so I kept the diff small.

## Test

Adds a lightweight `tasty` smoke test (new `cli` group) asserting `cabal-to-nix --help` exits 0 and prints usage. It's kept **outside** the existing golden-test `withResource` wrapper so it needs neither the Hackage index nor network, and it uses a tiny custom provider (10 lines) to avoid adding a `tasty-hunit` dependency. `cabal-to-nix` is added to the test-suite `build-tool-depends` so it's on `PATH`.

## What I verified

nix-tools is consumed by haskell.nix as a **prebuilt static binary from a release**, so this change won't affect haskell.nix builds until the next nix-tools release.

I could not compile the full package in-worktree (it pins `with-compiler: ghc-9.6` and needs the whole hnix/Cabal source closure; only a ghc-9.14 shim was available). Instead:

- **`cabal2nix/Main.hs`**: reproduced the exact changed logic (the `usage` binding, the new guarded `LambdaCase` alternative with guard fall-through, and `die usage`) in a faithful standalone module and compiled + ran it with GHC — `--help`/`-h` print the usage and exit 0; a bad multi-arg invocation exits 1; a single real argument still routes to the normal processing path. Typecheck and runtime behaviour confirmed.
- **`tests/Tests.hs`**: the pure assertion helper `checkHelp` was typechecked and run standalone (correct for exit-0-with-usage, exit-0-without-usage, and non-zero-exit cases). The `tasty` provider wiring itself was not compiled here (tasty isn't in the bare GHC's package DB) but uses the already-imported, stable `Test.Tasty.Providers` API.

Closes #1688.
