### PR TITLE
mkFlake: build haddock documentation in CI (#1932)

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -467,6 +467,24 @@ in {
           package)
       { };
 
+  # Flake haddock documentation, keyed by component name like `mkFlakePackages`.
+  # Only library/test components with `doHaddock` enabled expose a `doc` output
+  # (see `builder/comp-builder.nix`), so guarding on `component ? doc` selects
+  # exactly those and skips exes, benchmarks and haddock-disabled components —
+  # no null or broken jobs (see #1932).
+  mkFlakeHaddock =
+    foldrAttrVals
+      (package: acc:
+        foldComponents
+          subComponentTypes
+          (component: a:
+            if component ? doc
+              then a // { ${component.passthru.identifier.component-id} = component.doc; }
+              else a)
+          acc
+          package)
+      { };
+
   # Flake package names that are flat and match the cabal component names.
   mkFlakeApps =
     foldrAttrVals
@@ -510,6 +528,7 @@ in {
         , coverage
         , devShells
         , checkedProject
+        , haddock ? {}
     }: {
       # Run all the tests and code coverage
       checks = removeRecurseForDerivations checks;
@@ -517,6 +536,8 @@ in {
         coverage
         # Make sure all the packages build
         packages
+        # Make sure the haddock documentation builds
+        haddock
         # Build and cache any tools in the `devShells`
         devShells;
       # Build tools and cache tools needed for the project
@@ -538,10 +559,14 @@ in {
         , apps ? mkFlakeApps haskellPackages
         , checks ? mkFlakeChecks (collectChecks' haskellPackages)
         , coverage ? {}
+        # Build the haddock documentation of the project components in CI so
+        # broken docs are caught. Set `doHaddock = false` to opt out (#1932).
+        , doHaddock ? true
+        , haddock ? lib.optionalAttrs doHaddock (mkFlakeHaddock haskellPackages)
         , devShell ? project.shell
         , devShells ? { default = devShell; }
         , checkedProject ? project.appendModule { checkMaterialization = true; }
-        , ciJobs ? mkFlakeCiJobs project { inherit checks coverage packages devShells checkedProject; }
+        , ciJobs ? mkFlakeCiJobs project { inherit checks coverage packages haddock devShells checkedProject; }
         , hydraJobs ? ciJobs
       }: {
       inherit

--- a/modules/flake.nix
+++ b/modules/flake.nix
@@ -43,5 +43,15 @@
         turned on by default.
       '';
     };
+    doHaddock = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Specifies if the flake `ciJobs` and `hydraJobs` should include a
+        `haddock` group building the documentation (`.doc`) of each
+        library/test component that has haddock enabled, so that broken
+        documentation is caught by CI (see #1932).
+      '';
+    };
   };
 }

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -941,6 +941,7 @@ final: prev: {
                   coverage = final.lib.optionalAttrs project.args.flake.doCoverage
                     (haskellLib.projectCoverageCiJobs
                       project selectPackages project.args.flake.coverageProjectModule);
+                  inherit (project.args.flake) doHaddock;
                 };
                 forAllCrossCompilers = prefix: project: (
                     [{ ${prefix} = mkFlake project; }]

--- a/test/unit.nix
+++ b/test/unit.nix
@@ -51,6 +51,64 @@ lib.runTests {
     expected = componentsConfig.components;
   };
 
+  # mkFlakeHaddock collects the `doc` output of every component that produces
+  # haddock (a library/test with doHaddock enabled exposes a `doc` attr), keyed
+  # by component-id, and skips components without docs — exes/benchmarks and
+  # haddock-disabled libraries (see #1932).
+  testMkFlakeHaddock =
+    let
+      mkComp = id: extra: { passthru.identifier.component-id = id; } // extra;
+    in {
+      expr = haskellLib.mkFlakeHaddock {
+        pkgA.components = {
+          library = mkComp "pkgA:lib:pkgA" { doc = "DOC-libA"; };
+          sublibs.s = mkComp "pkgA:lib:s" { doc = "DOC-subA"; };
+          exes.e = mkComp "pkgA:exe:e" { };            # no doc -> skipped
+          tests.t = mkComp "pkgA:test:t" { doc = "DOC-testA"; };
+          foreignlibs = { };
+          benchmarks = { };
+        };
+        pkgB.components = {
+          library = mkComp "pkgB:lib:pkgB" { };        # haddock disabled -> no doc -> skipped
+          sublibs = { }; exes = { }; tests = { };
+          foreignlibs = { }; benchmarks = { };
+        };
+      };
+      expected = {
+        "pkgA:lib:pkgA" = "DOC-libA";
+        "pkgA:lib:s" = "DOC-subA";
+        "pkgA:test:t" = "DOC-testA";
+      };
+    };
+
+  # A project with no haddock-producing components yields an empty group,
+  # matching what `doHaddock = false` produces.
+  testMkFlakeHaddockEmpty = {
+    expr = haskellLib.mkFlakeHaddock {
+      pkgB.components.library.passthru.identifier.component-id = "pkgB:lib:pkgB";
+    };
+    expected = { };
+  };
+
+  # mkFlakeCiJobs surfaces the haddock group so hydra builds documentation.
+  testMkFlakeCiJobsHaddock = {
+    expr = (haskellLib.mkFlakeCiJobs { roots = "ROOTS"; } {
+      packages = { }; checks = { }; coverage = { }; devShells = { };
+      checkedProject = { };
+      haddock = { "pkgA:lib:pkgA" = "DOC"; };
+    }).haddock;
+    expected = { "pkgA:lib:pkgA" = "DOC"; };
+  };
+
+  # The haddock arg defaults to {} so any other caller of mkFlakeCiJobs keeps working.
+  testMkFlakeCiJobsHaddockDefault = {
+    expr = (haskellLib.mkFlakeCiJobs { roots = "ROOTS"; } {
+      packages = { }; checks = { }; coverage = { }; devShells = { };
+      checkedProject = { };
+    }).haddock;
+    expected = { };
+  };
+
   # testing that the tests work
   testId = {
     expr = lib.id 1;


### PR DESCRIPTION
## Summary

`mkFlake` (and therefore `ciJobs`/`hydraJobs`) produced no jobs for the haddock
(`.doc`) outputs, so CI never checked that documentation builds — a real bug
slipped through because of this (see the issue). This adds a `haddock` job
group.

- **`mkFlakeHaddock`** (`lib/default.nix`) folds over the local packages'
  components and collects each one's `doc` output, keyed by component-id like
  `mkFlakePackages`. Only library/test components with haddock enabled expose a
  `doc` attr (see `builder/comp-builder.nix`), so guarding on `component ? doc`
  selects exactly those and skips exes, benchmarks and haddock-disabled
  components — no null/broken jobs.
- **`mkFlakeCiJobs`** gains a `haddock` group. Its new arg defaults to `{}`, so
  the function stays compatible for any other caller.
- **`mkFlake`** computes `haddock` (gated on a new `doHaddock` arg, default
  `true`) and threads it through.
- A **`doHaddock`** flake module option (`modules/flake.nix`, default `true`)
  lets users opt out; it's wired through the overlay's `mkFlake` wrapper.

Default **on**, since catching broken haddock is the whole point of the issue.

## Non-breaking

Purely additive — `checks`, `coverage`, `packages`, `devShells`, `roots`,
`plan-nix`/`stack-nix` are all unchanged. Opt out per project with
`flake = { doHaddock = false; };`.

## Tests / verification

- Added four IFD-free unit tests in `test/unit.nix`:
  `testMkFlakeHaddock` (selection + keying: library and test docs collected,
  exe and haddock-disabled library skipped), `testMkFlakeHaddockEmpty`,
  `testMkFlakeCiJobsHaddock`, `testMkFlakeCiJobsHaddockDefault`. The full
  `unit.tests` suite evaluates to `[]` (all pass) under `ghc9124`.
- All edited files `nix-instantiate --parse` cleanly.
- Confirmed via `lib.evalModules` that the new `doHaddock` option is valid and
  defaults to `true`.
- I did **not** run a full project-flake eval (it requires building `plan-nix`
  via IFD + network); the unit tests exercise the selection and CI-jobs wiring
  directly, and CI will exercise the end-to-end flake path.

Related: #2029 (hydra-build-products for haddock, already merged in a sibling
quick-fix) and #737 (standalone project-wide haddock).

Closes #1932.
