### PR TITLE
lib: clear error when a dependency's library was not in the install plan

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -356,18 +356,25 @@ in {
   # In the case of sublibs the `depends` value should already be the derivation.
   dependToLib = d:
     # Do not simplify this to `d.components.library or d`, as that
-    # will not give a good error message if the `.library`
-    # is missing (happens if the package is unplanned,
-    # but has overrides).
-    # It would be nice to put an `assert` here, but there is
-    # currently no good way to get the name of the dependency
-    # when it is not in the plan.  The attribute path of
-    # `d` in the `nix` error should include the name
-    # eg. `packages.Cabal.components.library`.
+    # would silently drop the dependency when `.library` is missing
+    # (which happens when the package is unplanned but has overrides).
+    # A package value carries its `identifier` (see hspkg-builder.nix), so
+    # when the library component is absent we can throw a message naming the
+    # dependency instead of the opaque `attribute 'library' missing` error
+    # (see #1379).  Checking `d.components ? library` adds no strictness: the
+    # non-error path already forces `d.components` to read `.library`.
     if d ? components
-    then if d ? instantiations
-         then d.components.library.override { inherit (d) instantiations; }
-         else d.components.library
+    then if d.components ? library
+         then if d ? instantiations
+              then d.components.library.override { inherit (d) instantiations; }
+              else d.components.library
+         else throw ("haskell.nix: the library of package '${d.identifier.name or "<unknown>"}'"
+           + " is not available because it was not in the install plan."
+           + " This usually means the package was given overrides (e.g. via"
+           + " `modules` / `packages.${d.identifier.name or "<name>"}`) but is not part"
+           + " of the cabal plan, so none of its components were planned."
+           + " Add it to the project's dependencies (so it appears in the plan),"
+           + " or remove the override.")
     else d;
 
   projectOverlays = import ./project-overlays.nix {

--- a/test/unit.nix
+++ b/test/unit.nix
@@ -57,6 +57,29 @@ lib.runTests {
     expected = 1;
   };
 
+  # `dependToLib` returns the library component of a dependency package.
+  testDependToLibResolvesLibrary = {
+    expr = haskellLib.dependToLib { identifier.name = "foo"; components.library = "the-lib"; };
+    expected = "the-lib";
+  };
+
+  # A sublib `depends` value is already the derivation (no `components`), so it
+  # is passed through unchanged.
+  testDependToLibPassesSublibThrough = {
+    expr = haskellLib.dependToLib "already-a-derivation";
+    expected = "already-a-derivation";
+  };
+
+  # An unplanned package (has `components`, but no planned `library`) must throw
+  # rather than silently vanish or give an opaque `attribute 'library' missing`
+  # (see #1379).  `runTests` can only assert that evaluation fails; the message
+  # wording is checked out of band.
+  testDependToLibThrowsForUnplannedPackage = {
+    expr = (builtins.tryEval
+      (haskellLib.dependToLib { identifier.name = "foo"; components = { }; })).success;
+    expected = false;
+  };
+
   testParseBlock1 = {
     expr = __toJSON (haskellLib.parseSourceRepositoryPackageBlock "cabal.project" {} {} "" ''
         type: git


### PR DESCRIPTION
Fixes the opaque error reported in #1379.

## Problem
When a package is *unplanned* (not in the cabal install plan) but has been given overrides, depending on it failed with an unhelpful `attribute 'library' missing` error pointing deep inside `packages.<x>.components.library`. `dependToLib` (`lib/default.nix`) had a comment noting an `assert` would be nicer "but there is currently no good way to get the name of the dependency when it is not in the plan".

## Fix
A package value carries its `identifier` at the top level (`builder/hspkg-builder.nix`), and an unplanned package simply lacks a `library` under `components` (`allComponent` filters to `buildable && planned`). So the name *is* reachable. `dependToLib` now, in the missing-library branch only, throws a clear message naming the package and explaining it was not in the install plan (add it to the plan, or drop the override).

- Only the previously-failing branch changes; when `library` is present the result is byte-identical.
- No added strictness: the normal path already forces `d.components` to read `.library`, so `d.components ? library` costs nothing.

## Tests
Added `test/unit.nix` cases exercising the real `haskellLib.dependToLib`: library resolves, sublib (no `components`) passes through, and an unplanned package throws. Full `unit.tests` suite eval → `[]` (pass) under `ghc9124`. Verified out of band that the real throw reads:

> haskell.nix: the library of package 'my-dep' is not available because it was not in the install plan. This usually means the package was given overrides (e.g. via `modules` / `packages.my-dep`) but is not part of the cabal plan, so none of its components were planned. Add it to the project's dependencies (so it appears in the plan), or remove the override.

A normal project is unaffected (the normal path is unchanged); I did not run a full project eval (needs plan-nix IFD + network).

## Follow-up (out of scope)
The plan also floated stubbing the throw at component-assembly time so direct `hsPkgs.<pkg>.components.library` access gives the same message; this PR keeps the change minimal and targeted at the reported dependency path.

Closes #1379.