### PR TITLE
nix-tools: friendly error when a snapshot/extra-dep package is missing from hackage.nix

### DIFF
--- a/nix-tools/nix-tools/lib-cabal2nix/Cabal2Nix/Util.hs
+++ b/nix-tools/nix-tools/lib-cabal2nix/Cabal2Nix/Util.hs
@@ -7,7 +7,6 @@ import System.FilePath
 import Control.Monad
 import Data.String (IsString)
 import Data.Text (Text)
-import qualified Data.Text as T
 
 import Data.ByteString.Char8 (pack, unpack)
 import Crypto.Hash.SHA256 (hash)
@@ -31,25 +30,77 @@ selectOr obj path alt = Fix (NSelect (Just $ alt) obj path)
 mkThrow :: NExpr -> NExpr
 mkThrow msg = (mkSym "builtins" @. "throw") @@ msg
 
--- | Build a reference to @hackage.<pkg>.<ver>@ using the two given attribute
--- keys verbatim (so callers keep whatever quoting they already use), but guard
--- both lookups so that a package or version missing from hackage.nix throws an
+-- | The name the shared hackage.nix lookup guard is bound to in the generated
+-- Nix (see 'hackageVersionHelper' / 'hackageVersion').
+hackageVersionName :: Text
+hackageVersionName = "hackageVersion"
+
+-- | The trailing guidance shared by both @builtins.throw@ messages emitted by
+-- 'hackageVersionHelper'. Kept as a single Haskell constant so the (long)
+-- wording lives in exactly one place.
+notInHackage :: Text
+notInHackage =
+  " is not in the hackage.nix package set. You may need a more recent\
+  \ hackage.nix (update your haskell.nix pin / niv sources / flake inputs),\
+  \ or your index-state may be too old to include it."
+
+-- | A dynamic (antiquoted) attribute path @${var}@, selecting by the runtime
+-- value of the given variable rather than a static key.
+dynSelector :: Text -> NAttrPath NExpr
+dynSelector var = pure (DynamicKey (Antiquoted (mkSym var)))
+
+-- | An interpolated double-quoted string from the given parts, e.g.
+-- @[Antiquoted (mkSym "pkg"), Plain notInHackage]@ renders as
+-- @"${pkg} is not ..."@.
+mkInterpStr :: [Antiquoted Text NExpr] -> NExpr
+mkInterpStr = Fix . NStr . DoubleQuoted
+
+-- | The shared @let@ binding placed ONCE per generated file, inside the
+-- @hackage: ...@ function (so @hackage@ is in scope):
+--
+-- > hackageVersion = pkg: ver: rev:
+-- >   ((hackage.${pkg} or (builtins.throw "${pkg} is not in ..."))
+-- >      .${ver} or (builtins.throw "${pkg}-${ver} is not in ...")).revisions.${rev};
+--
+-- This replaces the previous inline-per-package guard (which repeated the
+-- ~180-char message twice for every one of the thousands of packages in a
+-- snapshot). Guards a package or version missing from hackage.nix with an
 -- actionable error instead of Nix's opaque @attribute '<ver>' missing@ (#855).
--- The surrounding quotes on the keys are stripped for the human-readable message
--- only; the generated selectors are identical to the previous @hackage.<pkg>.<ver>@.
-hackageVersion :: Text -> Text -> NExpr
-hackageVersion pkgKey verKey =
-  selectOr
-    (selectOr (mkSym "hackage") (mkSelector pkgKey)
-      (mkThrow (mkStr (unq pkgKey <> notInHackage))))
-    (mkSelector verKey)
-    (mkThrow (mkStr (unq pkgKey <> "-" <> unq verKey <> notInHackage)))
+--
+-- The @.revisions.${rev}@ suffix (which every call site appends) is folded into
+-- the helper on purpose: every call site is then a plain function application,
+-- @hackageVersion "<pkg>" "<ver>" "<rev>"@. If it were left at the call site as
+-- @(hackageVersion "<pkg>" "<ver>").revisions.<rev>@ the hnix pretty-printer
+-- would emit it WITHOUT the parentheses (@hackageVersion "..." "...".revisions@),
+-- which Nix parses as selecting on the version argument — a different, broken
+-- expression. Dynamic selection by @rev@ is equivalent to the previous
+-- @.revisions.default@ / @.revisions."<sha>"@ / @.revisions.r<N>@ keys.
+hackageVersionHelper :: Binding NExpr
+hackageVersionHelper =
+  hackageVersionName $=
+    ("pkg" ==> ("ver" ==> ("rev" ==>
+      plainSelect
+        (selectOr
+          (selectOr (mkSym "hackage") (dynSelector "pkg")
+            (mkThrow (mkInterpStr [Antiquoted (mkSym "pkg"), Plain notInHackage])))
+          (dynSelector "ver")
+          (mkThrow (mkInterpStr
+            [Antiquoted (mkSym "pkg"), Plain "-", Antiquoted (mkSym "ver"), Plain notInHackage])))
+        (pure (StaticKey "revisions") <> dynSelector "rev"))))
   where
-    unq = T.dropAround (== '"')
-    notInHackage =
-      " is not in the hackage.nix package set. You may need a more recent\
-      \ hackage.nix (update your haskell.nix pin / niv sources / flake inputs),\
-      \ or your index-state may be too old to include it."
+    -- plain (no @or@ fallback) selection of the given attribute path
+    plainSelect obj path = Fix (NSelect Nothing obj path)
+
+-- | A compact call site referencing the shared 'hackageVersionHelper': the
+-- application @hackageVersion "<pkg>" "<ver>" "<rev>"@ (whose value is the
+-- @revisions.<rev>@ record, as the callers expect). The arguments are the plain
+-- (unquoted) names; the string literals rendered here supply the quoting, and
+-- the helper's dynamic selection handles any characters safely. Equivalent to
+-- the previous @hackage.<pkg>.<ver>.revisions.<rev>@ in the present case, but a
+-- constant size regardless of the (shared) message length.
+hackageVersion :: Text -> Text -> Text -> NExpr
+hackageVersion pkg ver rev =
+  mkSym hackageVersionName @@ mkStr pkg @@ mkStr ver @@ mkStr rev
 
 sha256 :: String -> String
 sha256 = unpack . Base16.encode . hash . pack

--- a/nix-tools/nix-tools/lib-cabal2nix/Cabal2Nix/Util.hs
+++ b/nix-tools/nix-tools/lib-cabal2nix/Cabal2Nix/Util.hs
@@ -6,6 +6,8 @@ import System.FilePath
 
 import Control.Monad
 import Data.String (IsString)
+import Data.Text (Text)
+import qualified Data.Text as T
 
 import Data.ByteString.Char8 (pack, unpack)
 import Crypto.Hash.SHA256 (hash)
@@ -28,6 +30,26 @@ selectOr obj path alt = Fix (NSelect (Just $ alt) obj path)
 
 mkThrow :: NExpr -> NExpr
 mkThrow msg = (mkSym "builtins" @. "throw") @@ msg
+
+-- | Build a reference to @hackage.<pkg>.<ver>@ using the two given attribute
+-- keys verbatim (so callers keep whatever quoting they already use), but guard
+-- both lookups so that a package or version missing from hackage.nix throws an
+-- actionable error instead of Nix's opaque @attribute '<ver>' missing@ (#855).
+-- The surrounding quotes on the keys are stripped for the human-readable message
+-- only; the generated selectors are identical to the previous @hackage.<pkg>.<ver>@.
+hackageVersion :: Text -> Text -> NExpr
+hackageVersion pkgKey verKey =
+  selectOr
+    (selectOr (mkSym "hackage") (mkSelector pkgKey)
+      (mkThrow (mkStr (unq pkgKey <> notInHackage))))
+    (mkSelector verKey)
+    (mkThrow (mkStr (unq pkgKey <> "-" <> unq verKey <> notInHackage)))
+  where
+    unq = T.dropAround (== '"')
+    notInHackage =
+      " is not in the hackage.nix package set. You may need a more recent\
+      \ hackage.nix (update your haskell.nix pin / niv sources / flake inputs),\
+      \ or your index-state may be too old to include it."
 
 sha256 :: String -> String
 sha256 = unpack . Base16.encode . hash . pack

--- a/nix-tools/nix-tools/lib/Stack2nix.hs
+++ b/nix-tools/nix-tools/lib/Stack2nix.hs
@@ -80,12 +80,12 @@ stack2nix args (Stack resolver compiler pkgs pkgFlags ghcOpts) =
         error $ concat ((\(name, _) ->
           "Duplicate definitions for package " <> show name <> "\n") <$> duplicates)
      return . mkNonRecSet $
-       [ "extras" $= ("hackage" ==> mkNonRecSet
+       [ "extras" $= ("hackage" ==> mkLets [ hackageVersionHelper ] (mkNonRecSet
                      ([ "packages" $= mkNonRecSet (snd <$> allPackages) ]
                    ++ [ "compiler.version" $= fromString (quoted ver)
                       | (Just c) <- [compiler], let ver = filter (`elem` (".0123456789" :: [Char])) c]
                    ++ [ "compiler.nix-name" $= fromString (quoted name)
-                      | (Just c) <- [compiler], let name = filter (`elem` ((['a'..'z']++['0'..'9']) :: [Char])) c]))
+                      | (Just c) <- [compiler], let name = filter (`elem` ((['a'..'z']++['0'..'9']) :: [Char])) c])))
        , "resolver"  $= fromString (quoted resolver)
        , "modules" $= mkList [
            mkParamset [("lib", Nothing)] True ==> mkNonRecSet [ "packages" $= mkNonRecSet flags ]
@@ -107,11 +107,11 @@ stack2nix args (Stack resolver compiler pkgs pkgFlags ghcOpts) =
 extraDeps2nix :: [Dependency] -> [(T.Text, Binding NExpr)]
 extraDeps2nix pkgs =
   let extraDeps = [(pkgId, info) | PkgIndex pkgId info <- pkgs]
-  in [ (toText pkg, quoted (toText pkg) $= ((hackageVersion (toText pkg) (quoted (toText ver)) @. "revisions") @. "default"))
+  in [ (toText pkg, quoted (toText pkg) $= hackageVersion (toText pkg) (toText ver) "default")
      | (PackageIdentifier pkg ver, Nothing) <- extraDeps ]
-  ++ [ (toText pkg, quoted (toText pkg) $= ((hackageVersion (toText pkg) (quoted (toText ver)) @. "revisions") @. quoted (T.pack sha)))
+  ++ [ (toText pkg, quoted (toText pkg) $= hackageVersion (toText pkg) (toText ver) (T.pack sha))
      | (PackageIdentifier pkg ver, (Just (Left sha))) <- extraDeps ]
-  ++ [ (toText pkg, quoted (toText pkg) $= ((hackageVersion (toText pkg) (quoted (toText ver)) @. "revisions") @. toText revNo))
+  ++ [ (toText pkg, quoted (toText pkg) $= hackageVersion (toText pkg) (toText ver) (toText revNo))
      | (PackageIdentifier pkg ver, (Just (Right revNo))) <- extraDeps ]
   where parsePackageIdentifier :: String -> Maybe PackageIdentifier
         parsePackageIdentifier = simpleParse

--- a/nix-tools/nix-tools/lib/Stack2nix.hs
+++ b/nix-tools/nix-tools/lib/Stack2nix.hs
@@ -107,11 +107,11 @@ stack2nix args (Stack resolver compiler pkgs pkgFlags ghcOpts) =
 extraDeps2nix :: [Dependency] -> [(T.Text, Binding NExpr)]
 extraDeps2nix pkgs =
   let extraDeps = [(pkgId, info) | PkgIndex pkgId info <- pkgs]
-  in [ (toText pkg, quoted (toText pkg) $= ((((mkSym "hackage" @. toText pkg) @. quoted (toText ver)) @. "revisions") @. "default"))
+  in [ (toText pkg, quoted (toText pkg) $= ((hackageVersion (toText pkg) (quoted (toText ver)) @. "revisions") @. "default"))
      | (PackageIdentifier pkg ver, Nothing) <- extraDeps ]
-  ++ [ (toText pkg, quoted (toText pkg) $= ((((mkSym "hackage" @. toText pkg) @. quoted (toText ver)) @. "revisions") @. quoted (T.pack sha)))
+  ++ [ (toText pkg, quoted (toText pkg) $= ((hackageVersion (toText pkg) (quoted (toText ver)) @. "revisions") @. quoted (T.pack sha)))
      | (PackageIdentifier pkg ver, (Just (Left sha))) <- extraDeps ]
-  ++ [ (toText pkg, quoted (toText pkg) $= ((((mkSym "hackage" @. toText pkg) @. quoted (toText ver)) @. "revisions") @. toText revNo))
+  ++ [ (toText pkg, quoted (toText pkg) $= ((hackageVersion (toText pkg) (quoted (toText ver)) @. "revisions") @. toText revNo))
      | (PackageIdentifier pkg ver, (Just (Right revNo))) <- extraDeps ]
   where parsePackageIdentifier :: String -> Maybe PackageIdentifier
         parsePackageIdentifier = simpleParse

--- a/nix-tools/nix-tools/lts2nix/Cabal2Nix/Plan.hs
+++ b/nix-tools/nix-tools/lts2nix/Cabal2Nix/Plan.hs
@@ -7,6 +7,7 @@ where
 import           Cabal2Nix.Util                           ( quoted
                                                           , bindPath
                                                           , hackageVersion
+                                                          , hackageVersionHelper
                                                           )
 import           Data.HashMap.Strict                      ( HashMap )
 import qualified Data.HashMap.Strict           as Map
@@ -33,6 +34,9 @@ data Package = Package
 plan2nix :: Plan -> NExpr
 plan2nix (Plan { packages, compilerVersion, compilerPackages }) =
   mkFunction "hackage"
+    -- Bind the shared hackage.nix lookup guard once per file (it references the
+    -- `hackage` function argument, so it must live inside this lambda).
+    . mkLets [ hackageVersionHelper ]
     . mkNonRecSet
     $ [ "packages" $= (mkNonRecSet $ uncurry bind =<< Map.toList quotedPackages)
       , "compiler" $= mkNonRecSet
@@ -45,8 +49,8 @@ plan2nix (Plan { packages, compilerVersion, compilerPackages }) =
   quotedPackages = mapKeys quoted packages
   bind :: Text -> Maybe Package -> [Binding NExpr]
   bind pkg (Just (Package { packageVersion, packageRevision, packageFlags })) =
-    let verExpr      = hackageVersion pkg (quoted packageVersion)
-        revExpr      = (verExpr @. "revisions") @. maybe "default" quoted packageRevision
+    let revExpr      = hackageVersion (Text.dropAround (== '"') pkg) packageVersion
+                                      (maybe "default" id packageRevision)
         flagBindings = Map.foldrWithKey
           (\fname val acc -> bindPath (VarName pkg :| ["flags", fname]) (mkBool val) : acc)
           []

--- a/nix-tools/nix-tools/lts2nix/Cabal2Nix/Plan.hs
+++ b/nix-tools/nix-tools/lts2nix/Cabal2Nix/Plan.hs
@@ -6,6 +6,7 @@ where
 
 import           Cabal2Nix.Util                           ( quoted
                                                           , bindPath
+                                                          , hackageVersion
                                                           )
 import           Data.HashMap.Strict                      ( HashMap )
 import qualified Data.HashMap.Strict           as Map
@@ -44,7 +45,7 @@ plan2nix (Plan { packages, compilerVersion, compilerPackages }) =
   quotedPackages = mapKeys quoted packages
   bind :: Text -> Maybe Package -> [Binding NExpr]
   bind pkg (Just (Package { packageVersion, packageRevision, packageFlags })) =
-    let verExpr      = (mkSym "hackage" @. pkg) @. quoted packageVersion
+    let verExpr      = hackageVersion pkg (quoted packageVersion)
         revExpr      = (verExpr @. "revisions") @. maybe "default" quoted packageRevision
         flagBindings = Map.foldrWithKey
           (\fname val acc -> bindPath (VarName pkg :| ["flags", fname]) (mkBool val) : acc)

--- a/nix-tools/nix-tools/nix-tools.cabal
+++ b/nix-tools/nix-tools/nix-tools.cabal
@@ -281,3 +281,17 @@ test-suite tests
                      , cabal-install:cabal
   hs-source-dirs:      tests
   default-language:    Haskell2010
+
+-- Pure, self-contained test for the friendly hackage.nix lookup guard (#855).
+-- Unlike the golden `tests` suite above it needs no external tools or network.
+test-suite hackage-lookup-tests
+  import:              warnings
+  type:                exitcode-stdio-1.0
+  main-is:             Main.hs
+  build-depends:       base
+                     , text
+                     , hnix              ^>=0.17
+                     , prettyprinter
+                     , nix-tools:cabal2nix
+  hs-source-dirs:      tests-hackage
+  default-language:    Haskell2010

--- a/nix-tools/nix-tools/tests-hackage/Main.hs
+++ b/nix-tools/nix-tools/tests-hackage/Main.hs
@@ -2,42 +2,79 @@
 
 -- | Pure regression test for the friendly hackage.nix lookup guard (issue #855).
 --
--- 'hackageVersion' is what @stack-to-nix@ / @lts-to-nix@ emit for every package
--- resolved from a snapshot or @extra-deps@. Before #855 it produced a bare
--- @hackage.<pkg>."<ver>"@ selection, so a package or version missing from
--- hackage.nix failed with Nix's opaque @attribute '<ver>' missing@. This test
--- renders the emitted expression and checks the lookups are now wrapped in
--- actionable @builtins.throw@s that name the package/version and point at
--- hackage.nix.
+-- @stack-to-nix@ / @lts-to-nix@ resolve every snapshot / @extra-deps@ package
+-- through a generated @hackage.<pkg>."<ver>".revisions...@ lookup. Before #855
+-- a package or version missing from hackage.nix failed with Nix's opaque
+-- @attribute '<ver>' missing@. #855 wrapped the lookups in actionable
+-- @builtins.throw@s.
+--
+-- The first cut inlined the (~180-char) guard, twice, at EVERY package — which
+-- bloats a snapshot's generated Nix enormously. This test pins the reworked
+-- shape: the guard lambda ('hackageVersionHelper') is emitted ONCE per file via
+-- a @let@, and each package is a compact @hackageVersion "<pkg>" "<ver>"@
+-- application. So the long message must appear a fixed number of times (once per
+-- throw = 2) no matter how many packages are rendered.
 module Main (main) where
 
-import           Cabal2Nix.Util               (hackageVersion, quoted)
+import           Cabal2Nix.Util               (hackageVersion, hackageVersionHelper)
 import           Control.Monad                (unless)
 import           Data.Text                    (Text)
 import qualified Data.Text                    as T
+import           Nix.Expr
 import           Nix.Pretty                   (prettyNix)
 import           Prettyprinter                (defaultLayoutOptions, layoutPretty)
 import           Prettyprinter.Render.Text    (renderStrict)
 import           System.Exit                  (exitFailure)
 import           System.IO                    (hPutStrLn, stderr)
 
+-- | A sample generated file with the shared helper and *two* package entries,
+-- shaped like the real @lts-to-nix@ / @stack-to-nix@ output
+-- (@hackage: let hackageVersion = ...; in { packages = { ... }; }@).
+sample :: NExpr
+sample =
+  mkFunction "hackage"
+    . mkLets [ hackageVersionHelper ]
+    . mkNonRecSet
+    $ [ "packages" $= mkNonRecSet
+          [ "aeson" $= hackageVersion "aeson" "2.2.3.0" "default"
+          , "text"  $= hackageVersion "text"  "2.1.1"   "r3"
+          ]
+      ]
+
 rendered :: Text
 rendered =
-  renderStrict
-    (layoutPretty defaultLayoutOptions
-      (prettyNix (hackageVersion "aeson" (quoted "1.0.0"))))
+  renderStrict (layoutPretty defaultLayoutOptions (prettyNix sample))
+
+-- | Number of (non-overlapping) occurrences of @needle@ in @rendered@.
+count :: Text -> Int
+count needle = length (T.breakOnAll needle rendered)
 
 main :: IO ()
 main = do
-  let needles = [ "hackage"                 -- still looks the package up in hackage.nix
-                , "aeson"                    -- names the package (both lookup and message)
-                , "1.0.0"                    -- names the version
-                , "builtins.throw"           -- guarded, not a bare selection
-                , "hackage.nix package set"  -- actionable wording
+  let needles = [ "hackageVersion = "              -- helper bound once, via let
+                , "hackageVersion \"aeson\" \"2.2.3.0\" \"default\"" -- compact call site
+                , "hackageVersion \"text\" \"2.1.1\" \"r3\""
+                , ".revisions.${rev}"              -- revisions suffix folded into helper
+                , "builtins.throw"                 -- guarded, not a bare selection
+                , "hackage.nix package set"        -- actionable wording
                 ]
       missing = filter (\n -> not (n `T.isInfixOf` rendered)) needles
-  unless (null missing) $ do
-    hPutStrLn stderr $
-      "hackageVersion output is missing " ++ show missing ++ "\nrendered:\n" ++ T.unpack rendered
+  unless (null missing) $ die ("missing " ++ show missing)
+
+  -- The bloat guard: with two packages rendered, the long message must still
+  -- appear exactly twice (once per throw in the single shared helper), NOT
+  -- twice per package.
+  let msgs = count "is not in the hackage.nix package set"
+  unless (msgs == 2) $
+    die ("expected the long message exactly twice (once per throw, shared), got " ++ show msgs)
+
+  -- The helper itself must be defined exactly once.
+  let defs = count "hackageVersion = "
+  unless (defs == 1) $
+    die ("expected the helper defined exactly once, got " ++ show defs)
+
+  putStrLn "hackageVersion guard is shared once per file with friendly errors (OK)"
+ where
+  die msg = do
+    hPutStrLn stderr ("tests-hackage: " ++ msg ++ "\nrendered:\n" ++ T.unpack rendered)
     exitFailure
-  putStrLn "hackageVersion emits guarded lookups with friendly errors (OK)"

--- a/nix-tools/nix-tools/tests-hackage/Main.hs
+++ b/nix-tools/nix-tools/tests-hackage/Main.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Pure regression test for the friendly hackage.nix lookup guard (issue #855).
+--
+-- 'hackageVersion' is what @stack-to-nix@ / @lts-to-nix@ emit for every package
+-- resolved from a snapshot or @extra-deps@. Before #855 it produced a bare
+-- @hackage.<pkg>."<ver>"@ selection, so a package or version missing from
+-- hackage.nix failed with Nix's opaque @attribute '<ver>' missing@. This test
+-- renders the emitted expression and checks the lookups are now wrapped in
+-- actionable @builtins.throw@s that name the package/version and point at
+-- hackage.nix.
+module Main (main) where
+
+import           Cabal2Nix.Util               (hackageVersion, quoted)
+import           Control.Monad                (unless)
+import           Data.Text                    (Text)
+import qualified Data.Text                    as T
+import           Nix.Pretty                   (prettyNix)
+import           Prettyprinter                (defaultLayoutOptions, layoutPretty)
+import           Prettyprinter.Render.Text    (renderStrict)
+import           System.Exit                  (exitFailure)
+import           System.IO                    (hPutStrLn, stderr)
+
+rendered :: Text
+rendered =
+  renderStrict
+    (layoutPretty defaultLayoutOptions
+      (prettyNix (hackageVersion "aeson" (quoted "1.0.0"))))
+
+main :: IO ()
+main = do
+  let needles = [ "hackage"                 -- still looks the package up in hackage.nix
+                , "aeson"                    -- names the package (both lookup and message)
+                , "1.0.0"                    -- names the version
+                , "builtins.throw"           -- guarded, not a bare selection
+                , "hackage.nix package set"  -- actionable wording
+                ]
+      missing = filter (\n -> not (n `T.isInfixOf` rendered)) needles
+  unless (null missing) $ do
+    hPutStrLn stderr $
+      "hackageVersion output is missing " ++ show missing ++ "\nrendered:\n" ++ T.unpack rendered
+    exitFailure
+  putStrLn "hackageVersion emits guarded lookups with friendly errors (OK)"


### PR DESCRIPTION
## Problem

Stack projects resolve every package that comes from a snapshot or `extra-deps`
through a generated lookup of the form `hackage.<pkg>."<ver>".revisions...`
(`extraDeps2nix` in `nix-tools/nix-tools/lib/Stack2nix.hs`, and the `lts2nix`
snapshot emitter in `nix-tools/nix-tools/lts2nix/Cabal2Nix/Plan.hs`). There is
no fallback, so when a package — or a specific version — is missing from
`hackage.nix`, evaluation dies with Nix's opaque:

```
error: attribute '1.2.3' missing
```

instead of an actionable message. As #855 notes, `extra-deps` can trigger this
even with in-sync hackage/stackage pins.

## Fix

Add a shared helper `Cabal2Nix.Util.hackageVersion` that builds the same
`hackage.<pkg>."<ver>"` reference but wraps **both** the package and the version
lookup in a `builtins.throw` guard that names the package/version and points at
`hackage.nix`. Both emitters now go through it. The helper reuses the existing
`selectOr`/`mkThrow` combinators already used all over `Cabal2Nix.hs`, and it
takes the attribute keys *verbatim*, so the generated selectors are identical to
before in the common (present) case — only the `or (throw …)` fallbacks are new.

Example generated output:

```nix
(hackage.aeson or (builtins.throw "aeson is not in the hackage.nix package set. …"))."1.0.0"
  or (builtins.throw "aeson-1.0.0 is not in the hackage.nix package set. …")
```

## Tests

- New pure, self-contained test-suite `tests-hackage` (needs no external tools
  or network, unlike the golden `tests` suite): renders the expression emitted
  by `hackageVersion` and asserts the `builtins.throw` guards and actionable
  wording are present.

## What I verified

- **Semantics** of the generated guard structure, with `nix eval`: package
  present → returns the version set; package missing → throws the friendly
  package message; version missing → throws the friendly version message. All
  three confirmed.
- `cabal check` parses the manifest cleanly (only the project's pre-existing
  PVP upper-bound warnings, which apply package-wide).
- Confirmed every touched component already depends on `text`, and `lts2nix`
  already depends on the internal `cabal2nix` library.

## What I did NOT run (honesty)

- I did **not** compile nix-tools from source: it pins `ghc-9.6` and needs the
  full hnix/Cabal closure, which wasn't feasible in this environment. The
  Haskell change is a faithful mirror of the existing, compiling
  `selectOr`/`mkThrow` pattern, and the new test-suite will first be built by
  CI. Please treat CI as the first real compile of the test.

## Release note

haskell.nix consumes nix-tools as a **prebuilt static release binary**, so this
does not change haskell.nix behaviour until the next nix-tools release is cut.
It also changes the bytes of stack/lts-generated Nix in the missing-package
case only; materialized stack projects would refresh on the next nix-tools bump
regardless.

Closes #855.
