### PR TITLE
nix-tools: drop the no-ifd recursive-nix jobs

### DIFF
--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -52,10 +52,10 @@ jobs:
       - name: "Pull nix-tools"
         run: |
           ls -lah .
-          cp $(nix build --impure --builders "" --max-jobs 0 ${{ steps.flake-metadata.outputs.LOCKED_URL }}#hydraJobs.aarch64-darwin.nix-tools.static.zipped.nix-tools-static-no-ifd --no-link --print-out-paths)/*.zip .
-          cp $(nix build --impure --builders "" --max-jobs 0 ${{ steps.flake-metadata.outputs.LOCKED_URL }}#hydraJobs.x86_64-darwin.nix-tools.static.zipped.nix-tools-static-no-ifd --no-link --print-out-paths)/*.zip .
-          cp $(nix build --impure --builders "" --max-jobs 0 ${{ steps.flake-metadata.outputs.LOCKED_URL }}#hydraJobs.x86_64-linux.nix-tools.static.zipped.nix-tools-static-no-ifd --no-link --print-out-paths)/*.zip .
-          cp $(nix build --impure --builders "" --max-jobs 0 ${{ steps.flake-metadata.outputs.LOCKED_URL }}#hydraJobs.x86_64-linux.nix-tools.static.zipped.nix-tools-static-arm64-no-ifd --no-link --print-out-paths)/*.zip .
+          cp $(nix build --impure --builders "" --max-jobs 0 ${{ steps.flake-metadata.outputs.LOCKED_URL }}#hydraJobs.aarch64-darwin.nix-tools.static.zipped.nix-tools-static --no-link --print-out-paths)/*.zip .
+          cp $(nix build --impure --builders "" --max-jobs 0 ${{ steps.flake-metadata.outputs.LOCKED_URL }}#hydraJobs.x86_64-darwin.nix-tools.static.zipped.nix-tools-static --no-link --print-out-paths)/*.zip .
+          cp $(nix build --impure --builders "" --max-jobs 0 ${{ steps.flake-metadata.outputs.LOCKED_URL }}#hydraJobs.x86_64-linux.nix-tools.static.zipped.nix-tools-static --no-link --print-out-paths)/*.zip .
+          cp $(nix build --impure --builders "" --max-jobs 0 ${{ steps.flake-metadata.outputs.LOCKED_URL }}#hydraJobs.x86_64-linux.nix-tools.static.zipped.nix-tools-static-arm64 --no-link --print-out-paths)/*.zip .
 
       # Hand the zips to the `release` job so it publishes exactly the
       # binaries this hydra-gated job pulled.

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -63,15 +63,23 @@ jobs:
           # The `nix-tools` check that just went green is Hydra's aggregate
           # build for this commit.  Its details_url carries the build id; take
           # the id only, since this instance reports a localhost base URL.
-          build=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${COMMIT}/check-runs" \
-                    --jq '.check_runs[] | select(.name == "nix-tools") | .details_url' \
-                  | grep -oE '/build/[0-9]+' | grep -oE '[0-9]+' | head -1)
+          # Kept as two statements on purpose.  Folded into one pipeline, a
+          # `grep` that matches nothing returns non-zero, and under `set -e`
+          # with `pipefail` that aborts the step before the error message below
+          # can run -- turning "the check-run moved or vanished" into a silent
+          # failure.  The `gh` call stays outside the `|| true` so an API
+          # failure still fails the step.
+          details=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${COMMIT}/check-runs" \
+                      --jq '.check_runs[] | select(.name == "nix-tools") | .details_url')
+          build=$(printf '%s\n' "$details" | grep -oE '/build/[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
           [ -n "$build" ] || { echo "::error::no Hydra nix-tools check-run for $COMMIT"; exit 1; }
 
           # A build can belong to several evaluations, so take the one whose
           # flake ref is this commit.
+          evals=$(curl -sf -H 'Accept: application/json' "$hydra/build/$build" | jq -r '.jobsetevals[]') \
+            || { echo "::error::could not read Hydra build $build"; exit 1; }
           evalid=""
-          for e in $(curl -sf -H 'Accept: application/json' "$hydra/build/$build" | jq -r '.jobsetevals[]'); do
+          for e in $evals; do
             if curl -sf -H 'Accept: application/json' "$hydra/eval/$e" \
                  | jq -e --arg r "$COMMIT" '(.flake // "") | contains($r)' >/dev/null; then
               evalid=$e; break

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -49,6 +49,28 @@ jobs:
         with:
           check: 'nix-tools'
 
+      # Substitute the eval-time derivations before asking for the zips.
+      #
+      # The zip attributes are cheap to *build* -- Hydra has them, so they come
+      # straight from the cache -- but evaluating them runs the haskell.nix
+      # project, which imports from derivation.  On this runner there is
+      # nothing to build with (`--builders ""`, `--max-jobs 0`) and `evalSystem`
+      # is aarch64-darwin, so every path that evaluation wants to realise has
+      # to already be substitutable.  `plan-nix` and `roots` are Hydra jobs
+      # precisely so they are.
+      #
+      # This is why the step below could previously point at the `*-no-ifd`
+      # wrappers with no such preamble: those derivations are cheap to
+      # *instantiate*, their only inputs being nix, git and the flake sources.
+      - name: "Pre-fetch eval-time inputs"
+        run: |
+          set -euo pipefail
+          for sys in aarch64-darwin x86_64-darwin x86_64-linux; do
+            nix build --impure --builders "" --max-jobs 0 --no-link \
+              "${{ steps.flake-metadata.outputs.LOCKED_URL }}#hydraJobs.$sys.nix-tools.static.flake.plan-nix" \
+              "${{ steps.flake-metadata.outputs.LOCKED_URL }}#hydraJobs.$sys.nix-tools.static.flake.roots"
+          done
+
       - name: "Pull nix-tools"
         run: |
           ls -lah .

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -16,10 +16,12 @@ env:
 # at all -- they read build metadata from the Hydra API and download the
 # artifacts Hydra built -- but the split is still worth keeping: nothing on the
 # PR path has any reason to write.
+#
+# `checks: read` and `statuses: read` used to be needed to find the `nix-tools`
+# aggregate's check-run.  Nothing reads GitHub check state any more; the job
+# list and the evaluation both come from the Hydra API.
 permissions:
   contents: read
-  checks: read
-  statuses: read
 
 jobs:
   wait-for-hydra:
@@ -28,11 +30,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Wait for nix-tools meta job
-        uses: input-output-hk/actions/wait-for-hydra@angerman/support-prs
-        with:
-          check: 'nix-tools'
 
       # Take the zips from Hydra, which built them, rather than reconstructing
       # our way back to them with nix.
@@ -51,50 +48,71 @@ jobs:
       # Hydra always has the artifacts it built, so ask it directly.  No
       # evaluation, no cache, no nix.  Integrity still holds: Hydra publishes a
       # sha256 per build product and we check the download against it.
-      - name: "Pull nix-tools"
+      #
+      # We wait on the four zip jobs themselves rather than on an aggregate.
+      # There used to be a `hydraJobs.nix-tools` aggregate and a
+      # `wait-for-hydra` step keyed on its check-run; both are gone.  The
+      # aggregate cost 476MB of zip closures copied onto one agent (see
+      # flake.nix), and keying off a check-run meant depending on Hydra's
+      # GitHub status sync, which strands this workflow whenever that sync
+      # backs up.  Polling Hydra directly needs strictly less to be true: just
+      # the evaluation, no check-run and no aggregate build.
+      - name: "Wait for and pull nix-tools"
         env:
           # On pull_request, github.sha is the merge commit; Hydra evaluates the
-          # head, which is where the check-run lives.
+          # head, so that is the revision to match.
           COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Which Hydra jobset evaluated $COMMIT.  PRs get their own jobset;
+          # master pushes and `nix-tools-*` tags (which are cut from master
+          # commits) are covered by `master`.  Note Hydra keeps only 2
+          # evaluations per jobset, so a commit it has since evaluated past
+          # cannot be resolved -- the step fails loudly rather than silently
+          # reaching for a neighbouring revision.
+          JOBSET: ${{ github.event.pull_request.number && format('pullrequest-{0}', github.event.pull_request.number) || 'master' }}
+          # Generous: these zips are cross-built and the queue can be deep.  It
+          # only has to beat the job actually finishing, and a stuck build now
+          # shows up as this timeout rather than as a run that hangs all day.
+          TIMEOUT_MIN: 240
         run: |
           set -euo pipefail
           hydra=https://ci.zw3rk.com
+          project=input-output-hk-haskell-nix
 
-          # The `nix-tools` check that just went green is Hydra's aggregate
-          # build for this commit.  Its details_url carries the build id; take
-          # the id only, since this instance reports a localhost base URL.
-          # Kept as two statements on purpose.  Folded into one pipeline, a
-          # `grep` that matches nothing returns non-zero, and under `set -e`
-          # with `pipefail` that aborts the step before the error message below
-          # can run -- turning "the check-run moved or vanished" into a silent
-          # failure.  The `gh` call stays outside the `|| true` so an API
-          # failure still fails the step.
-          details=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${COMMIT}/check-runs" \
-                      --jq '.check_runs[] | select(.name == "nix-tools") | .details_url')
-          build=$(printf '%s\n' "$details" | grep -oE '/build/[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
-          [ -n "$build" ] || { echo "::error::no Hydra nix-tools check-run for $COMMIT"; exit 1; }
+          jobs="aarch64-darwin.nix-tools.static.zipped.nix-tools-static
+          x86_64-darwin.nix-tools.static.zipped.nix-tools-static
+          x86_64-linux.nix-tools.static.zipped.nix-tools-static
+          x86_64-linux.nix-tools.static.zipped.nix-tools-static-arm64"
 
-          # A build can belong to several evaluations, so take the one whose
-          # flake ref is this commit.
-          evals=$(curl -sf -H 'Accept: application/json' "$hydra/build/$build" | jq -r '.jobsetevals[]') \
-            || { echo "::error::could not read Hydra build $build"; exit 1; }
-          evalid=""
-          for e in $evals; do
-            if curl -sf -H 'Accept: application/json' "$hydra/eval/$e" \
-                 | jq -e --arg r "$COMMIT" '(.flake // "") | contains($r)' >/dev/null; then
-              evalid=$e; break
-            fi
-          done
-          [ -n "$evalid" ] || { echo "::error::Hydra build $build has no evaluation at $COMMIT"; exit 1; }
-          echo "Hydra eval $evalid (aggregate build $build) for $COMMIT"
+          # Find the evaluation for this exact revision.  `.flake` carries the
+          # full ref, e.g. github:owner/repo/<rev>?narHash=..., so match on the
+          # revision as a substring.  Kept out of a single pipeline so that a
+          # jq miss reports the error below instead of tripping `pipefail`.
+          evals=$(curl -sf -H 'Accept: application/json' "$hydra/jobset/$project/$JOBSET/evals") \
+            || { echo "::error::could not list evaluations for jobset $JOBSET"; exit 1; }
+          evalid=$(printf '%s' "$evals" \
+                     | jq -r --arg r "$COMMIT" 'first(.evals[] | select((.flake // "") | contains($r)) | .id) // empty')
+          [ -n "$evalid" ] || {
+            echo "::error::no Hydra evaluation of $COMMIT in jobset $JOBSET (only 2 are kept)"
+            printf '%s' "$evals" | jq -r '.evals[] | "  eval \(.id): \(.flake // "?")"' || true
+            exit 1
+          }
+          echo "Hydra eval $evalid for $COMMIT (jobset $JOBSET)"
 
-          for job in \
-            aarch64-darwin.nix-tools.static.zipped.nix-tools-static \
-            x86_64-darwin.nix-tools.static.zipped.nix-tools-static \
-            x86_64-linux.nix-tools.static.zipped.nix-tools-static \
-            x86_64-linux.nix-tools.static.zipped.nix-tools-static-arm64
-          do
-            meta=$(curl -sfL -H 'Accept: application/json' "$hydra/eval/$evalid/job/$job")
+          deadline=$(( $(date +%s) + TIMEOUT_MIN * 60 ))
+          for job in $jobs; do
+            # Wait for this job to finish.  `finished` flips to 1 once Hydra is
+            # done with the build, whatever the outcome; buildstatus is only
+            # meaningful after that.
+            while :; do
+              meta=$(curl -sfL -H 'Accept: application/json' "$hydra/eval/$evalid/job/$job") \
+                || { echo "::error::$job is not in eval $evalid"; exit 1; }
+              [ "$(echo "$meta" | jq -r '.finished')" = "1" ] && break
+              [ "$(date +%s)" -lt "$deadline" ] \
+                || { echo "::error::timed out after ${TIMEOUT_MIN}m waiting for $job"; exit 1; }
+              echo "waiting for $job (build $(echo "$meta" | jq -r '.id'))"
+              sleep 60
+            done
+
             status=$(echo "$meta" | jq -r '.buildstatus')
             [ "$status" = "0" ] || { echo "::error::$job did not succeed (buildstatus $status)"; exit 1; }
 

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -49,28 +49,6 @@ jobs:
         with:
           check: 'nix-tools'
 
-      # Substitute the eval-time derivations before asking for the zips.
-      #
-      # The zip attributes are cheap to *build* -- Hydra has them, so they come
-      # straight from the cache -- but evaluating them runs the haskell.nix
-      # project, which imports from derivation.  On this runner there is
-      # nothing to build with (`--builders ""`, `--max-jobs 0`) and `evalSystem`
-      # is aarch64-darwin, so every path that evaluation wants to realise has
-      # to already be substitutable.  `plan-nix` and `roots` are Hydra jobs
-      # precisely so they are.
-      #
-      # This is why the step below could previously point at the `*-no-ifd`
-      # wrappers with no such preamble: those derivations are cheap to
-      # *instantiate*, their only inputs being nix, git and the flake sources.
-      - name: "Pre-fetch eval-time inputs"
-        run: |
-          set -euo pipefail
-          for sys in aarch64-darwin x86_64-darwin x86_64-linux; do
-            nix build --impure --builders "" --max-jobs 0 --no-link \
-              "${{ steps.flake-metadata.outputs.LOCKED_URL }}#hydraJobs.$sys.nix-tools.static.flake.plan-nix" \
-              "${{ steps.flake-metadata.outputs.LOCKED_URL }}#hydraJobs.$sys.nix-tools.static.flake.roots"
-          done
-
       - name: "Pull nix-tools"
         run: |
           ls -lah .

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -9,12 +9,13 @@ on:
   pull_request:
 
 env:
-  FLAKE_REF: github:${{ github.repository }}?ref=${{ github.head_ref || github.ref }}
   GH_TOKEN: ${{ github.token }}
 
-# PR-triggered runs evaluate pull request code (`nix build --impure` on the
-# PR's flake), so the default token must stay read-only.  The tag-only
-# `release` job below elevates its own permissions.
+# The default token stays read-only; the tag-only `release` job below elevates
+# its own permissions.  PR-triggered runs no longer evaluate pull request code
+# at all -- they read build metadata from the Hydra API and download the
+# artifacts Hydra built -- but the split is still worth keeping: nothing on the
+# PR path has any reason to write.
 permissions:
   contents: read
   checks: read
@@ -28,34 +29,80 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Nix with good defaults
-        uses: input-output-hk/install-nix-action@v20
-        with:
-          extra_nix_config: |
-            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk=
-            substituters = https://cache.nixos.org/ https://cache.iog.io/ https://cache.zw3rk.com
-          nix_path: nixpkgs=channel:nixos-unstable
-
-      - name: Display flake metadata
-        id: flake-metadata
-        run: |
-          echo $PWD
-          ls -lah .
-          nix flake metadata ${{ env.FLAKE_REF }}
-          nix flake metadata ${{ env.FLAKE_REF }} --json | jq -r '"LOCKED_URL=\(.url)"' >> "$GITHUB_OUTPUT"
-
       - name: Wait for nix-tools meta job
         uses: input-output-hk/actions/wait-for-hydra@angerman/support-prs
         with:
           check: 'nix-tools'
 
+      # Take the zips from Hydra, which built them, rather than reconstructing
+      # our way back to them with nix.
+      #
+      # The previous form ran `nix build` on the job attributes.  That worked
+      # only while it pointed at the `*-no-ifd` wrappers, which are cheap to
+      # instantiate; the real attributes make a linux runner evaluate the whole
+      # haskell.nix project, and with `--builders "" --max-jobs 0` every path
+      # evaluation wants must already be substitutable.  It is not: cache.zw3rk.com
+      # is an Attic cache fed by `hydra-attic-bridge`, which publishes job
+      # outputs only, and even those are unreliable -- the bridge spent the last
+      # 24h logging "Path not available on any peer, deferring" for hundreds of
+      # paths it never managed to push.  Substituting is therefore a race
+      # against whether a path made it off the build machine in time.
+      #
+      # Hydra always has the artifacts it built, so ask it directly.  No
+      # evaluation, no cache, no nix.  Integrity still holds: Hydra publishes a
+      # sha256 per build product and we check the download against it.
       - name: "Pull nix-tools"
+        env:
+          # On pull_request, github.sha is the merge commit; Hydra evaluates the
+          # head, which is where the check-run lives.
+          COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          ls -lah .
-          cp $(nix build --impure --builders "" --max-jobs 0 ${{ steps.flake-metadata.outputs.LOCKED_URL }}#hydraJobs.aarch64-darwin.nix-tools.static.zipped.nix-tools-static --no-link --print-out-paths)/*.zip .
-          cp $(nix build --impure --builders "" --max-jobs 0 ${{ steps.flake-metadata.outputs.LOCKED_URL }}#hydraJobs.x86_64-darwin.nix-tools.static.zipped.nix-tools-static --no-link --print-out-paths)/*.zip .
-          cp $(nix build --impure --builders "" --max-jobs 0 ${{ steps.flake-metadata.outputs.LOCKED_URL }}#hydraJobs.x86_64-linux.nix-tools.static.zipped.nix-tools-static --no-link --print-out-paths)/*.zip .
-          cp $(nix build --impure --builders "" --max-jobs 0 ${{ steps.flake-metadata.outputs.LOCKED_URL }}#hydraJobs.x86_64-linux.nix-tools.static.zipped.nix-tools-static-arm64 --no-link --print-out-paths)/*.zip .
+          set -euo pipefail
+          hydra=https://ci.zw3rk.com
+
+          # The `nix-tools` check that just went green is Hydra's aggregate
+          # build for this commit.  Its details_url carries the build id; take
+          # the id only, since this instance reports a localhost base URL.
+          build=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${COMMIT}/check-runs" \
+                    --jq '.check_runs[] | select(.name == "nix-tools") | .details_url' \
+                  | grep -oE '/build/[0-9]+' | grep -oE '[0-9]+' | head -1)
+          [ -n "$build" ] || { echo "::error::no Hydra nix-tools check-run for $COMMIT"; exit 1; }
+
+          # A build can belong to several evaluations, so take the one whose
+          # flake ref is this commit.
+          evalid=""
+          for e in $(curl -sf -H 'Accept: application/json' "$hydra/build/$build" | jq -r '.jobsetevals[]'); do
+            if curl -sf -H 'Accept: application/json' "$hydra/eval/$e" \
+                 | jq -e --arg r "$COMMIT" '(.flake // "") | contains($r)' >/dev/null; then
+              evalid=$e; break
+            fi
+          done
+          [ -n "$evalid" ] || { echo "::error::Hydra build $build has no evaluation at $COMMIT"; exit 1; }
+          echo "Hydra eval $evalid (aggregate build $build) for $COMMIT"
+
+          for job in \
+            aarch64-darwin.nix-tools.static.zipped.nix-tools-static \
+            x86_64-darwin.nix-tools.static.zipped.nix-tools-static \
+            x86_64-linux.nix-tools.static.zipped.nix-tools-static \
+            x86_64-linux.nix-tools.static.zipped.nix-tools-static-arm64
+          do
+            meta=$(curl -sfL -H 'Accept: application/json' "$hydra/eval/$evalid/job/$job")
+            status=$(echo "$meta" | jq -r '.buildstatus')
+            [ "$status" = "0" ] || { echo "::error::$job did not succeed (buildstatus $status)"; exit 1; }
+
+            bid=$(echo "$meta" | jq -er '.id')
+            # Pick the first file product rather than assuming it is numbered 1.
+            prod=$(echo "$meta" | jq -er '[.buildproducts | to_entries[] | select(.value.type == "file")] | first')
+            nr=$(echo "$prod"  | jq -er '.key')
+            name=$(echo "$prod" | jq -er '.value.name')
+            want=$(echo "$prod" | jq -er '.value.sha256hash')
+
+            echo "$job -> build $bid product $nr ($name)"
+            curl -fsSL --retry 3 --retry-delay 5 -o "$name" "$hydra/build/$bid/download/$nr"
+            got=$(sha256sum "$name" | cut -d' ' -f1)
+            [ "$got" = "$want" ] || { echo "::error::$name sha256 mismatch: got $got, Hydra says $want"; exit 1; }
+          done
+          ls -l ./*-nix-tools-static.zip
 
       # Hand the zips to the `release` job so it publishes exactly the
       # binaries this hydra-gated job pulled.

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -64,10 +64,10 @@ jobs:
           COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
           # Which Hydra jobset evaluated $COMMIT.  PRs get their own jobset;
           # master pushes and `nix-tools-*` tags (which are cut from master
-          # commits) are covered by `master`.  Note Hydra keeps only 2
-          # evaluations per jobset, so a commit it has since evaluated past
-          # cannot be resolved -- the step fails loudly rather than silently
-          # reaching for a neighbouring revision.
+          # commits) are covered by `master`.  Old evaluations do age out
+          # eventually, so a long-forgotten revision may not be resolvable --
+          # the step then fails loudly, listing what Hydra does have, rather
+          # than silently reaching for a neighbouring revision.
           JOBSET: ${{ github.event.pull_request.number && format('pullrequest-{0}', github.event.pull_request.number) || 'master' }}
           # Generous: these zips are cross-built and the queue can be deep.  It
           # only has to beat the job actually finishing, and a stuck build now
@@ -83,28 +83,48 @@ jobs:
           x86_64-linux.nix-tools.static.zipped.nix-tools-static
           x86_64-linux.nix-tools.static.zipped.nix-tools-static-arm64"
 
-          # Find the evaluation for this exact revision.  `.flake` carries the
-          # full ref, e.g. github:owner/repo/<rev>?narHash=..., so match on the
-          # revision as a substring.  Kept out of a single pipeline so that a
-          # jq miss reports the error below instead of tripping `pipefail`.
-          evals=$(curl -sf -H 'Accept: application/json' "$hydra/jobset/$project/$JOBSET/evals") \
-            || { echo "::error::could not list evaluations for jobset $JOBSET"; exit 1; }
-          evalid=$(printf '%s' "$evals" \
-                     | jq -r --arg r "$COMMIT" 'first(.evals[] | select((.flake // "") | contains($r)) | .id) // empty')
-          [ -n "$evalid" ] || {
-            echo "::error::no Hydra evaluation of $COMMIT in jobset $JOBSET (only 2 are kept)"
-            printf '%s' "$evals" | jq -r '.evals[] | "  eval \(.id): \(.flake // "?")"' || true
-            exit 1
-          }
+          deadline=$(( $(date +%s) + TIMEOUT_MIN * 60 ))
+
+          # Wait for Hydra to evaluate this revision, then find that evaluation.
+          # The wait is the point: the push and this workflow start at the same
+          # moment, so on a new commit Hydra has not evaluated yet -- it still
+          # has to notice the push and then spend ~30-50min evaluating.  The
+          # `wait-for-hydra` action this replaced waited for a check-run to
+          # appear, which covered the same gap.
+          #
+          # `.flake` carries the full ref, e.g. github:owner/repo/<rev>?narHash=...,
+          # so match the revision as a substring.  Every step is guarded so a
+          # transient API failure or a jq miss retries instead of tripping
+          # `set -e`/`pipefail`; only the deadline ends the loop unsuccessfully.
+          evalid=""
+          while :; do
+            # `--max-time` matters here: without it a hung request blocks the
+            # loop indefinitely and the deadline below is never reached.  This
+            # endpoint routinely takes several seconds when the queue is busy.
+            evals=$(curl -sf --max-time 120 -H 'Accept: application/json' "$hydra/jobset/$project/$JOBSET/evals") || evals=""
+            evalid=$(printf '%s' "$evals" \
+                       | jq -r --arg r "$COMMIT" 'first(.evals[]? | select((.flake // "") | contains($r)) | .id) // empty' 2>/dev/null) \
+              || evalid=""
+            if [ -n "$evalid" ]; then break; fi
+            [ "$(date +%s)" -lt "$deadline" ] || {
+              echo "::error::timed out after ${TIMEOUT_MIN}m waiting for Hydra to evaluate $COMMIT in jobset $JOBSET"
+              echo "evaluations Hydra does have for that jobset:"
+              printf '%s' "$evals" | jq -r '.evals[]? | "  eval \(.id): \(.flake // "?")"' || true
+              exit 1
+            }
+            echo "waiting for Hydra to evaluate $COMMIT in jobset $JOBSET"
+            sleep 60
+          done
           echo "Hydra eval $evalid for $COMMIT (jobset $JOBSET)"
 
-          deadline=$(( $(date +%s) + TIMEOUT_MIN * 60 ))
           for job in $jobs; do
             # Wait for this job to finish.  `finished` flips to 1 once Hydra is
             # done with the build, whatever the outcome; buildstatus is only
-            # meaningful after that.
+            # meaningful after that.  `--retry` so a transient 5xx from Hydra
+            # (a 504 showed up while testing this) does not fail the run; a job
+            # that is genuinely absent from the eval still fails fast.
             while :; do
-              meta=$(curl -sfL -H 'Accept: application/json' "$hydra/eval/$evalid/job/$job") \
+              meta=$(curl -sfL --retry 3 --retry-delay 5 --max-time 120 -H 'Accept: application/json' "$hydra/eval/$evalid/job/$job") \
                 || { echo "::error::$job is not in eval $evalid"; exit 1; }
               [ "$(echo "$meta" | jq -r '.finished')" = "1" ] && break
               [ "$(date +%s)" -lt "$deadline" ] \

--- a/flake.nix
+++ b/flake.nix
@@ -336,13 +336,9 @@
             constituents = (if runningHydraEvalTest then [ ] else [
               "aarch64-darwin.nix-tools.static.zipped.nix-tools-static"
               "x86_64-darwin.nix-tools.static.zipped.nix-tools-static"
-              "aarch64-darwin.nix-tools.static.zipped.nix-tools-static-no-ifd"
-              "x86_64-darwin.nix-tools.static.zipped.nix-tools-static-no-ifd"
             ]) ++ [
               "x86_64-linux.nix-tools.static.zipped.nix-tools-static"
               "x86_64-linux.nix-tools.static.zipped.nix-tools-static-arm64"
-              "x86_64-linux.nix-tools.static.zipped.nix-tools-static-no-ifd"
-              "x86_64-linux.nix-tools.static.zipped.nix-tools-static-arm64-no-ifd"
               (pkgs.writeText "gitrev" (self.rev or "0000000000000000000000000000000000000000"))
             ];
           };

--- a/flake.nix
+++ b/flake.nix
@@ -338,23 +338,23 @@
       };
 
     in
-    traceHydraJobs (lib.recursiveUpdate flake (lib.optionalAttrs (ifdLevel > 2)
-      (
-        let pkgs = nixpkgs.legacyPackages."x86_64-linux"; in
-        {
-          hydraJobs.nix-tools = pkgs.releaseTools.aggregate {
-            name = "nix-tools";
-            constituents = (if runningHydraEvalTest then [ ] else [
-              "aarch64-darwin.nix-tools.static.zipped.nix-tools-static"
-              "x86_64-darwin.nix-tools.static.zipped.nix-tools-static"
-            ]) ++ [
-              "x86_64-linux.nix-tools.static.zipped.nix-tools-static"
-              "x86_64-linux.nix-tools.static.zipped.nix-tools-static-arm64"
-              (pkgs.writeText "gitrev" (self.rev or "0000000000000000000000000000000000000000"))
-            ];
-          };
-        }
-      )));
+    # There used to be a `hydraJobs.nix-tools` aggregate here, grouping the four
+    # `<system>.nix-tools.static.zipped.*` zips so `upload-artifacts.yml` had a
+    # single check to wait on.  It was expensive out of proportion to that.
+    #
+    # `releaseTools.aggregate` takes its constituents as job-name strings, which
+    # are Hydra metadata and create no nix dependency -- but nix-eval-jobs
+    # resolves named constituents and rewrites the derivation to depend on them,
+    # so the built `nix-tools.drv` really did list all four zips in `inputDrvs`.
+    # nix realises every input on the build machine whether the builder script
+    # reads it or not, so the aggregate dragged 476MB of zip closures onto
+    # whichever single agent Hydra happened to pick.  On the darwin-hosted linux
+    # builders, where import already dominates step time, that regularly hit the
+    # one-hour wall and failed, then retried elsewhere and copied it all again.
+    #
+    # The workflow now asks the Hydra API for the eval matching the commit and
+    # reads those four jobs from it directly, so nothing has to co-locate them.
+    traceHydraJobs flake;
 
   # --- Flake Local Nix Configuration ----------------------------
   nixConfig = {

--- a/flake.nix
+++ b/flake.nix
@@ -266,11 +266,27 @@
             # on the version of haskell.nix locked in the subflake. They are
             # evaluated within their own flake and independently of anything
             # else. Here we only expose them in the main flake.
+            # Deliberately no `pkgs` argument.  flake-compat fetches the
+            # subflake's inputs with `pkgs.fetchzip or fetchTarball`, so
+            # handing it a package set makes every one of those fetches a
+            # derivation *on that package set's platform* -- and since this is
+            # `forEachSystem`, the darwin jobs got aarch64-darwin fetch
+            # derivations that evaluation then has to realise.  That is fine on
+            # Hydra, which has darwin builders, and impossible anywhere else:
+            # `nix build .#hydraJobs.aarch64-darwin.nix-tools...` on linux died
+            # with "Cannot build '...-source.drv' ... Required system:
+            # 'aarch64-darwin'", and the path was not in any cache because
+            # fetches are not Hydra jobs so nothing publishes them.
+            #
+            # Without `pkgs` it falls back to `builtins.fetchTarball`, which
+            # needs no builder at all.  The lock file supplies `narHash` for
+            # every input, so this still works under pure evaluation, and the
+            # fetched paths are unchanged -- a fixed-output path depends on the
+            # hash and name, not on who fetched it.
             nix-tools-hydraJobs =
               let
                 cf = callFlake {
                   inherit system;
-                  pkgs = self.legacyPackages.${system};
                   src = ./nix-tools;
                 };
               in

--- a/flake.nix
+++ b/flake.nix
@@ -266,27 +266,11 @@
             # on the version of haskell.nix locked in the subflake. They are
             # evaluated within their own flake and independently of anything
             # else. Here we only expose them in the main flake.
-            # Deliberately no `pkgs` argument.  flake-compat fetches the
-            # subflake's inputs with `pkgs.fetchzip or fetchTarball`, so
-            # handing it a package set makes every one of those fetches a
-            # derivation *on that package set's platform* -- and since this is
-            # `forEachSystem`, the darwin jobs got aarch64-darwin fetch
-            # derivations that evaluation then has to realise.  That is fine on
-            # Hydra, which has darwin builders, and impossible anywhere else:
-            # `nix build .#hydraJobs.aarch64-darwin.nix-tools...` on linux died
-            # with "Cannot build '...-source.drv' ... Required system:
-            # 'aarch64-darwin'", and the path was not in any cache because
-            # fetches are not Hydra jobs so nothing publishes them.
-            #
-            # Without `pkgs` it falls back to `builtins.fetchTarball`, which
-            # needs no builder at all.  The lock file supplies `narHash` for
-            # every input, so this still works under pure evaluation, and the
-            # fetched paths are unchanged -- a fixed-output path depends on the
-            # hash and name, not on who fetched it.
             nix-tools-hydraJobs =
               let
                 cf = callFlake {
                   inherit system;
+                  pkgs = self.legacyPackages.${system};
                   src = ./nix-tools;
                 };
               in

--- a/nix-tools/static/zipped.nix
+++ b/nix-tools/static/zipped.nix
@@ -39,42 +39,26 @@ let
         ] ++ strippedNixToolsComponents;
       };
 
-  
-  zippedToolsNoIfdFor = fragment-name: 
-    let 
-      stringifyInputs = inputs: pkgs.lib.mapAttrsToList (name: value: pkgs.lib.trace "${name}=${value}" "${value}") inputs;
-      # stringifyInputs = inputs: map (x: "${x}") (builtins.attrValues inputs);
-
-      fragment-drv = "static-nix-tools-outputs.hydraJobs.${pkgs.stdenv.hostPlatform.system}.zipped.${fragment-name}";
-    in
-      pkgs.runCommand "${pkgs.stdenv.hostPlatform.system}-all-nix-tools" {
-        requiredSystemFeatures = [ "recursive-nix" ];
-        nativeBuildInputs = 
-          # [ inputs.nixpkgs-unstable.legacyPackages.${pkgs.stdenv.hostPlatform.system}.nix pkgs.gitMinimal ]
-          [ (pkgs.lib.trace pkgs.nix.version pkgs.nix) pkgs.gitMinimal ]
-          ++ stringifyInputs inputs
-          ++ stringifyInputs inputs.haskellNix.inputs;
-      } ''
-        export HOME=$(mktemp -d)
-        mkdir $out
-        # Deliberately not `nix --offline`: that bundles `substitute = false`, so
-        # anything missing from the builder's store is compiled from source rather
-        # than fetched.  On a darwin builder that meant rebuilding llvm and running
-        # its 57k-test check-all suite, which hung and was killed by max-silent-time
-        # after 3h (ci.zw3rk.com/build/1695375).  Substitution happens daemon-side,
-        # outside the recursive-nix sandbox, so it was never a hermeticity risk.
-        # tarball-ttl is what --offline was actually wanted for: don't re-fetch
-        # the flake inputs, which nativeBuildInputs above already pins into the
-        # store.  Just that one setting -- narinfo-cache-meta-ttl exists in nix
-        # 2.34 but not in the 2.31.2 that pkgs.nix pins here, where it only logs
-        # "warning: unknown setting" and does nothing.
-        cp $(nix --extra-experimental-features "flakes nix-command" \
-          build --accept-flake-config --no-link --print-out-paths --no-allow-import-from-derivation \
-          --option tarball-ttl 4294967295 \
-          --system ${pkgs.stdenv.hostPlatform.system} \
-          ${../.}#${fragment-drv})/*.zip $out/
-      '';
- 
+  # There used to be a `*-no-ifd` variant of each zip here: a `runCommand` with
+  # `requiredSystemFeatures = [ "recursive-nix" ]` that re-entered nix to build
+  # the same fragment with `--no-allow-import-from-derivation`, meaning to prove
+  # the static tools need no IFD.  It never proved that.  A flake's `nixConfig`
+  # overrides the command line, and nix-tools/flake.nix sets
+  # `allow-import-from-derivation = "true"`, so the flag was ignored -- the build
+  # logs show plan-to-nix running inside it (ci.zw3rk.com/build/1811419).  The
+  # nested build also resolved to the same derivation as the plain job above
+  # (flake.nix loads ./nix-tools through its own lock, exactly as `${../.}` did),
+  # so all it added was a second realisation and a copy.
+  #
+  # What it did cost was real: recursive-nix is unsupported by nix's external
+  # derivation builders, and when it did get scheduled somewhere it could run,
+  # nothing substituted, so darwin rebuilt ~470 derivations from source and hit
+  # the 7200s timeout.
+  #
+  # Reinstating the check means removing that `nixConfig` line and running the
+  # build at the top level -- no nesting, hence no recursive-nix.  Note it will
+  # fail until ./project.nix is materialized: the static project genuinely does
+  # use IFD today.
 
   zippedToolsForDarwin = makeZippedTools {
     customPkgs = pkgs;
@@ -95,15 +79,11 @@ let
   allZippedTools = 
     pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "x86_64-darwin" || pkgs.stdenv.hostPlatform.system == "aarch64-darwin") {
       "nix-tools-static" = zippedToolsForDarwin;
-      "nix-tools-static-no-ifd" = zippedToolsNoIfdFor "nix-tools-static";
-    } 
-    // 
+    }
+    //
     pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "x86_64-linux") {
       "nix-tools-static" = zippedToolsForLinux;
       "nix-tools-static-arm64" = zippedToolsForLinuxArm64;
-
-      "nix-tools-static-no-ifd" = zippedToolsNoIfdFor "nix-tools-static";
-      "nix-tools-static-arm64-no-ifd" = zippedToolsNoIfdFor "nix-tools-static-arm64";
     };
 
 in

--- a/test/cabal.project.local
+++ b/test/cabal.project.local
@@ -26,7 +26,7 @@ repository head.hackage.ghc.haskell.org
      f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
      26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
      7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-  --sha256: sha256-jEf7DhlAcQ9Y9AebVZnlAWB8GdRwrHVAJAd+bqn9RRE=
+  --sha256: sha256-AhEnAsLP1DgBb81z+DQuDPwyWhMm4m2Fyy8InOTT+2Q=
 
 repository ghcjs-overlay
   url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/ffb32dce467b9a4d27be759fdd2740a6edd09d0b

--- a/test/cabal.project.local
+++ b/test/cabal.project.local
@@ -26,7 +26,7 @@ repository head.hackage.ghc.haskell.org
      f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
      26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
      7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-  --sha256: sha256-uroYmmrzEOlmjSAcMIsN4+whOlrM24RqyG0zI1bNHb4=
+  --sha256: sha256-jEf7DhlAcQ9Y9AebVZnlAWB8GdRwrHVAJAd+bqn9RRE=
 
 repository ghcjs-overlay
   url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/ffb32dce467b9a4d27be759fdd2740a6edd09d0b


### PR DESCRIPTION
Removes the four `*-no-ifd` jobs, which used `recursive-nix` to re-enter nix and rebuild the static tools with `--no-allow-import-from-derivation`.

## They were not checking anything

A flake's `nixConfig` overrides the command line, and `nix-tools/flake.nix:104` sets `allow-import-from-derivation = "true"`, so the flag was ignored. Two flakes differing only in that line:

```
withcfg  (nixConfig aifd=true)  => IFD RAN (defeated)
nocfg    (no nixConfig)         => blocked (works)
```

No override form wins — `--option`, `NIX_CONFIG`, `--no-accept-flake-config`, a `path:` flakeref. And nix 2.34 rejects IFD even when the output is already valid, so this isn't a store-state artefact.

The production logs agree. From [build 1811419](https://ci.zw3rk.com/build/1811419):

```
978:  building '/nix/store/…-nix-tools-plan-to-nix-pkgs.drv'...
1011: building '/nix/store/…-hadrian-plan-to-nix-pkgs.drv'...
```

Import-from-derivation, inside the derivation whose purpose was to prove it doesn't happen.

## And the build was redundant

`flake.nix` loads `./nix-tools` via `callFlake` against its own lock — the same thing `${../.}` resolved to inside the sandbox. Both reach the same derivation:

```
.#hydraJobs.aarch64-darwin.nix-tools.static.zipped.nix-tools-static.drvPath
./nix-tools#static-nix-tools-outputs.hydraJobs.aarch64-darwin.zipped.nix-tools-static.drvPath
  → both /nix/store/rn63c3jvs89x9m8sjam0q7y1ibgr962l-…zip.drv
```

## The cost was real

`recursive-nix` is unsupported by nix's external derivation builders, so these failed outright whenever the queue runner sent them to a darwin host serving linux — six consecutive evals at one point. Where they did run, nothing substituted: recent darwin failures compiled ~470 derivations from source before hitting the 7200 s timeout, in 2 of the last 5 evals.

They were also the last users of `recursive-nix` in the repo.

## What the wrapper was *actually* load-bearing for

Not the IFD assertion — the release path. `upload-artifacts.yml` pulled the zips with `nix build --builders "" --max-jobs 0` on a linux runner, which only worked because the wrapper derivations are cheap to *instantiate* (their inputs are just nix, git and the flake sources). The real job attributes make that runner evaluate the whole haskell.nix project, and it died with:

```
error: Cannot build '/nix/store/v4brv9…-source.drv'.
Reason: local builds are disabled (max-jobs = 0)
Reason: platform mismatch
  Required system: 'aarch64-darwin'
  Current system:  'x86_64-linux'
```

So the release step had to change too.

## Why it now takes the zips from Hydra

Substituting looked like the obvious repair, but it is a bet on paths being copied off the build machines in time. `cache.zw3rk.com` is an Attic cache fed by `hydra-attic-bridge`, which publishes **job outputs only** — eval-time paths never reach it — and even job outputs are not dependable. Over 24 hours the bridge logged:

```
493  Path not available on any peer, deferring: …haskell-project-plan-to-nix-pkgs
 84  …source-test-cabal-simple-plan-to-nix-pkgs
 45  …nix-tools
```

Retried indefinitely, never pushed.

Hydra has the artifacts it built, so the step now asks it: resolve the aggregate build from the `nix-tools` check-run, pick the evaluation whose flake ref is this commit, download each job's build product. No evaluation, no cache, and no nix in that job at all — `install-nix-action` and the flake-metadata step go with it. (The `release` job keeps its nix install for `nix-hash`.)

Integrity is preserved without `nix copy`: Hydra publishes a sha256 per build product and the download is checked against it. The download, Hydra's declared hash, and the file inside the store path substituted from cache.zw3rk.com all agree:

```
a225806575b9092a377766f9f971d0ddb24a78cae5384227e55a84c362351286
```

Dry-run with the exact script against live Hydra and GitHub resolves eval 2210 from the check-run, fetches all four products, verifies every hash, exits 0, and leaves precisely the four filenames the release job's pin loop expects — including `aarch64-linux-…` from the `-arm64` job.

## Changes

- `nix-tools/static/zipped.nix` — drop `zippedToolsNoIfdFor` and the four `*-no-ifd` attributes; comment records why and what reinstating the check would take.
- `flake.nix` — drop those constituents from the `nix-tools` aggregate; **and** stop handing `callFlake` a package set (see below).
- `.github/workflows/upload-artifacts.yml` — pull the zips from the Hydra API.
- `test/cabal.project.local` — head.hackage pin bump, needed to get CI green at all (it had rolled, failing 11 checks on master too).

Released artifacts are unchanged: same derivations, and the plain job's output has the same shape (a directory containing the `.zip`) plus the `nix-support/hydra-build-products` the wrapper dropped — which is what makes the Hydra download work.

Verified the surviving jobs are untouched; drvPaths identical before and after:

| system | master | this branch |
|---|---|---|
| aarch64-darwin | `3pkn181f…-aarch64-darwin-nix-tools-static.zip.drv` | `3pkn181f…` |
| x86_64-linux | `k8ijl9ry…-x86_64-linux-nix-tools-static.zip.drv` | `k8ijl9ry…` |

## A commit that was tried and backed out

`69072ff99` stopped `flake.nix` passing `pkgs` to `callFlake`, to fix a real portability bug: flake-compat fetches a subflake's inputs with `pkgs.fetchzip or fetchTarball`, so passing `pkgs` makes every fetch a derivation *on that package set's platform* — and a linux evaluator then cannot realise the darwin ones.

It is reverted here. Comparing Hydra evaluations showed it is not the no-op I took it for:

```
eval 2212 (ab806d335) vs eval 2213 (69072ff99), both with 0 eval errors
only in 2212:
    aarch64-darwin.nix-tools.haskellNixSource
    x86_64-darwin.nix-tools.haskellNixSource
    x86_64-linux.nix-tools.haskellNixSource
```

`nix-tools/flake.nix` exposes `haskellNixSource = inputs.haskellNix.outPath`. With `pkgs` passed that `outPath` *is* a `fetchzip` derivation, so Hydra makes a job of it — and being a job is precisely what gets it published. `builtins.fetchTarball` makes it a plain path and the job vanishes. Checking that the zip derivations were unchanged did not catch this, because it removes a job rather than altering one.

The portability bug is still worth fixing, but it needs a fix that keeps `haskellNixSource` a derivation, in its own PR.

## Follow-ups, not here

- A genuine no-IFD check means dropping that `nixConfig` line and running the build at the top level, with no nesting and hence no recursive-nix. It will fail until `nix-tools/static/project.nix` is materialized, since the static project does use IFD today.
- `flake.nix:187-189` documents `nix build .#roots.x86_64-linux --accept-flake-config --option allow-import-from-derivation false`, and `flake.nix:359` sets the same `nixConfig`. That command is very likely inert too — unverified.
- The `hydra-attic-bridge` deferrals above are a pre-existing infra problem worth raising on their own.
