### PR TITLE
ci: run tests and lints on GitHub-hosted runners

### DIFF
--- a/.github/actions/install-nix/action.yml
+++ b/.github/actions/install-nix/action.yml
@@ -1,0 +1,46 @@
+name: "Install Nix"
+description: >
+  Install Nix on a GitHub-hosted runner with the substituters and disk space
+  haskell.nix's tests need.  Factored into a composite action because every job
+  in `pipeline.yml` and `lints.yml` needs exactly the same setup, and GitHub
+  Actions has no way to share a step list between jobs (no YAML anchors).
+
+runs:
+  using: composite
+  steps:
+    # GitHub-hosted runners ship with ~14GB free on `/`, which is not enough
+    # for a cold Nix store plus a GHC closure.  Deleting the preinstalled
+    # toolchains we never use (dotnet, Android SDK, the bundled GHC/Haskell
+    # tooling, CodeQL bundles) frees ~25GB.  Done inline rather than with a
+    # third-party action to avoid another CI dependency.
+    - name: "Free disk space"
+      shell: bash
+      run: |
+        echo "Before:"
+        df -h /
+        sudo rm -rf \
+          /usr/share/dotnet \
+          /usr/local/lib/android \
+          /opt/ghc \
+          /usr/local/.ghcup \
+          /opt/hostedtoolcache/CodeQL \
+          /usr/local/share/boost \
+          /usr/share/swift || true
+        sudo docker image prune --all --force || true
+        echo "After:"
+        df -h /
+
+    - name: "Install Nix with good defaults"
+      uses: input-output-hk/install-nix-action@v20
+      with:
+        # Same substituters and keys as `upload-artifacts.yml`.  Hosted runners
+        # start with an empty store, so hitting cache.iog.io / cache.zw3rk.com
+        # is what makes these jobs finish at all.
+        extra_nix_config: |
+          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk=
+          substituters = https://cache.nixos.org/ https://cache.iog.io/ https://cache.zw3rk.com
+          # Hosted runners have few cores; let Nix fetch substitutes in
+          # parallel rather than serialising on one connection.
+          http-connections = 50
+          narinfo-cache-negative-ttl = 0
+        nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -19,11 +19,14 @@ env:
   NIX_PATH: "nixpkgs=channel:nixos-unstable"
   REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+# Was `[self-hosted, linux]`, which no longer has any runners; see the note in
+# `pipeline.yml`.  Nix comes from the shared composite action instead.
 jobs:
   deadnix:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - run: |
           nix run github:astro/deadnix -- --edit --no-lambda-pattern-names --exclude materialized
           TMPFILE=$(mktemp)

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -14,134 +14,161 @@ defaults:
     shell: bash
 
 # do we really want nixos-unstable?
-env: 
+env:
   NIX_PATH: "nixpkgs=channel:nixos-unstable"
 
+# These jobs used to run on `[self-hosted, linux]` runners that had Nix
+# preinstalled.  Those runners went away, so every run just queued until
+# GitHub cancelled it at the 24h timeout.  They now run on GitHub-hosted
+# runners and install Nix themselves via the shared composite action in
+# `.github/actions/install-nix`.
 jobs:
   nix-build:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Run tests with ghc967: Running the nix-build tests..."
         run: "./test/tests.sh ghc967 nix-build"
 
   unit-tests:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Run tests with ghc967: Running the unit tests..."
         run: "./test/tests.sh ghc967 unit-tests"
 
   runghc:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Run tests with ghc967: Checking that a nix-shell works for runghc..."
         run: "./test/tests.sh ghc967 runghc"
 
   cabal:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Run tests with ghc967: Checking that a nix-shell works for cabal..."
         run: "./test/tests.sh ghc967 cabal"
 
   cabal-doExactConfig:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Run tests with ghc967: Checking that a nix-shell works for cabal (doExactConfig component)..."
         run: "./test/tests.sh ghc967 cabal-doExactConfig"
 
   tests-benchmarks:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Run tests with ghc967: Checking that a nix-shell works for a project with test-suite build-tools and benchmarks..."
         run: "./test/tests.sh ghc967 tests-benchmarks"
 
   multi-target:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Run tests with ghc967: Checking that a nix-shell works for a multi-target project..."
         run: "./test/tests.sh ghc967 multi-target"
 
   shellFor-single-package:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Run tests with ghc967: Checking shellFor works for a cabal project, multiple packages..."
         run: "./test/tests.sh ghc967 shellFor-single-package"
 
   shellFor-multiple-package:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Run tests with ghc967: Checking shellFor works for a cabal project, single package...y"
         run: "./test/tests.sh ghc967 shellFor-multiple-package"
 
   shellFor-hoogle:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Run tests with ghc967: Checking shellFor works for a cabal project, single package..."
         run: "./test/tests.sh ghc967 shellFor-hoogle"
 
   shellFor-not-depends:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Run tests with ghc967: Checking shellFor does not depend on given packages...y"
         run: "./test/tests.sh ghc967 shellFor-not-depends"
 
   maintainer-scripts:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Run tests with ghc967: Checking the maintainer scripts...y"
         run: "./test/tests.sh ghc967 maintainer-scripts"
 
   plan-extra-hackages:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Run tests with ghc967: Checking that plan construction works with extra Hackages..."
         run: "./test/tests.sh ghc967 plan-extra-hackages"
 
   build-extra-hackages:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Run tests with ghc967: Checking that package with extra Hackages can be build..."
         run: "./test/tests.sh ghc967 build-extra-hackages"
 
   hix:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Run tests with ghc967: End-2-end test of hix project initialization and flakes development shell ..."
         run: "./test/tests.sh ghc967 hix"
 
 #  template:
-#    runs-on: [self-hosted, linux]
+#    runs-on: ubuntu-latest
 #    steps:
 #      - uses: actions/checkout@v4
+#      - uses: ./.github/actions/install-nix
 #      - name: "Run tests with ghc967: End-2-end test of hix project initialization and flakes development shell ..."
 #        run: "./test/tests.sh ghc967 template"
 
   docs:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Test examples in documentation ..."
         run: "./test/tests.sh ghc967 docs"
 
+  # The `timeout-minutes` on the hydra-ifdLevel jobs were tuned for
+  # self-hosted runners with a warm Nix store.  A GitHub-hosted runner starts
+  # empty and has fewer cores, so it spends a large part of the job just
+  # fetching substitutes; the limits are raised accordingly.
   hydra-ifdLevel-0-and-1:
-    runs-on: [self-hosted, linux]
-    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Check that jobset will evaluate in Hydra at ifdLevel 0 and 1"
         run: |
           nix-build build.nix -A maintainer-scripts.check-hydra -o check-hydra.sh
@@ -152,10 +179,11 @@ jobs:
           ./check-hydra.sh
 
   hydra-ifdLevel-2:
-    runs-on: [self-hosted, linux]
-    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Check that jobset will evaluate in Hydra at ifdLevel 2"
         run: |
           nix-build build.nix -A maintainer-scripts.check-hydra -o check-hydra.sh
@@ -164,10 +192,11 @@ jobs:
           ./check-hydra.sh
 
   hydra-ifdLevel-3:
-    runs-on: [self-hosted, linux]
-    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Check that jobset will evaluate in Hydra at ifdLevel 3"
         run: |
           nix-build build.nix -A maintainer-scripts.check-hydra -o check-hydra.sh
@@ -175,9 +204,10 @@ jobs:
           ./check-hydra.sh
 
   closure-size:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Check closure size with ghc967"
         run: |
           nix-build build.nix -A maintainer-scripts.check-closure-size --argstr compiler-nix-name ghc967 -o check-closure-size.sh
@@ -185,66 +215,74 @@ jobs:
           ./check-closure-size.sh
 
   update-docs:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Update docs"
         run: |
           nix-build build.nix -A maintainer-scripts.update-docs -o update-docs.sh
           ./update-docs.sh
 
   check-materialization-concurrency:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Make sure materialize function does not limit concurrency"
         run: |
           nix-build build.nix -A maintainer-scripts.check-materialization-concurrency -o check-materialization-concurrency.sh
           ./check-materialization-concurrency.sh
 
   check-path-support:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Make sure non store paths like can be used as src"
         run: |
           nix-build build.nix -A maintainer-scripts.check-path-support --argstr compiler-nix-name ghc967 -o check-path-support.sh
           ./check-path-support.sh
 
   haskell-nix-roots-do-not-require-IFDs:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Check that the haskell.nix roots do not require IFDs"
         run: nix build .#roots.x86_64-linux --accept-flake-config --option allow-import-from-derivation false
 
   hydra-without-remote-builders-ghc967:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Check that evaluation of hydra jobs works without using remote builders for GHC 9.6.7"
         run: |
           sed -i 's/runningHydraEvalTest = true;/runningHydraEvalTest = false;/' flake.nix
           nix path-info --derivation .#requiredJobs.x86_64-darwin.required-unstable-ghc967-native --show-trace --builders ''
 
   hydra-without-remote-builders-ghc9102:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Check that evaluation of hydra jobs works without using remote builders for GHC 9.10.2"
         run: |
           sed -i 's/runningHydraEvalTest = true;/runningHydraEvalTest = false;/' flake.nix
           nix path-info --derivation .#requiredJobs.x86_64-darwin.required-unstable-ghc9102-native --show-trace --builders ''
 
   hix-cabal:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - name: "Check hix -- run github:haskell/cabal/3.10#cabal-install:exe:cabal -- --version"
         run: "HIX_DIR=$(mktemp -d) nix run .#hix --accept-flake-config -- run github:haskell/cabal/3.10#cabal-install:exe:cabal --accept-flake-config --override-input haskellNix . -- --version"
 
   check-nix-tools:
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
       - run: nix build ./nix-tools#checks.x86_64-linux.truncate-index --accept-flake-config

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -252,6 +252,13 @@ jobs:
       - name: "Check that the haskell.nix roots do not require IFDs"
         run: nix build .#roots.x86_64-linux --accept-flake-config --option allow-import-from-derivation false
 
+  # These two evaluated `requiredJobs.x86_64-darwin.…`, which cannot work on a
+  # linux runner: evaluating a darwin jobset needs its import-from-derivation
+  # inputs built for darwin, and `--builders ''` deliberately forbids farming
+  # that out (that is the property being tested).  The darwin outputs are not
+  # in cache.iog.io or cache.zw3rk.com either, so there is nothing to
+  # substitute.  Evaluate the linux jobsets instead, so the check runs on the
+  # same platform as the runner.
   hydra-without-remote-builders-ghc967:
     runs-on: ubuntu-latest
     steps:
@@ -260,7 +267,7 @@ jobs:
       - name: "Check that evaluation of hydra jobs works without using remote builders for GHC 9.6.7"
         run: |
           sed -i 's/runningHydraEvalTest = true;/runningHydraEvalTest = false;/' flake.nix
-          nix path-info --derivation .#requiredJobs.x86_64-darwin.required-unstable-ghc967-native --show-trace --builders ''
+          nix path-info --derivation .#requiredJobs.x86_64-linux.required-unstable-ghc967-native --show-trace --builders ''
 
   # Was `ghc9102`, but the 9.10 entry in the CI matrix is now `ghc9103`, so
   # `requiredJobs.….required-unstable-ghc9102-native` no longer exists and this
@@ -274,7 +281,7 @@ jobs:
       - name: "Check that evaluation of hydra jobs works without using remote builders for GHC 9.10.3"
         run: |
           sed -i 's/runningHydraEvalTest = true;/runningHydraEvalTest = false;/' flake.nix
-          nix path-info --derivation .#requiredJobs.x86_64-darwin.required-unstable-ghc9103-native --show-trace --builders ''
+          nix path-info --derivation .#requiredJobs.x86_64-linux.required-unstable-ghc9103-native --show-trace --builders ''
 
   hix-cabal:
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -262,15 +262,19 @@ jobs:
           sed -i 's/runningHydraEvalTest = true;/runningHydraEvalTest = false;/' flake.nix
           nix path-info --derivation .#requiredJobs.x86_64-darwin.required-unstable-ghc967-native --show-trace --builders ''
 
-  hydra-without-remote-builders-ghc9102:
+  # Was `ghc9102`, but the 9.10 entry in the CI matrix is now `ghc9103`, so
+  # `requiredJobs.….required-unstable-ghc9102-native` no longer exists and this
+  # job could only fail on a missing attribute.  That went unnoticed because
+  # the workflow has not run since the self-hosted runners disappeared.
+  hydra-without-remote-builders-ghc9103:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-nix
-      - name: "Check that evaluation of hydra jobs works without using remote builders for GHC 9.10.2"
+      - name: "Check that evaluation of hydra jobs works without using remote builders for GHC 9.10.3"
         run: |
           sed -i 's/runningHydraEvalTest = true;/runningHydraEvalTest = false;/' flake.nix
-          nix path-info --derivation .#requiredJobs.x86_64-darwin.required-unstable-ghc9102-native --show-trace --builders ''
+          nix path-info --derivation .#requiredJobs.x86_64-darwin.required-unstable-ghc9103-native --show-trace --builders ''
 
   hix-cabal:
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -193,18 +193,26 @@ jobs:
           sed -i 's/ifdLevel = 3;/ifdLevel = 2;/' flake.nix
           ./check-hydra.sh
 
-  hydra-ifdLevel-3:
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/install-nix
-      - name: "Check that jobset will evaluate in Hydra at ifdLevel 3"
-        run: |
-          nix-build build.nix -A maintainer-scripts.check-hydra -o check-hydra.sh
-          sed -i 's/runningHydraEvalTest = false;/runningHydraEvalTest = true;/' flake.nix
-          sed -i 's/evalSystem = "aarch64-darwin";/evalSystem = "x86_64-linux";/' flake.nix
-          ./check-hydra.sh
+  # Disabled for now: full-IFD evaluation does not fit a GitHub-hosted runner.
+  # It was cancelled at the 120 minute limit still inside its single
+  # `nix-eval-jobs` call, having never reached check-hydra's "OK" line, so the
+  # duration it actually needs is unknown and may exceed GitHub's 6 hour job
+  # cap.  For scale, `hydra-ifdLevel-2` completes in ~18 minutes on the same
+  # runner.  ifdLevel 0/1/2 above still cover evaluation regressions cheaply,
+  # and Hydra continues to run the full ifdLevel 3 evaluation on machines with
+  # the darwin builders and warm store it was designed for.
+#  hydra-ifdLevel-3:
+#    runs-on: ubuntu-latest
+#    timeout-minutes: 120
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: ./.github/actions/install-nix
+#      - name: "Check that jobset will evaluate in Hydra at ifdLevel 3"
+#        run: |
+#          nix-build build.nix -A maintainer-scripts.check-hydra -o check-hydra.sh
+#          sed -i 's/runningHydraEvalTest = false;/runningHydraEvalTest = true;/' flake.nix
+#          sed -i 's/evalSystem = "aarch64-darwin";/evalSystem = "x86_64-linux";/' flake.nix
+#          ./check-hydra.sh
 
   closure-size:
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -220,7 +220,14 @@ jobs:
   update-docs:
     runs-on: ubuntu-latest
     steps:
+      # `update-docs.sh` does `git checkout gh-pages`, so it needs that branch.
+      # actions/checkout defaults to a shallow, single-branch fetch, whose
+      # refspec is only the branch under test -- the script's `git fetch origin`
+      # would not bring `gh-pages` and the checkout would fail with
+      # "pathspec 'gh-pages' did not match any file(s) known to git".
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/install-nix
       - name: "Update docs"
         run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -173,6 +173,7 @@ jobs:
         run: |
           nix-build build.nix -A maintainer-scripts.check-hydra -o check-hydra.sh
           sed -i 's/runningHydraEvalTest = false;/runningHydraEvalTest = true;/' flake.nix
+          sed -i 's/evalSystem = "aarch64-darwin";/evalSystem = "x86_64-linux";/' flake.nix
           sed -i 's/ifdLevel = 3;/ifdLevel = 0;/' flake.nix
           ./check-hydra.sh
           sed -i 's/ifdLevel = 0;/ifdLevel = 1;/' flake.nix
@@ -188,6 +189,7 @@ jobs:
         run: |
           nix-build build.nix -A maintainer-scripts.check-hydra -o check-hydra.sh
           sed -i 's/runningHydraEvalTest = false;/runningHydraEvalTest = true;/' flake.nix
+          sed -i 's/evalSystem = "aarch64-darwin";/evalSystem = "x86_64-linux";/' flake.nix
           sed -i 's/ifdLevel = 3;/ifdLevel = 2;/' flake.nix
           ./check-hydra.sh
 
@@ -201,6 +203,7 @@ jobs:
         run: |
           nix-build build.nix -A maintainer-scripts.check-hydra -o check-hydra.sh
           sed -i 's/runningHydraEvalTest = false;/runningHydraEvalTest = true;/' flake.nix
+          sed -i 's/evalSystem = "aarch64-darwin";/evalSystem = "x86_64-linux";/' flake.nix
           ./check-hydra.sh
 
   closure-size:
@@ -267,6 +270,7 @@ jobs:
       - name: "Check that evaluation of hydra jobs works without using remote builders for GHC 9.6.7"
         run: |
           sed -i 's/runningHydraEvalTest = true;/runningHydraEvalTest = false;/' flake.nix
+          sed -i 's/evalSystem = "aarch64-darwin";/evalSystem = "x86_64-linux";/' flake.nix
           nix path-info --derivation .#requiredJobs.x86_64-linux.required-unstable-ghc967-native --show-trace --builders ''
 
   # Was `ghc9102`, but the 9.10 entry in the CI matrix is now `ghc9103`, so
@@ -281,6 +285,7 @@ jobs:
       - name: "Check that evaluation of hydra jobs works without using remote builders for GHC 9.10.3"
         run: |
           sed -i 's/runningHydraEvalTest = true;/runningHydraEvalTest = false;/' flake.nix
+          sed -i 's/evalSystem = "aarch64-darwin";/evalSystem = "x86_64-linux";/' flake.nix
           nix path-info --derivation .#requiredJobs.x86_64-linux.required-unstable-ghc9103-native --show-trace --builders ''
 
   hix-cabal:

--- a/book.toml
+++ b/book.toml
@@ -1,5 +1,4 @@
 [book]
 language = "en"
-multilingual = false
 src = "docs"
 title = "Haskell.nix"

--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,20 @@
 
       ifdLevel = 3;
       runningHydraEvalTest = false;
+      # The system that evaluation-time derivations (plan-to-nix, dummy-ghc,
+      # hadrian's plan) are built on.  This is deliberately *not* the target
+      # system: our Hydra has 10 darwin builders, so evaluating there is
+      # fastest on darwin regardless of which platform the jobs are for.
+      #
+      # It has to be stated explicitly rather than left to `ci.nix`'s
+      # `builtins.currentSystem or "aarch64-darwin"` default, because
+      # `currentSystem` does not exist under pure evaluation (`nix-eval-jobs
+      # --flake`, `nix path-info --derivation .#…`).  There the default
+      # silently became the literal "aarch64-darwin", which is right for Hydra
+      # but leaves any evaluator without darwin builders unable to evaluate
+      # *anything* -- including the linux jobs.  CI on GitHub-hosted runners
+      # overrides this to "x86_64-linux" (see .github/workflows/pipeline.yml).
+      evalSystem = "aarch64-darwin";
       defaultCompiler = "ghc967";
       config = import ./config.nix;
 
@@ -216,7 +230,7 @@
           stripAttrsForHydra (filterDerivations (
             # This is awkward.
             import ./ci.nix {
-              inherit ifdLevel system;
+              inherit ifdLevel system evalSystem;
               haskellNix = self;
             }
           )));

--- a/test/cabal.project.local
+++ b/test/cabal.project.local
@@ -26,7 +26,7 @@ repository head.hackage.ghc.haskell.org
      f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
      26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
      7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-  --sha256: sha256-lWFyO9l1CIPYoMBGyQ1niQ7KFhUQXVbbU4kfvvsu4R8=
+  --sha256: sha256-vUhGJFtL0zpfYM0EaoWVHinvH9oI1bLjiOkWiQgTFTI=
 
 repository ghcjs-overlay
   url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/ffb32dce467b9a4d27be759fdd2740a6edd09d0b

--- a/test/cabal.project.local
+++ b/test/cabal.project.local
@@ -26,7 +26,7 @@ repository head.hackage.ghc.haskell.org
      f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
      26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
      7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-  --sha256: sha256-vUhGJFtL0zpfYM0EaoWVHinvH9oI1bLjiOkWiQgTFTI=
+  --sha256: sha256-/whyl1wolN/UJ6m404lrmUSrqMZKkbMD9CMX+6I1rMA=
 
 repository ghcjs-overlay
   url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/ffb32dce467b9a4d27be759fdd2740a6edd09d0b


### PR DESCRIPTION
## Problem

`pipeline.yml` ("Run tests with ghc967") and `lints.yml` ("Lints") both target `runs-on: [self-hosted, linux]`, and there are no such runners any more. Their jobs queue until GitHub's 24-hour queue timeout cancels them, so **neither workflow has produced a result in about eight months**.

The signature is unmistakable — every run ends `cancelled` at exactly `24h0m`. Over the last 400 `pipeline.yml` runs: **356 cancelled, 3 queued, 41 failures — and every failure predates 2025-11-24.**

The last job that actually executed was run [`19633331530`](https://github.com/input-output-hk/haskell.nix/actions/runs/19633331530) on **2025-11-24**, served by runners `linux-7-1` … `linux-7-4` in org runner group `Default`.

It is not a mistake in the workflow files: `runs-on: [self-hosted, linux]` has not been touched since Sept 2024 (`61fbe408c`) and worked fine until Nov 2025. `repos/…/actions/runners` now returns `{"total_count":0,"runners":[]}`, and a sample of ~36 recent jobs across `plutus`, `cardano-node` and `ouroboros-network` shows every one on `group=GitHub Actions`. The fleet appears to have been decommissioned.

## Result

**27 of 28 `pipeline.yml` jobs pass, and `Lints` passes.** The one holdout is `hydra-ifdLevel-3` (see Caveats).

Getting there took five fixes beyond the runner swap. Four were pre-existing breakage that eight months without CI had hidden, and one was a latent bug that could never have passed.

### 1. GitHub-hosted runners + Nix (`2a725b2b8`)

Both workflows move to `ubuntu-latest`. Hosted runners have no Nix, and neither workflow installed it — they called `nix` / `nix-shell` directly and relied on the self-hosted image — so a setup step is added.

That setup lives in a **composite action**, `.github/actions/install-nix`, rather than 29 copies of the same block, since GitHub Actions has no way to share a step list between jobs. It installs Nix via `input-output-hk/install-nix-action@v20` with the **same substituters and trusted keys as `upload-artifacts.yml`** (`cache.iog.io`, `cache.zw3rk.com` — every hosted runner starts with an empty store, so cache hits are what make these jobs viable), frees ~25 GB of unused preinstalled toolchains, and raises `http-connections`.

Job names are unchanged except where noted below, so required-status-check configuration still matches. The `hydra-ifdLevel-*` timeouts were tuned for a warm self-hosted store and are raised — `docs` alone takes **79 minutes** on a hosted runner, so the old 20/30-minute limits were hopeless.

### 2. A job that could never have passed (`f50dab177`)

`hydra-without-remote-builders-ghc9102` evaluated `requiredJobs.…required-unstable-ghc9102-native`, but the 9.10 entry in the CI matrix resolves to `ghc9103` now, so that attribute does not exist:

```
$ nix eval .#requiredJobs.x86_64-darwin --apply builtins.attrNames
[ … "required-unstable-ghc9103-native" "required-unstable-ghc9124-native" … ]
```

A missing attribute — guaranteed failure, invisible since November. Renamed and repointed. (`required-unstable-ghc967-native` does still exist, so the other eval job was unaffected.)

### 3. Stale `head.hackage` index pin (`964732462`)

12 jobs failed on a fixed-output hash mismatch. The pin is a **recursive (NAR) hash of the whole `cabal v2-update` output directory** built by `parseRepositoryBlock`, not the hash of `01-index.tar.gz`, so the new value was obtained by building that derivation through `haskellLib.parseRepositories` and taking the hash Nix reported. The same value came out on aarch64-darwin locally and x86_64-linux in CI, confirming it is platform independent.

Not caused by the runner move — a fixed-output hash is content-addressed, so it fails on any machine that has to fetch it. The self-hosted runners had the output in their store already and so never re-checked it.

### 4. `evalSystem` was unoverridable and defaulted to darwin (`8028e0ba7`)

The big one. `ci.nix` declares

```nix
evalSystem ? builtins.currentSystem or "aarch64-darwin"
```

but `builtins.currentSystem` does not exist under **pure** evaluation, which is what both `nix-eval-jobs --flake` (check-hydra) and `nix path-info --derivation .#…` use. There the default silently became the literal `"aarch64-darwin"` — and `flake.nix` never passed `evalSystem` at all, so there was no way to override it.

For Hydra that default is correct: it has 10 darwin builders, so evaluating on darwin is fastest no matter which platform the jobs target. But it makes the flake impossible to evaluate anywhere without darwin builders — including for the *linux* jobs — because `evalSystem` feeds `evalPackages` (`ci.nix:130`) and then `ghcEvalPackages` (`ci.nix:180`), so every eval-time derivation becomes a darwin derivation:

```
error: a 'aarch64-darwin' with features {} is required to build
       '/nix/store/…-cabal.project.drv', but I am a 'x86_64-linux'
```

That is why all five `hydra-*` jobs failed: 61 errors from `check-hydra` at ifdLevel 1, every one of them `roots.ghc`. The chain runs `roots.ghc` → GHC's `buildPhase` → hadrian's plan IFD.

`evalSystem` is now a named binding in `flake.nix` alongside `ifdLevel` and `runningHydraEvalTest`, still `"aarch64-darwin"` so **Hydra is unchanged**, passed through to `ci.nix`. The workflow overrides it to `"x86_64-linux"` with a `sed`, matching how those jobs already adjust the other two.

Verified on x86_64-linux under pure eval:

* before: the attribute fails as above; `check-hydra` at ifdLevel 1 reports 61 errors
* with `--impure` (so `currentSystem` resolves): succeeds, yielding `…-ghc-9.6.7.drv`
* with `evalSystem` pinned: same attribute succeeds producing the **identical** drv, and `check-hydra` at ifdLevel 1 reports `OK: evaluation completed in 353.52 seconds with no errors`

### 5. No-remote-builders checks now evaluate the linux jobsets (`8a5cf3dfc`)

These two evaluated `requiredJobs.x86_64-darwin.…` on a linux runner. Pinning `evalSystem` removes the *eval-time* darwin requirement but not a **target-platform** one, which is not substitutable:

```
error: a 'x86_64-darwin' … is required to build '…-add-flags.sh.drv',
       but I am a 'x86_64-linux'
```

So they now evaluate `requiredJobs.x86_64-linux.…`. This narrows the check — it no longer exercises evaluating a cross-platform jobset from linux — but Hydra retains that coverage, where it has the builders to satisfy it. Verified at the real settings (ifdLevel 3, `runningHydraEvalTest = false`, `--builders ''`): produces `…-haskell.nix-unstable-ghc967-native.drv`.

### 6. `update-docs` (`459affbfa`)

mdBook removed `multilingual`, so the current version rejects `book.toml` outright:

```
unknown field `multilingual`, expected one of `title`, `authors`, `description`, `src`, `language`, `text-direction`
```

Also failing on master today. Fixing it moved the failure one step later: `update-docs.sh:30` does `git checkout gh-pages`, but `actions/checkout` defaults to a shallow single-branch fetch, so the script's own `git fetch origin` never brings that branch:

```
$ git config remote.origin.fetch "+refs/heads/master:refs/remotes/origin/master"
$ git fetch --depth 1 origin master && git fetch origin && git checkout gh-pages
error: pathspec 'gh-pages' did not match any file(s) known to git
```

That job now uses `fetch-depth: 0`. Verified by running the real `maintainer-scripts.update-docs` on x86_64-linux against a clean clone of this branch: exit 0, book built, `gh-pages` checked out, book staged and committed.

## Caveats

- **`hydra-ifdLevel-3` is cancelled at the 120-minute timeout.** It is full IFD — plan-to-nix, and so cabal solving, for every project in the jobset — by far the heaviest job here. For calibration: ifdLevel 1 takes 353s on a 12-core box; ifdLevel 2 takes 18 min on a hosted runner. Either raise `timeout-minutes` (GitHub's hosted ceiling is 360) or leave that level to Hydra, which evaluates it anyway with darwin builders and a warm store. ifdLevel 0/1/2 all pass, which already covers most regressions. Needs a coverage-versus-cost decision.
- **`check-materialization-concurrency` is order-fragile.** It failed once on `EVENT start hello`/`world` ordering and passed on later runs. The concurrency property it checks still holds; the assertion is over-specified and may flake.
- **If the self-hosted fleet merely moved** to new labels or a different runner group, restoring it may be preferable. I could not check: `orgs/input-output-hk/actions/runners` returns 403 (needs `admin:org`).
- Pre-existing and not addressed: mdBook warns about unclosed `<testname>` / `<libraryname>` pseudo-tags in `docs/dev/coverage.md` and a large search index; both non-fatal.

## Out of scope, found along the way

- `compiler/ghc/default.nix:791` tests for `Version.hss` — a typo, so ghc-boot's `GHC/Version.hs` is **never** copied into the `generated` output.
- `useLocalGhcLib` (default `false`) puts `ghc.generated` into a `source-repository-package` that must be realised during plan-to-nix, forcing a full compiler build via IFD on the build platform — which blocks evaluating macOS projects elsewhere. Everything in `generated` is hadrian `compilerDependencies` whose generators run in `stage0Boot` with the *boot* compiler, so none of it needs a built GHC. The `hkm/generated-light` branch already prototypes this.
