### PR TITLE
comp-builder: add per-component buildJobs option (#1479)

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -15,6 +15,7 @@
 , prePatch ? component.prePatch, postPatch ? component.postPatch
 , preConfigure ? component.preConfigure, postConfigure ? component.postConfigure
 , setupBuildFlags ? component.setupBuildFlags
+, buildJobs ? component.buildJobs
 , preBuild ? component.preBuild , postBuild ? component.postBuild
 , preCheck ? component.preCheck , postCheck ? component.postCheck
 , setupInstallFlags ? component.setupInstallFlags
@@ -228,6 +229,15 @@ let
     if configureAllComponents
       then allComponent
       else component;
+
+  # The `-jN` flag passed to `Setup build`.  When `buildJobs` is null we keep
+  # the historical default (`-j` capped at min(NIX_BUILD_CORES, 4)); otherwise
+  # the component pins the job count (e.g. `buildJobs = 1` for a sequential,
+  # low-memory build).  See #1479.
+  buildJobsFlag =
+    if buildJobs == null
+      then "-j$(($NIX_BUILD_CORES > 4 ? 4 : $NIX_BUILD_CORES))"
+      else "-j${toString buildJobs}";
 
   # Ignore attempts to include DWARF info when it is not possible
   enableDWARF = drvArgs.enableDWARF or false
@@ -460,7 +470,7 @@ let
       LANG = "en_US.UTF-8";         # GHC needs the locale configured during the Haddock phase.
       LC_ALL = "en_US.UTF-8";
 
-      enableParallelBuilding = true;
+      enableParallelBuilding = buildJobs != 1;
 
       SETUP_HS = setup + "/bin/${setup.exeName}";
 
@@ -699,7 +709,7 @@ let
       '' else ''
         runHook preBuild
         # https://gitlab.haskell.org/ghc/ghc/issues/9221
-        $SETUP_HS build ${haskellLib.componentTarget componentId} -j$(($NIX_BUILD_CORES > 4 ? 4 : $NIX_BUILD_CORES)) ${lib.concatStringsSep " " setupBuildFlags}
+        $SETUP_HS build ${haskellLib.componentTarget componentId} ${buildJobsFlag} ${lib.concatStringsSep " " setupBuildFlags}
         runHook postBuild
       '');
 

--- a/modules/component-options.nix
+++ b/modules/component-options.nix
@@ -16,6 +16,19 @@
       default = [];
     };
 
+    buildJobs = lib.mkOption {
+      description = ''
+        Number of jobs to pass to `Setup build` as `-jN` for this component.
+        `null` (the default) keeps the standard behaviour of `-j` capped at
+        `min(NIX_BUILD_CORES, 4)`.  Set to `1` to build sequentially (useful
+        for memory-hungry packages that OOM under parallel builds), or to any
+        other positive integer to pin the parallelism.  Only affects the v1
+        (`builderVersion = 1`) builder.
+      '';
+      type = lib.types.nullOr lib.types.ints.positive;
+      default = null;
+    };
+
     testFlags = lib.mkOption {
       type = haskellLib.types.listOfFilteringNulls lib.types.str;
       default = [];

--- a/test/build-jobs/default.nix
+++ b/test/build-jobs/default.nix
@@ -1,0 +1,71 @@
+# Test the per-component `buildJobs` option (#1479).
+#
+# `buildJobs` controls the `-jN` flag passed to `Setup build` and the
+# derivation's `enableParallelBuilding`.  We assert on the component
+# derivation's `buildPhase` / `enableParallelBuilding` attributes directly
+# (an eval-level check) so the test does not need to compile anything.
+{ stdenv, lib, project', haskellLib, testSrc, compiler-nix-name, evalPackages, runCommand }:
+
+with lib;
+
+let
+  mkProject = extra: project' {
+    inherit compiler-nix-name evalPackages;
+    src = testSrc "cabal-simple";
+    modules = [
+      ({
+        # cabal-simple's library has no exposed modules -> haddock fails.
+        packages.cabal-simple.doHaddock = false;
+      } // extra)
+    ];
+  };
+
+  # Default project: no `buildJobs` set.
+  defaultExe = (mkProject {}).hsPkgs.cabal-simple.components.exes.cabal-simple;
+
+  # `buildJobs = 1`: sequential build.
+  seqExe = (mkProject {
+    packages.cabal-simple.components.exes.cabal-simple.buildJobs = 1;
+  }).hsPkgs.cabal-simple.components.exes.cabal-simple;
+
+  # `buildJobs = 3`: pinned parallelism.
+  pinnedExe = (mkProject {
+    packages.cabal-simple.components.exes.cabal-simple.buildJobs = 3;
+  }).hsPkgs.cabal-simple.components.exes.cabal-simple;
+
+  cappedDefault = "-j$(($NIX_BUILD_CORES > 4 ? 4 : $NIX_BUILD_CORES))";
+
+  checks = [
+    # Default is unchanged: capped `-j` and parallel building on.
+    { name = "default keeps capped -j";
+      ok = hasInfix cappedDefault defaultExe.buildPhase; }
+    { name = "default enables parallel building";
+      ok = defaultExe.enableParallelBuilding == true; }
+    # buildJobs = 1 -> `-j1`, parallel building off, capped default gone.
+    { name = "buildJobs=1 passes -j1";
+      ok = hasInfix "-j1 " seqExe.buildPhase; }
+    { name = "buildJobs=1 disables parallel building";
+      ok = seqExe.enableParallelBuilding == false; }
+    { name = "buildJobs=1 drops the capped default";
+      ok = !(hasInfix cappedDefault seqExe.buildPhase); }
+    # buildJobs = 3 -> `-j3`, parallel building on.
+    { name = "buildJobs=3 passes -j3";
+      ok = hasInfix "-j3 " pinnedExe.buildPhase; }
+    { name = "buildJobs=3 keeps parallel building";
+      ok = pinnedExe.enableParallelBuilding == true; }
+  ];
+
+  failures = filter (c: !c.ok) checks;
+
+in lib.recurseIntoAttrs {
+  ifdInputs = {
+    inherit ((mkProject {})) plan-nix;
+  };
+
+  run = assert lib.assertMsg (failures == [])
+    "build-jobs test failed: ${toString (map (c: c.name) failures)}";
+    runCommand "build-jobs-test" { passthru = { inherit defaultExe seqExe pinnedExe; }; } ''
+      printf "build-jobs: all %d eval checks passed\n" ${toString (length checks)} >&2
+      touch $out
+    '';
+}

--- a/test/default.nix
+++ b/test/default.nix
@@ -179,6 +179,7 @@ let
   # All tests.
   allTests = {
     cabal-simple = callTest ./cabal-simple { inherit util; };
+    build-jobs = callTest ./build-jobs {};
     dummy-ghc-info = callTest ./dummy-ghc-info {};
     check-datadir = callTest ./check-datadir {};
     pkgconf-pc-version = callTest ./pkgconf-pc-version {};


### PR DESCRIPTION
## Summary

Adds a first-class, per-component `buildJobs` option so memory-hungry packages can reduce or disable parallel building — the long-standing request in #1479.

The v1 builder previously hardcoded `enableParallelBuilding = true` (`builder/comp-builder.nix`) and baked `-j$(($NIX_BUILD_CORES > 4 ? 4 : $NIX_BUILD_CORES))` into the `Setup build` invocation, with no way to override short of an undocumented trailing `-j1` in `setupBuildFlags`.

## Change

New nullable option in `modules/component-options.nix`:

```nix
packages.foo.components.exes.bar.buildJobs = 1;   # sequential, low-memory
```

- `null` (default) → unchanged: `-j` capped at `min(NIX_BUILD_CORES, 4)`, `enableParallelBuilding = true`
- `1` → `-j1` and `enableParallelBuilding = false`
- `N` → pinned `-jN`, `enableParallelBuilding = true`

Wired through `builder/comp-builder.nix` via a `buildJobsFlag` binding and `enableParallelBuilding = buildJobs != 1`.

**Default behaviour is byte-identical** when the option is unset: the emitted flag string is exactly the original literal and `enableParallelBuilding` stays `true` (`null != 1`), so no existing derivation changes hash.

## Scope: v1 only

Deliberately scoped to the v1 builder. The v2 builder (`comp-v2-builder.nix`) documents that it cannot faithfully reproduce per-component differentiation, and a v2 slice may build several components at once, so a per-component job count doesn't map cleanly onto v2. The option's description says so.

## Tests

Adds `test/build-jobs` (registered in `test/default.nix`). It builds the `cabal-simple` project three ways (default, `buildJobs = 1`, `buildJobs = 3`) and asserts — at **eval level, without compiling** — on the resulting exe component's `buildPhase` string and `enableParallelBuilding`:

- default keeps the capped `-j` expression and `enableParallelBuilding = true`
- `buildJobs = 1` emits `-j1`, drops the capped default, and sets `enableParallelBuilding = false`
- `buildJobs = 3` emits `-j3` and keeps `enableParallelBuilding = true`

## Verification done

- Both edited nix files and the new test `nix-instantiate --parse` cleanly.
- `nix-instantiate test/default.nix --argstr compiler-nix-name ghc9124 -A build-jobs.run` **succeeds**, i.e. the module option is accepted and all 7 eval assertions pass (they guard the `run` derivation via `assert`, so instantiation would abort if any failed).
- Direct eval confirmed the branch logic: unset → original literal + `true`; `1` → `-j1` + `false`; `8` → `-j8` + `true`.

Closes #1479.
