### PR TITLE
nix-tools: link to repository from Hackage (homepage, bug-reports, source-repository)

### DIFF
--- a/nix-tools/nix-tools/nix-tools.cabal
+++ b/nix-tools/nix-tools/nix-tools.cabal
@@ -7,8 +7,15 @@ license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Moritz Angermann
 maintainer:          moritz.angermann@gmail.com
+homepage:            https://github.com/input-output-hk/haskell.nix
+bug-reports:         https://github.com/input-output-hk/haskell.nix/issues
 category:            Distribution
 build-type:          Simple
+
+source-repository head
+  type:              git
+  location:          https://github.com/input-output-hk/haskell.nix
+  subdir:            nix-tools/nix-tools
 
 common warnings
   ghc-options:         -Wall


### PR DESCRIPTION
## Summary

The published `nix-tools` package's Hackage page has no link back to its source repository, which the reporter of #1680 needed when cataloguing Haskell-Nix projects. `nix-tools/nix-tools/nix-tools.cabal` carried only name/synopsis/license/author/maintainer.

This adds the standard linking metadata:

- `homepage: https://github.com/input-output-hk/haskell.nix`
- `bug-reports: https://github.com/input-output-hk/haskell.nix/issues`
- a `source-repository head` stanza (`git`, the repo URL, `subdir: nix-tools/nix-tools`)

## Testing

`cabal check` in `nix-tools/nix-tools/` parses the manifest cleanly with the new fields — the only diagnostics are pre-existing PVP missing-upper-bound warnings/errors (e.g. `base`) that are unrelated to this change and present on `master`.

## Notes

- The metadata only appears on Hackage once the **next nix-tools release** is cut (nix-tools is consumed by haskell.nix as a prebuilt static release binary), so this has no effect on haskell.nix builds themselves.
- #1680 also asked that **haddock docs be uploaded with releases**. That is a release-process change (`cabal upload --documentation`, or relying on Hackage's doc builder), not a source change, and there is no single obvious release checklist in-repo to amend — so it's left as a release-process follow-up (see the static-nix-tools release step tracked in #2506) rather than forced into this diff.

Closes #1680.
