### PR TITLE
Warn when a nonReinstallablePkgs override is silently dropped (#1657)

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -99,6 +99,24 @@ in {
     || isBenchmark componentId;
   mayHaveExecutable = isExecutableType;
 
+  # Names in `nonReinstallablePkgs` that a project pins to a version other than
+  # the one shipped with the compiler.  Such overrides are silently dropped by
+  # the `nonReinstallablePkgs` shadow in `config.hsPkgs`, so callers warn about
+  # them rather than letting the build fail later with an opaque
+  # `installed package ... is broken due to missing package X-<ver>` error
+  # (see #1657).  `packages` maps a package name to its module config (or null,
+  # for a shadowed entry); `compilerPackages` maps a name to the version string
+  # the compiler ships.  Only packages actually pinned to a differing version
+  # are returned, so a normal project yields `[]`.
+  shadowedNonReinstallablePkgs = { nonReinstallablePkgs, packages, compilerPackages }:
+    lib.filter (name:
+         packages ? ${name}
+      && packages.${name} != null
+      && compilerPackages ? ${name}
+      && (packages.${name}.package.identifier.version or null) != null
+      && packages.${name}.package.identifier.version != compilerPackages.${name}
+    ) nonReinstallablePkgs;
+
   # Was there a reference to the package source in the `cabal.project` or `stack.yaml` file.
   # This is used to make the default `packages` list for `shellFor`.
   isLocalPackage = p: p.isLocal or false;

--- a/modules/component-driver.nix
+++ b/modules/component-driver.nix
@@ -7,6 +7,36 @@ let
     inherit (config) nonReinstallablePkgs hsPkgs compiler evalPackages builderVersion crossTemplateHaskellSupport cabalProjectLocal;
   };
 
+  # Packages listed in `nonReinstallablePkgs` are forced to the copy shipped
+  # with the compiler (see the `genAttrs ... (_: null)` shadow in `config.hsPkgs`
+  # below).  If the project's plan pins such a package to a *different* version
+  # (via a local package, source-repository-package or extra-hackage) that
+  # override is silently discarded and the build later fails with an opaque
+  # `installed package ... is broken due to missing package <pkg>-<ver>` error.
+  # Warn about that here rather than leaving the user to debug the broken
+  # package-db (see #1657).  We only iterate `nonReinstallablePkgs`, and only
+  # fire when the planned version differs from the compiler-shipped one, so a
+  # normal project (planned version == shipped version) never triggers this.
+  shadowedNonReinstallable = lib.filter (name:
+       config.packages ? ${name}
+    && config.packages.${name} != null
+    && config.compiler.packages ? ${name}
+    && (config.packages.${name}.package.identifier.version or null) != null
+    && config.packages.${name}.package.identifier.version != config.compiler.packages.${name}
+  ) config.nonReinstallablePkgs;
+
+  warnShadowedNonReinstallable = value: lib.foldr (name: acc:
+    lib.warn ''
+      haskell.nix: package '${name}' is listed in `nonReinstallablePkgs`, but this
+      project pins it to version ${config.packages.${name}.package.identifier.version} (the compiler ships ${config.compiler.packages.${name}}).
+      The pinned version will be ignored and the compiler's copy used instead, which
+      usually surfaces later as an opaque
+        `installed package ... is broken due to missing package ${name}-...`
+      error.  To use your version, remove '${name}' from `nonReinstallablePkgs`, e.g.
+        nonReinstallablePkgs = builtins.filter (n: n != "${name}") nonReinstallablePkgs;
+      Otherwise drop the override to keep using the compiler's copy.'' acc)
+    value shadowedNonReinstallable;
+
 in
 
 {
@@ -147,12 +177,12 @@ in
     type = lib.types.unspecified;
   };
 
-  config.hsPkgs =
+  config.hsPkgs = warnShadowedNonReinstallable (
     { inherit (builder) shellFor makeConfigFiles ghcWithPackages ghcWithHoogle;
       buildPackages = buildModules.config.hsPkgs; # TODO perhaps remove this
       pkgsBuildBuild = buildModules.config.hsPkgs;
     } //
     lib.mapAttrs
       (name: pkg: if !(options.packages.${name}.isDefined or true) || pkg == null then null else builder.build-package config pkg)
-      (config.packages // lib.genAttrs (config.nonReinstallablePkgs ++ config.bootPkgs) (_: null));
+      (config.packages // lib.genAttrs (config.nonReinstallablePkgs ++ config.bootPkgs) (_: null)));
 }

--- a/modules/component-driver.nix
+++ b/modules/component-driver.nix
@@ -14,16 +14,15 @@ let
   # override is silently discarded and the build later fails with an opaque
   # `installed package ... is broken due to missing package <pkg>-<ver>` error.
   # Warn about that here rather than leaving the user to debug the broken
-  # package-db (see #1657).  We only iterate `nonReinstallablePkgs`, and only
-  # fire when the planned version differs from the compiler-shipped one, so a
-  # normal project (planned version == shipped version) never triggers this.
-  shadowedNonReinstallable = lib.filter (name:
-       config.packages ? ${name}
-    && config.packages.${name} != null
-    && config.compiler.packages ? ${name}
-    && (config.packages.${name}.package.identifier.version or null) != null
-    && config.packages.${name}.package.identifier.version != config.compiler.packages.${name}
-  ) config.nonReinstallablePkgs;
+  # package-db (see #1657).  The detection lives in `haskellLib` (and is unit
+  # tested); it only considers `nonReinstallablePkgs`, and only fires when the
+  # planned version differs from the compiler-shipped one, so a normal project
+  # (planned version == shipped version) never triggers this.
+  shadowedNonReinstallable = haskellLib.shadowedNonReinstallablePkgs {
+    inherit (config) nonReinstallablePkgs;
+    packages = config.packages;
+    compilerPackages = config.compiler.packages;
+  };
 
   warnShadowedNonReinstallable = value: lib.foldr (name: acc:
     lib.warn ''

--- a/test/unit.nix
+++ b/test/unit.nix
@@ -34,6 +34,40 @@ let
   };
 in
 lib.runTests {
+  # `shadowedNonReinstallablePkgs` flags names in `nonReinstallablePkgs` that the
+  # project pins to a version different from the compiler-shipped one (#1657).
+
+  # Fires only for the pinned-to-a-different-version entry.
+  testShadowedNonReinstallableFires = {
+    expr = haskellLib.shadowedNonReinstallablePkgs {
+      nonReinstallablePkgs = [ "base" "bytestring" "ghc-prim" ];
+      compilerPackages = { base = "4.18.0.0"; bytestring = "0.11.4.0"; ghc-prim = "0.10.0"; };
+      packages = { bytestring = { package.identifier.version = "0.12.0.0"; }; };
+    };
+    expected = [ "bytestring" ];
+  };
+
+  # A normal project (planned version == shipped version) yields nothing.
+  testShadowedNonReinstallableSilentWhenMatching = {
+    expr = haskellLib.shadowedNonReinstallablePkgs {
+      nonReinstallablePkgs = [ "base" "bytestring" ];
+      compilerPackages = { base = "4.18.0.0"; bytestring = "0.11.4.0"; };
+      packages = { bytestring = { package.identifier.version = "0.11.4.0"; }; };
+    };
+    expected = [ ];
+  };
+
+  # Nothing is flagged when no `nonReinstallablePkgs` entry is overridden
+  # (absent, or present but shadowed to null).
+  testShadowedNonReinstallableIgnoresUnpinned = {
+    expr = haskellLib.shadowedNonReinstallablePkgs {
+      nonReinstallablePkgs = [ "base" "rts" ];
+      compilerPackages = { base = "4.18.0.0"; rts = "1.0.2"; };
+      packages = { rts = null; };
+    };
+    expected = [ ];
+  };
+
   # identity function for applyComponents
   test-applyComponents-id = {
     expr = haskellLib.applyComponents (_componentId: component: component) emptyConfig;


### PR DESCRIPTION
## Summary

Fixes the footgun in #1657: overriding a package that appears in `nonReinstallablePkgs` (e.g. `bytestring` via a `source-repository-package` or extra-hackage) is **silently discarded** and only surfaces much later as an opaque

```
installed package ... is broken due to missing package bytestring-<ver>
```

In `modules/component-driver.nix`, `config.hsPkgs` shadows every `nonReinstallablePkgs`/`bootPkgs` entry to `null` (`config.packages // lib.genAttrs (nonReinstallablePkgs ++ bootPkgs) (_: null)`), forcing the compiler's own copy and throwing the user's override away with no hint.

This adds an **eval-time warning** at that exact point, naming the package, the version the project pinned, and the version the compiler ships, and telling the user how to fix it (remove it from `nonReinstallablePkgs`, or drop the override).

## Why a warning, not a throw

The reporter asked "at minimum for a warning/error". I chose `lib.warn` rather than `throw` because a hard failure could break configurations where the version difference is deliberate/benign, whereas a warning guarantees visibility while still letting evaluation proceed. `lib.warn` prints to stderr and returns the wrapped value unchanged.

## No false positives

The detection deliberately matches hamishmack's own suggestion in the thread ("drop entries whose planned version differs from the GHC-shipped one"):

- it iterates **only** `nonReinstallablePkgs`;
- it fires **only** when the package is present as a non-null entry in `config.packages` **and** its planned `identifier.version` differs from `config.compiler.packages.<name>` (the compiler-shipped version).

For an ordinary project, boot packages are pre-existing at the shipped version, so planned == shipped and nothing fires. A package being legitimately reinstalled at a new version is (by definition) *not* in `nonReinstallablePkgs`, so it is never iterated.

## Note on the original report

The default `nonReinstallablePkgs` list has since shrunk (`modules/install-plan/non-reinstallable.nix` is minimal, and the classic default no longer lists `bytestring` when `reinstallableLibGhc` is on), so the exact `bytestring` repro is gone. The footgun remains for the packages still listed and for `reinstallableLibGhc = false` setups — this PR adds the requested diagnostic for those.

## Tested

Pure-Nix eval-time change (no nix-tools rebuild). The predicate and message were verified deterministically:

```nix
# override bytestring 0.12.0.0 while compiler ships 0.11.5.3, both listed:
overrideFires = shadowed overrideCase;  # => [ "bytestring" ]
# ordinary project, planned version == shipped version:
normalNoFire  = shadowed normalCase;    # => [ ]
# pre-existing boot pkg present as a null entry:
nullNoFire    = shadowed nullCase;      # => [ ]
```

and the warn wrapper was confirmed to emit the message on stderr and return the wrapped value unchanged.

`nix-instantiate --parse modules/component-driver.nix` passes.

### Caveat

I attempted a full real-project eval (`test/cabal-simple`) to confirm no spurious warning fires end-to-end, but it aborted on an **environmental** fixed-output hash mismatch fetching the hackage index (`head.hackage.ghc.haskell.org`), unrelated to this change, before reaching `hsPkgs`. The no-false-positive guarantee therefore rests on the deterministic predicate test above and the fact that the filter only iterates `nonReinstallablePkgs` and only fires on a version mismatch. CI (which has the network/cache to complete IFD) will exercise the real path across the compiler matrix.

Closes #1657.
