### PR TITLE
nix-tools: don't disable substituters in the no-ifd recursive-nix build

### DIFF
--- a/nix-tools/static/zipped.nix
+++ b/nix-tools/static/zipped.nix
@@ -57,8 +57,20 @@ let
       } ''
         export HOME=$(mktemp -d)
         mkdir $out
-        cp $(nix --offline --extra-experimental-features "flakes nix-command" \
+        # Deliberately not `nix --offline`: that bundles `substitute = false`, so
+        # anything missing from the builder's store is compiled from source rather
+        # than fetched.  On a darwin builder that meant rebuilding llvm and running
+        # its 57k-test check-all suite, which hung and was killed by max-silent-time
+        # after 3h (ci.zw3rk.com/build/1695375).  Substitution happens daemon-side,
+        # outside the recursive-nix sandbox, so it was never a hermeticity risk.
+        # tarball-ttl is what --offline was actually wanted for: don't re-fetch
+        # the flake inputs, which nativeBuildInputs above already pins into the
+        # store.  Just that one setting -- narinfo-cache-meta-ttl exists in nix
+        # 2.34 but not in the 2.31.2 that pkgs.nix pins here, where it only logs
+        # "warning: unknown setting" and does nothing.
+        cp $(nix --extra-experimental-features "flakes nix-command" \
           build --accept-flake-config --no-link --print-out-paths --no-allow-import-from-derivation \
+          --option tarball-ttl 4294967295 \
           --system ${pkgs.stdenv.hostPlatform.system} \
           ${../.}#${fragment-drv})/*.zip $out/
       '';

--- a/test/cabal.project.local
+++ b/test/cabal.project.local
@@ -26,7 +26,7 @@ repository head.hackage.ghc.haskell.org
      f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
      26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
      7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-  --sha256: sha256-MnmVhCSUFAVA2BWCP8y8MwGld2HphdVBDPmBui79/5E=
+  --sha256: sha256-uroYmmrzEOlmjSAcMIsN4+whOlrM24RqyG0zI1bNHb4=
 
 repository ghcjs-overlay
   url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/ffb32dce467b9a4d27be759fdd2740a6edd09d0b


### PR DESCRIPTION
## Problem

The `*-no-ifd` jobs run a nested `nix build` inside a recursive-nix derivation with
`nix --offline`. `--offline` is a bundle of five settings, and one of them is
**`substitute = false`** — so anything the builder's store happens to be missing is
compiled from source instead of fetched.

On the darwin builders that meant rebuilding `llvm-20.1.8` and running its
57,336-test `check-all` suite inside the recursive-nix build. One lit test hung at
57,335 of 57,336; after 7200s of silence `max-silent-time` killed the build,
cascading `1 dependency failed` through `ghc-binary` to every Haskell package.
https://ci.zw3rk.com/build/1695375 died that way after 3h21m.

Whether a given eval hit this depended on whether the LAN peer cache happened to be
holding the closure, which is why it presented as intermittent. Same job shape,
same day:

| host | store | result |
|---|---|---|
| linux-0, `x86_64-linux-all-nix-tools` | warm | success, **116 s** |
| darwin-6, `aarch64-darwin-all-nix-tools` | cold for the darwin closure | **failed after 3h21m** |

## Fix

Request the two settings `--offline` was actually wanted for — don't re-fetch the
flake inputs, which `nativeBuildInputs` already pins into the store — without
switching substitution off. Substitution is performed by the daemon, *outside* the
recursive-nix sandbox, so disabling it bought no hermeticity.

## Verification

```
$ nix build --dry-run '…llvm-20.1.8.drv^*'
this path will be fetched (9.5 KiB download, 38.3 KiB unpacked):
  /nix/store/by4k98a4b8380cm0vqhj98c40skhl8qa-llvm-20.1.8-python

$ nix --offline build --dry-run '…llvm-20.1.8.drv^*'
these 4 derivations will be built:
  /nix/store/9zsd6wdg7ywrdk6vdl38f12w7h7g9zsf-llvm-tblgen-src-20.1.8.drv
  /nix/store/479c618h0ya41w7hnpilfypyj22g9nhy-llvm-tblgen-20.1.8.drv
  /nix/store/n470hckf5jm2m95cbhbahi709v5znfxq-llvm-src-20.1.8.drv
  /nix/store/1l28pj7s40jb0axz5m5695n7kgdvyp18-llvm-20.1.8.drv
```

With the two replacement options in place it reports the 9.5 KiB fetch again, i.e.
substitution is restored while the flake inputs stay pinned.

All four `*-no-ifd` jobs still instantiate: `aarch64-darwin`, `x86_64-linux`, and
`x86_64-linux` arm64.

Note that the `*-no-ifd` derivation hashes change, since `buildCommand` is part of
the derivation.

## History

This change was briefly pushed straight to `master` by mistake as e5c9c9e33 and
reverted in ab7a7aded. This PR re-submits it properly for review.
