### PR TITLE
stack2nix: apply stack precedence when snapshot and extra-deps overlap (#1690)

### DIFF
--- a/nix-tools/nix-tools/lib/Stack2nix/External/Resolve.hs
+++ b/nix-tools/nix-tools/lib/Stack2nix/External/Resolve.hs
@@ -1,5 +1,7 @@
 module Stack2nix.External.Resolve
   ( resolveSnapshot
+  , mergeDependencies
+  , dependencyPackageName
   ) where
 
 import Control.Monad (unless)
@@ -7,6 +9,8 @@ import Data.Aeson
 import Data.Yaml hiding (Parser)
 import Control.Applicative ((<|>))
 import Data.List (isPrefixOf, isSuffixOf)
+import Data.Maybe (mapMaybe)
+import qualified Data.Set as Set
 import System.FilePath ((</>), dropFileName)
 
 import qualified Data.ByteString.Lazy.Char8 as L8
@@ -16,7 +20,10 @@ import Network.HTTP.Client.TLS
 import           Network.HTTP.Types.Status  (ok200)
 import Control.Exception.Base (SomeException(..),PatternMatchFail(..))
 
-import Stack2nix.Stack (Stack(..), StackSnapshot(..))
+import Distribution.Types.PackageId (PackageIdentifier(..))
+import Distribution.Types.PackageName (PackageName)
+
+import Stack2nix.Stack (Stack(..), StackSnapshot(..), Dependency(..))
 
 -- | A @resolver@ value in a stack.yaml file may point to an URL. As such
 -- we need to be able to fetch one.
@@ -44,8 +51,42 @@ resolveSnapshot stackYaml stack@(Stack resolver compiler pkgs flags ghcOptions)
             case evalue of
               Left e -> error (show e)
               Right (Snapshot resolver' compiler' _name pkgs' flags' ghcOptions') ->
-                pure $ Stack resolver' (compiler' <|> compiler)  (pkgs <> pkgs') (flags <> flags')
+                pure $ Stack resolver' (compiler' <|> compiler)
+                    (mergeDependencies pkgs pkgs') (flags <> flags')
                     (ghcOptions <> ghcOptions')
     else pure stack
   where
     srcDir = dropFileName stackYaml
+
+-- | Merge two dependency lists, giving precedence to the first (higher
+-- priority) list. Stack resolves overlaps between the packages defined in a
+-- @stack.yaml@ and those coming from a (custom) snapshot resolver with the
+-- precedence: local packages > extra-deps > snapshot packages. In particular
+-- an @extra-deps@ entry shadows a snapshot package of the same name rather
+-- than being emitted twice (see haskell.nix issue #1690).
+--
+-- Here the higher priority list is the @stack.yaml@ dependencies (its
+-- @packages@ followed by its @extra-deps@) and the lower priority list is the
+-- snapshot's @packages@. When a package name is defined on both sides we keep
+-- the higher priority definition and drop the lower priority duplicate.
+--
+-- Only 'PkgIndex' dependencies can be keyed by package name at this stage;
+-- 'LocalPath' and 'DVCS' packages take their names from their @.cabal@ files,
+-- which have not been read yet. Dependencies that cannot be keyed by name are
+-- always kept, so genuine duplicates that are not a simple precedence
+-- resolution are still reported later on.
+--
+-- With no overlapping names this is exactly @high '<>' low@, keeping the
+-- common (no-duplicate) case byte-identical.
+mergeDependencies :: [Dependency] -> [Dependency] -> [Dependency]
+mergeDependencies high low = high ++ filter (not . shadowed) low
+  where
+    highNames = Set.fromList (mapMaybe dependencyPackageName high)
+    shadowed dep = maybe False (`Set.member` highNames) (dependencyPackageName dep)
+
+-- | The package name a dependency defines, when it can be determined without
+-- reading a @.cabal@ file. Only package index ('PkgIndex') entries (plain
+-- @name-version@ extra-deps and snapshot packages) qualify.
+dependencyPackageName :: Dependency -> Maybe PackageName
+dependencyPackageName (PkgIndex pkgId _) = Just (pkgName pkgId)
+dependencyPackageName _                  = Nothing

--- a/nix-tools/nix-tools/nix-tools.cabal
+++ b/nix-tools/nix-tools/nix-tools.cabal
@@ -281,3 +281,18 @@ test-suite tests
                      , cabal-install:cabal
   hs-source-dirs:      tests
   default-language:    Haskell2010
+
+-- Pure unit tests for the stack.yaml/snapshot dependency merge precedence
+-- (haskell.nix issue #1690). Unlike the golden `tests` suite these need no
+-- network access or external tools.
+test-suite unit-tests
+  import:              warnings
+                     , cabal-deps
+  type:                exitcode-stdio-1.0
+  main-is:             Unit.hs
+  build-depends:       base
+                     , nix-tools
+                     , tasty
+                     , tasty-hunit
+  hs-source-dirs:      tests
+  default-language:    Haskell2010

--- a/nix-tools/nix-tools/tests/Unit.hs
+++ b/nix-tools/nix-tools/tests/Unit.hs
@@ -1,0 +1,86 @@
+module Main (main) where
+
+import Data.Maybe (mapMaybe)
+
+import Distribution.Pretty (prettyShow)
+import Distribution.Types.PackageId (PackageIdentifier (..))
+import Distribution.Types.PackageName (PackageName)
+
+import Stack2nix.External.Resolve (dependencyPackageName, mergeDependencies)
+import Stack2nix.Stack (Dependency (..), parsePackageIdentifier)
+
+import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase, (@?=))
+
+-- | Build a package-index dependency (an @extra-deps@ / snapshot @packages@
+-- entry) from a @name-version@ string.
+pkgIndex :: String -> Dependency
+pkgIndex s = case parsePackageIdentifier s of
+  Just (pkgId, rev) -> PkgIndex pkgId rev
+  Nothing           -> error ("pkgIndex: could not parse " ++ show s)
+
+-- | Look up the version emitted for a given package name in a merged
+-- dependency list.
+lookupVersion :: PackageName -> [Dependency] -> [String]
+lookupVersion name deps =
+  [ prettyShow (pkgVersion pkgId)
+  | PkgIndex pkgId _ <- deps
+  , pkgName pkgId == name
+  ]
+
+names :: [Dependency] -> [PackageName]
+names = mapMaybe dependencyPackageName
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "Stack2nix.External.Resolve.mergeDependencies"
+  [ testCase "extra-dep shadows overlapping snapshot package (issue #1690)" $ do
+      -- stack.yaml extra-deps take precedence over snapshot packages.
+      let stackDeps = [pkgIndex "foo-2.0"]
+          snapshot  = [pkgIndex "foo-1.0"]
+          merged    = mergeDependencies stackDeps snapshot
+      assertEqual "only one definition for foo" 1 (length (names merged))
+      assertEqual "foo resolves to the extra-dep version"
+        ["2.0"] (lookupVersion (packageName "foo") merged)
+
+  , testCase "non-overlapping deps are all kept, in order" $ do
+      let stackDeps = [pkgIndex "foo-2.0"]
+          snapshot  = [pkgIndex "bar-1.0"]
+          merged    = mergeDependencies stackDeps snapshot
+      map prettyName (names merged) @?= ["foo", "bar"]
+
+  , testCase "no overlap is identical to plain concatenation" $ do
+      let stackDeps = [pkgIndex "foo-2.0", pkgIndex "baz-3.1"]
+          snapshot  = [pkgIndex "bar-1.0"]
+      map prettyName (names (mergeDependencies stackDeps snapshot))
+        @?= map prettyName (names (stackDeps <> snapshot))
+
+  , testCase "only the higher-priority overlap is dropped" $ do
+      let stackDeps = [pkgIndex "foo-2.0"]
+          snapshot  = [pkgIndex "foo-1.0", pkgIndex "bar-1.0"]
+          merged    = mergeDependencies stackDeps snapshot
+      map prettyName (names merged) @?= ["foo", "bar"]
+      assertEqual "foo resolves to the extra-dep version"
+        ["2.0"] (lookupVersion (packageName "foo") merged)
+
+  , testCase "un-keyable deps (local paths) are always kept" $ do
+      let stackDeps = [pkgIndex "foo-2.0", LocalPath "."]
+          snapshot  = [pkgIndex "foo-1.0", LocalPath "vendor/foo"]
+          merged    = mergeDependencies stackDeps snapshot
+          isLocal (LocalPath _) = True
+          isLocal _             = False
+      assertEqual "both local paths retained" 2 (length (filter isLocal merged))
+      assertEqual "foo resolves to the extra-dep version"
+        ["2.0"] (lookupVersion (packageName "foo") merged)
+  ]
+
+-- | Parse a bare package name (via a throwaway version).
+packageName :: String -> PackageName
+packageName n = case parsePackageIdentifier (n ++ "-0") of
+  Just (pkgId, _) -> pkgName pkgId
+  Nothing         -> error ("packageName: could not parse " ++ show n)
+
+prettyName :: PackageName -> String
+prettyName = prettyShow


### PR DESCRIPTION
## Problem

If a dependency appears both in the `packages:` of a custom snapshot resolver **and** in `extra-deps:` of `stack.yaml`, `stack-to-nix` used to emit it twice into the generated nix. This surfaced either as `attribute 'X' already defined` or, more recently, as an explicit `Duplicate definitions for package X` error from `Stack2nix.hs`.

Stack itself does not fail in this situation. It applies a precedence:

```
local packages > extra-deps > snapshot packages
```

i.e. an `extra-deps` entry shadows a snapshot package of the same name.

## Fix

`resolveSnapshot` (`nix-tools/nix-tools/lib/Stack2nix/External/Resolve.hs`) previously merged the stack.yaml dependencies with the snapshot's packages by plain concatenation (`pkgs <> pkgs'`). It now uses a new pure helper `mergeDependencies`, a package-name-keyed **left-biased** union:

- the higher-priority list is the stack.yaml deps (its `packages` followed by its `extra-deps`),
- the lower-priority list is the snapshot's `packages`,
- when the same package name is defined on both sides, the higher-priority definition is kept and the lower-priority duplicate is dropped.

Only `PkgIndex` dependencies (plain `name-version` entries) can be keyed by package name at this stage; `LocalPath` and `DVCS` packages take their names from their `.cabal` files, which have not been read yet, so those are always kept. As a result the `Duplicate definitions for package` check in `Stack2nix.hs` still fires for genuine within-list duplicates that are not a simple precedence resolution.

With no overlapping names the merge is exactly the old concatenation, so the common case is byte-identical.

A pure `tasty-hunit` `unit-tests` suite is added to `nix-tools.cabal` (no network / no external tools, unlike the existing golden `tests` suite) covering: the extra-dep-shadows-snapshot case, ordering preservation, the no-overlap-equals-concatenation invariant, dropping only the overlapping entry, and un-keyable (local path) entries always being kept.

## Testing

- Built the `nix-tools` library and the new `unit-tests` suite from source inside the repo's `nix develop` shell (GHC 9.6.7, `cabal build -w ghc`). Both compile cleanly.
- Ran the unit-tests suite: all 5 tests pass.

## Caveat

haskell.nix consumes `nix-tools` as a prebuilt static release binary, so this change does not affect haskell.nix builds until a new `nix-tools` release is cut and the pin is bumped. The verification above is at the source level only.

Closes #1690.
