### PR TITLE
stack2nix: accept array-form ghc-options in snapshots (#1676)

### DIFF
--- a/nix-tools/nix-tools/lib/Stack2nix.hs
+++ b/nix-tools/nix-tools/lib/Stack2nix.hs
@@ -38,7 +38,7 @@ import Cabal2Nix.Util
 import Stack2nix.Cache (appendCache, cacheHits)
 import Stack2nix.CLI (Args(..))
 import Stack2nix.Project
-import Stack2nix.Stack (Stack(..), Dependency(..), Location(..), PackageFlags, GhcOptions)
+import Stack2nix.Stack (Stack(..), Dependency(..), Location(..), PackageFlags, GhcOptions, GhcOptionsValue(..))
 import Stack2nix.External.Resolve
 
 import qualified Data.HashMap.Strict as HM
@@ -131,11 +131,13 @@ flags2nix pkgFlags =
   | (pkgName, flags) <- HM.toList pkgFlags
   ]
 
--- | Converts 'GhcOptions' into @{ packageName = { ghcOptions = "..."; }; }@
+-- | Converts 'GhcOptions' into @{ packageName = { ghcOptions = [ "..." ]; }; }@
+-- Each option token becomes its own list element (previously a multi-word
+-- string was emitted as a single element; see #1676).
 ghcOptions2nix :: GhcOptions -> [Binding NExpr]
 ghcOptions2nix ghcOptions =
   [ quoted pkgName $= mkNonRecSet
-    [ "ghcOptions" $= mkList [ mkStr opts ] ]
+    [ "ghcOptions" $= mkList (map mkStr (ghcOptionsTokens opts)) ]
   | (pkgName, opts) <- HM.toList ghcOptions
   ]
 

--- a/nix-tools/nix-tools/lib/Stack2nix/Stack.hs
+++ b/nix-tools/nix-tools/lib/Stack2nix/Stack.hs
@@ -15,6 +15,7 @@ module Stack2nix.Stack
   , StackSnapshot(..)
   , PackageFlags
   , GhcOptions
+  , GhcOptionsValue(..)
   , parsePackageIdentifier
   ) where
 
@@ -124,7 +125,23 @@ data Dependency
 -- flags are { pkg -> { flag -> bool } }
 type PackageFlags = HM.HashMap T.Text (HM.HashMap T.Text Bool)
 
-type GhcOptions = HM.HashMap T.Text T.Text
+-- | A package's @ghc-options@ value.  In @stack.yaml@ this is written as a
+-- single string (@"-O2 -Wall"@), but in snapshot/resolver definitions stack
+-- writes it as an array of strings (@["-O2", "-Wall"]@).  We accept both and
+-- normalise to a list of individual option tokens (see #1676).
+newtype GhcOptionsValue = GhcOptionsValue { ghcOptionsTokens :: [T.Text] }
+  deriving (Show)
+
+instance FromJSON GhcOptionsValue where
+  parseJSON v = GhcOptionsValue <$> (asList <|> asScalar)
+    where
+      -- array form: [String] (each element further split on whitespace so an
+      -- element like "-O2 -Wall" is still handled)
+      asList   = concatMap T.words <$> parseJSON v
+      -- scalar form: a single whitespace-separated String
+      asScalar = T.words <$> parseJSON v
+
+type GhcOptions = HM.HashMap T.Text GhcOptionsValue
 
 data Stack
   = Stack Resolver (Maybe Compiler) [Dependency] PackageFlags GhcOptions

--- a/nix-tools/nix-tools/nix-tools.cabal
+++ b/nix-tools/nix-tools/nix-tools.cabal
@@ -281,3 +281,20 @@ test-suite tests
                      , cabal-install:cabal
   hs-source-dirs:      tests
   default-language:    Haskell2010
+
+-- Pure parser tests (no external tools or network), kept separate from the
+-- golden `tests` suite above so they can run in isolation.
+test-suite stack-ghc-options-tests
+  import:              warnings
+  type:                exitcode-stdio-1.0
+  main-is:             StackGhcOptionsTests.hs
+  build-depends:       base
+                     , bytestring
+                     , nix-tools
+                     , tasty
+                     , tasty-hunit
+                     , text
+                     , unordered-containers
+                     , yaml
+  hs-source-dirs:      tests
+  default-language:    Haskell2010

--- a/nix-tools/nix-tools/tests/StackGhcOptionsTests.hs
+++ b/nix-tools/nix-tools/tests/StackGhcOptionsTests.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Self-contained parser tests for #1676: a package's @ghc-options@ must
+-- parse whether it is written as a single string (as in @stack.yaml@) or as
+-- an array of strings (as in snapshot/resolver definitions).  These tests are
+-- pure (no external tools or network), unlike the golden @tests@ suite.
+module Main (main) where
+
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Text as T
+import Data.Yaml (decodeEither')
+
+import Stack2nix.Stack (Stack(..), StackSnapshot(..), GhcOptionsValue(..))
+
+import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.HUnit (testCase, assertEqual, assertFailure)
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "ghc-options parsing (#1676)"
+  [ testCase "stack.yaml scalar-string ghc-options" $ do
+      let yaml = BS.unlines
+            [ "resolver: lts-20.0"
+            , "ghc-options:"
+            , "  mypkg: -O2 -Wall"
+            ]
+      case decodeEither' yaml of
+        Left err -> assertFailure ("failed to parse Stack: " ++ show err)
+        Right (Stack _ _ _ _ ghcOpts) ->
+          assertEqual "tokens" (Just ["-O2", "-Wall"]) (lookupTokens "mypkg" ghcOpts)
+
+  , testCase "snapshot array ghc-options" $ do
+      let yaml = BS.unlines
+            [ "resolver: lts-20.0"
+            , "name: my-snapshot"
+            , "ghc-options:"
+            , "  mypkg:"
+            , "    - -O2"
+            , "    - -Wall"
+            ]
+      case decodeEither' yaml of
+        Left err -> assertFailure ("failed to parse StackSnapshot: " ++ show err)
+        Right (Snapshot _ _ _ _ _ ghcOpts) ->
+          assertEqual "tokens" (Just ["-O2", "-Wall"]) (lookupTokens "mypkg" ghcOpts)
+
+  , testCase "snapshot scalar-string ghc-options still parses" $ do
+      let yaml = BS.unlines
+            [ "resolver: lts-20.0"
+            , "name: my-snapshot"
+            , "ghc-options:"
+            , "  mypkg: -O2 -Wall"
+            ]
+      case decodeEither' yaml of
+        Left err -> assertFailure ("failed to parse StackSnapshot: " ++ show err)
+        Right (Snapshot _ _ _ _ _ ghcOpts) ->
+          assertEqual "tokens" (Just ["-O2", "-Wall"]) (lookupTokens "mypkg" ghcOpts)
+  ]
+  where
+    lookupTokens :: T.Text -> HM.HashMap T.Text GhcOptionsValue -> Maybe [T.Text]
+    lookupTokens k = fmap ghcOptionsTokens . HM.lookup k


### PR DESCRIPTION
## Summary

In `stack.yaml` a package's `ghc-options` is written as a single string
(`-O2 -Wall`), but in snapshot/resolver definitions stack writes it as an array
of strings (`["-O2", "-Wall"]`). The nix-tools parser typed `ghc-options` as
`HashMap Text Text`, so an array value was a decode-time error and snapshots
using the array form failed to parse (#1676).

## Change

- `lib/Stack2nix/Stack.hs`: introduce `GhcOptionsValue`, whose `FromJSON`
  instance accepts **either** a scalar string **or** an array of strings,
  normalising to a list of individual option tokens. `GhcOptions` is now
  `HashMap Text GhcOptionsValue`.
- `lib/Stack2nix.hs`: `ghcOptions2nix` emits each token as its own list element
  (`ghcOptions = [ "-O2" "-Wall" ]`). Previously a multi-word string was emitted
  as a single list element (`[ "-O2 -Wall" ]`).
- Added a pure `tasty-hunit` test-suite `stack-ghc-options-tests` covering the
  scalar (stack.yaml) form, the array (snapshot) form, and a scalar form inside
  a snapshot — kept separate from the golden `tests` suite, which needs external
  tools + network.

The snapshot-merge path (`resolveSnapshot`, left-biased `HashMap` union) is
unaffected by the value-type change.

## Testing

- Reviewed the diff against the actual source: constructor arity/field order for
  `Stack`/`Snapshot` unchanged; all consumers of `GhcOptions` accounted for
  (`stack2nix`/`ghcOptions2nix`, `StackRepos` ignores it, `resolveSnapshot`
  merges via `HashMap` union). Both decode paths and `ghcOptions2nix` output
  checked by hand.
- Added the parser tests above (run under CI).

## Caveats

- **Behaviour change for the scalar form:** a multi-word `ghc-options` string
  now tokenizes into multiple list elements instead of one. This is the correct
  behaviour (the single-element wrapping was itself a latent bug), but it does
  change generated nix output — and therefore the plan-sha256 of any stack
  project that sets a multi-word `ghc-options` string. Single-token values are
  unaffected.
- haskell.nix consumes nix-tools as a **prebuilt static release binary**, so
  this source fix has no effect on haskell.nix builds until a new nix-tools
  release is cut.
- I did not complete a from-source nix-tools build in this environment; a
  standalone typecheck of the changed module was attempted separately.

Closes #1676.
