### PR TITLE
stack-project: support inputMap (mirror cabalProject)

### DIFF
--- a/lib/stack-cache-generator.nix
+++ b/lib/stack-cache-generator.nix
@@ -8,6 +8,15 @@
                      #   sha256map =
                      #     { "https://github.com/jgm/pandoc-citeproc"."0.17"
                      #         = "0dxx8cp2xndpw3jwiawch2dkrkp15mil7pyx7dvd810pwc22pm2q"; };
+, inputMap     ? {}
+                     # Maps a dependency git url to a local path / flake
+                     # input, mirroring the `cabalProject` `inputMap`
+                     # argument.  When a url is present here it is used
+                     # instead of fetching, so private repositories and
+                     # offline builds work:
+                     #   inputMap =
+                     #     { "https://github.com/jgm/pandoc-citeproc"
+                     #         = inputs.pandoc-citeproc; };
 , branchMap    ? null
                      # A way to specify in which branch a git commit can
                      # be found
@@ -77,6 +86,9 @@ let
     hashPath = path:
         builtins.readFile (evalPackages.runCommand "hash-path" { preferLocalBuild = true; }
             "echo -n $(${evalPackages.nix}/bin/nix-hash --type sha256 --base32 ${path}) > $out");
+    # `inputMap` may legitimately be `null` (the option type is
+    # `nullOr attrs`); treat that the same as an empty map.
+    inputMap' = if inputMap == null then {} else inputMap;
 in with evalPackages.lib;
 concatMap (dep:
         let
@@ -91,8 +103,23 @@ concatMap (dep:
               location = dep.url;
               tag = dep.rev;
             };
+            # When the dependency url is present in `inputMap` we use the
+            # mapped local path / flake input directly instead of fetching
+            # it.  This mirrors the `cabalProject` `inputMap` resolution in
+            # `lib/call-cabal-project-to-nix.nix`.
+            input =
+              if inputMap' ? "${dep.url}/${dep.rev}"
+                then inputMap'."${dep.url}/${dep.rev}"
+              else if inputMap' ? ${dep.url}
+                then
+                  (if (inputMap'.${dep.url}.rev or null) != dep.rev
+                    then throw "${inputMap'.${dep.url}.rev or "<no rev>"} may not match ${dep.rev} for ${dep.url} use \"${dep.url}/${dep.rev}\" as the inputMap key if ${dep.rev} is a branch or tag that points to ${inputMap'.${dep.url}.rev or "<no rev>"}."
+                    else inputMap'.${dep.url})
+              else null;
             pkgsrc =
-              if !is-private && sha256 != null
+              if input != null
+                then input
+              else if !is-private && sha256 != null
                 then evalPackages.fetchgit {
                   inherit (dep) url rev;
                   inherit sha256;
@@ -106,6 +133,10 @@ concatMap (dep:
                 name = cabalName "${pkgsrc}/${subdir}";
                 inherit (dep) url rev;
                 inherit is-private;
-                sha256 = if !is-private then hashPath pkgsrc else null;
-            } // (optionalAttrs (subdir != "") { inherit subdir; }))
+                # A mapped input is used directly as the package `src` by
+                # `mkCacheModule` (see `overlays/haskell.nix`), so there is
+                # no need to compute a sha256 for it.
+                sha256 = if input == null && !is-private then hashPath pkgsrc else null;
+            } // (optionalAttrs (subdir != "") { inherit subdir; })
+              // (optionalAttrs (input != null) { inherit input; }))
         (dep.subdirs or [ "" ])) repos

--- a/modules/stack-project.nix
+++ b/modules/stack-project.nix
@@ -63,6 +63,27 @@ with types;
               = "0dxx8cp2xndpw3jwiawch2dkrkp15mil7pyx7dvd810pwc22pm2q"; };
       '';
     };
+    inputMap = mkOption {
+      type = nullOr attrs;
+      default = {};
+      description = ''
+        Specifies the contents of the git urls referenced by the
+        `extra-deps` in the stack.yaml file.  This is the stack
+        equivalent of the `cabalProject` `inputMap` argument and is
+        the recommended way to make private git repositories (served
+        over ssh/git) and fully offline builds work.
+
+        Keys are the repository url (optionally suffixed with
+        `/<rev>`) and values are the corresponding local path or flake
+        input.  When a key of the form `<url>/<rev>` is present the
+        value is used directly.  When a bare `<url>` key is used the
+        value's `.rev` attribute is checked against the `commit` in the
+        stack.yaml file.
+
+        For example:
+          inputMap = { "https://github.com/jgm/pandoc-citeproc" = inputs.pandoc-citeproc; };
+      '';
+    };
     branchMap = mkOption {
       type = nullOr unspecified;
       default = null;

--- a/overlays/haskell.nix
+++ b/overlays/haskell.nix
@@ -482,12 +482,17 @@ final: prev: {
         # This handles private repositories with the `is-private` argument
         # (with `builtins.fetchGit`), as well as handling stack-based projects
         # with the `type` argument.
-        mkCacheLine = { name, url, rev, ref ? null, subdir ? ".", sha256 ? null, cabal-file ? "${name}.cabal", type ? "cabal", is-private ? false }:
+        mkCacheLine = { name, url, rev, ref ? null, subdir ? ".", sha256 ? null, cabal-file ? "${name}.cabal", type ? "cabal", is-private ? false, input ? null }:
           let
             # Fetch the entire repo, using either pkgs.fetchgit or
             # builtins.fetchGit depending on whether the repo is private.
+            # When the repo was resolved via `inputMap`
+            # (see `lib/stack-cache-generator.nix`) use the mapped local
+            # path / flake input directly instead of fetching it.
             entireRepo =
-              if is-private
+              if input != null
+              then input
+              else if is-private
               then
                 # It doesn't make sense to specify sha256 on a private repo
                 # because it is not used by buitins.fetchGit.
@@ -578,10 +583,16 @@ final: prev: {
             # TODO: this should be moved into `call-stack-to-nix`
             { packages =
                 let
-                  repoToAttr = { name, url, rev, ref ? null, sha256 ? null, subdir ? null, is-private ? false, ... }: {
+                  repoToAttr = { name, url, rev, ref ? null, sha256 ? null, subdir ? null, is-private ? false, input ? null, ... }: {
                     ${name} = {
                       src =
-                        if is-private
+                        # When a dependency url was resolved via `inputMap`
+                        # (see `lib/stack-cache-generator.nix`) use the mapped
+                        # local path / flake input directly instead of
+                        # fetching it again.
+                        if input != null
+                        then input
+                        else if is-private
                         then
                           builtins.fetchGit
                             ({ inherit url rev; } //

--- a/test/default.nix
+++ b/test/default.nix
@@ -206,6 +206,7 @@ let
     ghc-options-stack = callTest ./ghc-options/stack.nix {};
     exe-only = callTest ./exe-only { inherit util; };
     stack-source-repo = callTest ./stack-source-repo {};
+    stack-inputMap = callTest ./stack-inputMap { inherit testSrcRoot; };
     ghc-lib-reinstallable-cabal = callTest ./ghc-lib-reinstallable/cabal.nix {};
     ghc-lib-reinstallable-stack = callTest ./ghc-lib-reinstallable/stack.nix {};
     cabal-doctests = callTest ./cabal-doctests { inherit util; };

--- a/test/stack-inputMap/default.nix
+++ b/test/stack-inputMap/default.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, stackProject', testSrc, testSrcRoot, compiler-nix-name, evalPackages }:
+
+let
+  # The `extra-deps` git url is never fetched: `inputMap` maps it (keyed
+  # by `<url>/<commit>`) to the local test source tree, so the
+  # `cabal-simple` package used as the dependency comes from
+  # `${testSrcRoot}/cabal-simple`.  This exercises the `inputMap`
+  # support added for stack projects and keeps the test offline.
+  project = stackProject' {
+    src = testSrc "stack-inputMap";
+    inputMap = {
+      "https://github.com/input-output-hk/haskell.nix.git/bc01ebc05a8105035c9449943046b46c8364b932" = testSrcRoot;
+    };
+    inherit evalPackages;
+  };
+  packages = project.hsPkgs;
+
+in lib.recurseIntoAttrs {
+  meta.disabled = compiler-nix-name != "ghc984" || stdenv.hostPlatform.isGhcjs;
+  ifdInputs = {
+    inherit (project) stack-nix;
+  };
+  inherit (packages.stack-inputMap.components) library;
+}

--- a/test/stack-inputMap/package.yaml
+++ b/test/stack-inputMap/package.yaml
@@ -1,0 +1,8 @@
+name: stack-inputMap
+
+dependencies:
+- base
+- cabal-simple
+
+library:
+  source-dirs: src

--- a/test/stack-inputMap/src/Lib.hs
+++ b/test/stack-inputMap/src/Lib.hs
@@ -1,0 +1,6 @@
+module Lib
+    ( someFunc
+    ) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/test/stack-inputMap/stack.yaml
+++ b/test/stack-inputMap/stack.yaml
@@ -1,0 +1,10 @@
+resolver: lts-23.7
+
+packages:
+- .
+
+extra-deps:
+- git: https://github.com/input-output-hk/haskell.nix.git
+  commit: bc01ebc05a8105035c9449943046b46c8364b932
+  subdirs:
+    - cabal-simple


### PR DESCRIPTION
## Add `inputMap` support to `stackProject`

`cabalProject` supports an `inputMap` argument that maps a dependency git url to an actual flake input / local path, but `stackProject` only supported `sha256map`. As noted in the issue, `inputMap` is effectively the only way to make **private** git repositories (served over ssh/git) and fully offline builds work.

This PR adds `inputMap` to `stackProject`, mirroring the cabal side:

- New `inputMap` option in `modules/stack-project.nix` (same `nullOr attrs` type / `{}` default / style as the cabal-project option).
- `lib/stack-cache-generator.nix` now resolves `inputMap` before the `sha256map`/`fetchGit` fallback, using the same key semantics as `lib/call-cabal-project-to-nix.nix`: a `"<url>/<rev>"` key uses the value directly, a bare `"<url>"` key checks the value's `.rev` against the stack.yaml commit (and throws a helpful message on mismatch).
- The resolved source is carried through the cache entry so **both** cache consumers in `overlays/haskell.nix` (`mkCacheModule` and `mkCacheLine`/`mkCacheFile`) use the mapped input directly instead of re-fetching.
- Adds `test/stack-inputMap`, a stack project whose git `extra-dep` resolves via `inputMap` to the local test tree (no network fetch).

### Default behaviour unchanged

`inputMap` defaults to `{}`. When it is omitted, `inputMap ? <key>` is always false, so `input` is `null` and every touched expression reduces to exactly the previous code (the extra cache field is only added when a mapping is present). Existing stack projects are byte-for-byte unaffected.

Closes #1730.
