### PR TITLE
mkFlakePackages: only expose components in the install plan (#2028)

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -455,14 +455,25 @@ in {
       }]) (packageNames coverageProject));
 
   # Flake package names that are flat and match the cabal component names.
+  # Only expose components that are actually part of the cabal install plan.
+  # `plan-to-nix` sets `planned = true` for every component in `plan.json`
+  # (set project-wide for stack projects); a component that is not planned
+  # — e.g. a private sub-library that exists only to serve a disabled test
+  # suite — should not be built by `hydraJobs.packages` (see #2028).  This
+  # mirrors the `buildable && planned` filter already used for
+  # `config.allComponent` (modules/package.nix) and `applyComponents`.
+  flakeComponentIsPlanned = component:
+    (component.config.buildable or true) && (component.config.planned or false);
+
   mkFlakePackages =
     foldrAttrVals
       (package: acc:
         foldComponents
           subComponentTypes
-          (component: a: a // {
-            ${component.passthru.identifier.component-id} = component;
-          })
+          (component: a:
+            if flakeComponentIsPlanned component
+            then a // { ${component.passthru.identifier.component-id} = component; }
+            else a)
           acc
           package)
       { };
@@ -473,13 +484,16 @@ in {
       (package: acc:
         foldComponents
           [ "exes" "tests" "benchmarks" ]
-          (component: a: a // {
-            ${component.passthru.identifier.component-id} = {
-              type = "app";
-              program = component.exePath;
-              inherit (component) meta;
-            };
-          })
+          (component: a:
+            if flakeComponentIsPlanned component
+            then a // {
+              ${component.passthru.identifier.component-id} = {
+                type = "app";
+                program = component.exePath;
+                inherit (component) meta;
+              };
+            }
+            else a)
           acc
           package)
       { };

--- a/test/unit.nix
+++ b/test/unit.nix
@@ -32,6 +32,27 @@ let
     rev = "487eea1c249537d34c27f6143dff2b9d5586c657";
     sha256 = "077j5j3j86qy1wnabjlrg4dmqy1fv037dyq3xb8ch4ickpxxs123";
   };
+
+  # Built-component-shaped fixture for the `mkFlakePackages` filter (#2028):
+  # each component carries `passthru.identifier.component-id` and a `config`
+  # with the `buildable`/`planned` flags (as comp-builder exposes via
+  # `passthru.config`).  `priv` is a private sub-library that is not in the
+  # install plan; `disabled` is an unbuildable test suite.
+  mkFakeComponent = id: buildable: planned: {
+    passthru.identifier.component-id = id;
+    config = { inherit buildable planned; };
+  };
+  flakePackagesInput = {
+    nnn = {
+      components = {
+        library         = mkFakeComponent "nnn:lib:nnn"        true  true;
+        sublibs.used    = mkFakeComponent "nnn:lib:used"       true  true;
+        sublibs.priv    = mkFakeComponent "nnn:lib:priv"       true  false;
+        exes.eee        = mkFakeComponent "nnn:exe:eee"        true  true;
+        tests.disabled  = mkFakeComponent "nnn:test:disabled"  false false;
+      };
+    };
+  };
 in
 lib.runTests {
   # identity function for applyComponents
@@ -55,6 +76,28 @@ lib.runTests {
   testId = {
     expr = lib.id 1;
     expected = 1;
+  };
+
+  # `flakeComponentIsPlanned` keeps only buildable components that are in the
+  # install plan; `buildable` defaults to true and `planned` to false when a
+  # config omits them (see #2028).
+  test-flakeComponentIsPlanned = {
+    expr = map haskellLib.flakeComponentIsPlanned [
+      { config = { buildable = true;  planned = true;  }; }
+      { config = { buildable = true;  planned = false; }; }
+      { config = { buildable = false; planned = true;  }; }
+      { config = { }; }                    # planned defaults false -> excluded
+      { config = { planned = true; }; }    # buildable defaults true  -> included
+    ];
+    expected = [ true false false false true ];
+  };
+
+  # `mkFlakePackages` must drop the unplanned private sub-library and the
+  # disabled test suite, keeping the planned library, sub-library and exe.
+  test-mkFlakePackages-filters-unplanned = {
+    expr = lib.sort (a: b: a < b)
+      (builtins.attrNames (haskellLib.mkFlakePackages flakePackagesInput));
+    expected = [ "nnn:exe:eee" "nnn:lib:nnn" "nnn:lib:used" ];
   };
 
   testParseBlock1 = {


### PR DESCRIPTION
## Summary

`mkFlake` exposed **every** component of every local package as a flake package, so a private sub-library that exists only to serve a *disabled* test suite was still built by `hydraJobs.packages` (#2028). The right criterion (andreabedini's, on the issue) is: build exactly the components that appear in the cabal install plan.

`mkFlakePackages` and `mkFlakeApps` now skip components that are not in the plan, using a small `flakeComponentIsPlanned` predicate:

```nix
flakeComponentIsPlanned = component:
  (component.config.buildable or true) && (component.config.planned or false);
```

- `planned` is set to `true` by `plan-to-nix` for every component in `plan.json` (project-wide for stack projects); `buildable` comes from the `.cabal` file / module overrides. These are reachable on a built component via its `passthru.config` (`builder/comp-builder.nix`).
- This mirrors the `buildable && planned` filter already used by `config.allComponent` (`modules/package.nix`) and `applyComponents` (`lib/default.nix`), so flake `packages` now agree with what the rest of the code already considers "real".

### Safety

`planned` is a plain `bool` (default `false`), so there is no null/unknown case: excluding `planned == false` is exactly "require `planned == true`", which is the same condition the existing `allComponent`/`applyComponents` filters use. A component is dropped **only** when the install plan says it is not planned — nothing currently exposed is hidden otherwise.

Scope kept tight: this changes flake `packages`/`apps` (the subject of the issue). The checks-collection path (`collectChecks'`/`mkFlakeChecks`) is left as-is.

## Tests

Added two runnable unit tests in `test/unit.nix` (they exercise the real `haskellLib.mkFlakePackages` / `haskellLib.flakeComponentIsPlanned`, not a copy):

- `test-flakeComponentIsPlanned` — the predicate's truth table incl. default handling.
- `test-mkFlakePackages-filters-unplanned` — a package fixture whose unplanned private sub-library and disabled test suite are dropped, while the planned library, sub-library and exe are kept.

**Ran** the full `unit.tests` suite locally (`nix-build … -A unit.tests` then `nix-instantiate --eval --strict … -A unit.tests`) → `[]` (all pass, including the two new tests).

## Caveats

- I could not run a full real-project flake eval locally: building any project's `plan-nix` in this environment failed on an **unrelated environmental** fixed-output hash mismatch fetching the `head.hackage` index. The unit tests exercise the actual exported code path, and reachability of `.config.planned`/`.config.buildable` on built components is guaranteed by existing code that already reads those same fields on the same config object.

Closes #2028.
