### PR TITLE
stack: accept resolver/snapshot in pantry object form (#1677)

### DIFF
--- a/nix-tools/nix-tools/lib/Stack2nix/Stack.hs
+++ b/nix-tools/nix-tools/lib/Stack2nix/Stack.hs
@@ -22,6 +22,7 @@ import Data.Char (isDigit)
 import Data.List (isSuffixOf)
 import qualified Data.Text as T
 import Data.Aeson
+import Data.Aeson.Types (Parser, typeMismatch)
 import Control.Applicative ((<|>))
 import Data.Monoid (mempty)
 
@@ -188,10 +189,23 @@ instance FromJSON Location where
       gitHubUrl ownerRepo =
         "https://github.com/" <> ownerRepo <> ".git"
 
+-- | Parse the @resolver@ (or its modern synonym @snapshot@) field.  Stack
+-- accepts either the plain string form (@lts-20.11@, a URL, or a @.yaml@ path)
+-- or the pantry object form (@{ url, sha256, size }@); the latter used to fail
+-- with @expected String, but encountered Object@ (see #1677).  We reduce the
+-- object form to its @url@, which is all the downstream resolve path needs
+-- (the @sha256@/@size@ are pantry integrity fields we do not use).
+parseResolver :: Object -> Parser Resolver
+parseResolver s = (s .: "resolver" <|> s .: "snapshot") >>= go
+  where
+    go (String t) = pure (T.unpack t)
+    go (Object o) = o .: "url"
+    go v          = typeMismatch "resolver (a string or a { url: ... } object)" v
+
 instance FromJSON Stack where
   parseJSON = withObject "Stack" $ \s -> Stack
     -- `snapshot` is the modern synonym for `resolver` (stack >= 2.15.1).
-    <$> (s .: "resolver" <|> s .: "snapshot")
+    <$> parseResolver s
     <*> s .:? "compiler" .!= Nothing
     <*> ((<>) <$> s .:? "packages"   .!= [LocalPath "."]
               <*> s .:? "extra-deps" .!= [])
@@ -200,7 +214,7 @@ instance FromJSON Stack where
 
 instance FromJSON StackSnapshot where
   parseJSON = withObject "Snapshot" $ \s -> Snapshot
-    <$> (s .: "resolver" <|> s .: "snapshot")
+    <$> parseResolver s
     <*> s .:? "compiler" .!= Nothing
     <*> s .: "name"
     <*> s .:? "packages" .!= []

--- a/nix-tools/nix-tools/nix-tools.cabal
+++ b/nix-tools/nix-tools/nix-tools.cabal
@@ -281,3 +281,17 @@ test-suite tests
                      , cabal-install:cabal
   hs-source-dirs:      tests
   default-language:    Haskell2010
+
+-- Pure parser tests (no external tools/network); safe to run everywhere.
+test-suite stack-parser-tests
+  import:              warnings
+  type:                exitcode-stdio-1.0
+  main-is:             StackResolverTests.hs
+  build-depends:       base
+                     , bytestring
+                     , nix-tools
+                     , tasty
+                     , tasty-hunit
+                     , yaml
+  hs-source-dirs:      tests-stack-parser
+  default-language:    Haskell2010

--- a/nix-tools/nix-tools/tests-stack-parser/StackResolverTests.hs
+++ b/nix-tools/nix-tools/tests-stack-parser/StackResolverTests.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Pure parser tests for the stack @resolver@/@snapshot@ field (#1677).
+-- Self-contained: no external tools or network, so this suite is safe to run
+-- in CI without the golden-test fixtures.
+module Main (main) where
+
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Yaml as Y
+import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.HUnit (testCase, assertFailure, (@?=))
+
+import Stack2nix.Stack (Stack(..), StackSnapshot(..))
+
+-- Decode a YAML document, failing the test with the parse error otherwise.
+decode :: Y.FromJSON a => String -> IO a
+decode s = case Y.decodeEither' (B8.pack s) of
+  Left e  -> assertFailure ("unexpected parse failure: " ++ show e) >> undefined
+  Right a -> pure a
+
+stackResolver :: Stack -> String
+stackResolver (Stack r _ _ _ _) = r
+
+snapshotResolver :: StackSnapshot -> String
+snapshotResolver (Snapshot r _ _ _ _ _) = r
+
+main :: IO ()
+main = defaultMain $ testGroup "stack resolver parsing"
+  [ testCase "stack.yaml resolver as a plain string" $ do
+      s <- decode "resolver: lts-20.11\n"
+      stackResolver s @?= "lts-20.11"
+
+  , testCase "stack.yaml snapshot synonym" $ do
+      s <- decode "snapshot: lts-21.0\npackages: []\n"
+      stackResolver s @?= "lts-21.0"
+
+  , testCase "stack.yaml resolver in pantry object form uses url (#1677)" $ do
+      s <- decode "resolver:\n  url: https://example.com/snap.yaml\n  sha256: deadbeef\n  size: 42\n"
+      stackResolver s @?= "https://example.com/snap.yaml"
+
+  , testCase "custom snapshot resolver as a plain string" $ do
+      s <- decode "name: my-snap\nresolver: lts-20.11\npackages: []\n"
+      snapshotResolver s @?= "lts-20.11"
+
+  , testCase "custom snapshot resolver in pantry object form (#1677)" $ do
+      s <- decode "name: my-snap\nresolver:\n  url: https://example.com/snap.yaml\n  sha256: deadbeef\n  size: 42\npackages: []\n"
+      snapshotResolver s @?= "https://example.com/snap.yaml"
+
+  , testCase "resolver object without a url is rejected" $
+      case Y.decodeEither' (B8.pack "resolver:\n  sha256: deadbeef\n") :: Either Y.ParseException Stack of
+        Left _  -> pure ()
+        Right s -> assertFailure ("expected failure, got resolver " ++ show (stackResolver s))
+  ]

--- a/nix-tools/nix-tools/tests-stack-parser/StackResolverTests.hs
+++ b/nix-tools/nix-tools/tests-stack-parser/StackResolverTests.hs
@@ -7,7 +7,7 @@ module Main (main) where
 
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Yaml as Y
-import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.HUnit (testCase, assertFailure, (@?=))
 
 import Stack2nix.Stack (Stack(..), StackSnapshot(..))


### PR DESCRIPTION
Fixes part 1 of #1677: a stack `resolver:`/`snapshot:` given in the pantry
object form (`{ url, sha256, size }`) inside a `stack.yaml` or a custom
snapshot failed to parse with `expected String, but encountered Object`.

## Change
`type Resolver = String`, and `FromJSON Stack` / `FromJSON StackSnapshot`
parsed the field as a JSON string. A new `parseResolver` helper accepts either
the plain string (`lts-20.11`, a URL, or a `.yaml` path) or the object form,
reducing the object to its `url` — which is all the downstream resolve path
(`decodeURLEither` / `resolveSnapshot`) consumes; the `sha256`/`size` pantry
integrity fields are not used by nix-tools. A `url`-less object yields a clear
error. The existing string/URL path is unchanged, and both instances share the
helper.

## Scope
Part 2 of the issue (`archive:` entries in a snapshot's `packages:`) is left
unimplemented: archives are unsupported anyway and tracked separately in #1682.
This PR does not change that behaviour.

## Testing
- Extracted the exact `parseResolver` logic into a standalone program and ran
  it against real `aeson-2.2.3.0` + `yaml`: plain string, URL string,
  `snapshot` synonym, and object forms all parse (object -> its `url`), and a
  `url`-less object errors clearly.
- Added a self-contained `stack-parser-tests` suite (tasty-hunit; no external
  tools/network) that decodes both resolver forms via the real `FromJSON`
  instances for `Stack` and `StackSnapshot`.
- `cabal check` passes (only pre-existing missing-upper-bound warnings).
- I did NOT compile nix-tools from source here (it pins ghc-9.6 + the full
  hnix/Cabal closure); the new suite runs under CI.

## Release caveat
haskell.nix consumes nix-tools as a prebuilt static release binary, so this fix
reaches haskell.nix builds only after the next nix-tools release (cf. #2506).

Closes #1677.
