### PR TITLE
Build the head.hackage repository instead of downloading it

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -19,12 +19,17 @@ let
 in rec {
   tests = import ./test/default.nix { inherit pkgs evalPackages ifdLevel compiler-nix-name; };
 
+  # See test/head-hackage.nix: the tests use the head.hackage repository
+  # haskell.nix builds, not the published one.
+  headHackage = import ./test/head-hackage.nix { inherit pkgs; };
+
   tools = pkgs.lib.optionalAttrs (ifdLevel >= 3) (
     pkgs.lib.recurseIntoAttrs ({
       cabal-latest = tool compiler-nix-name "cabal" ({
         inherit evalPackages;
       } // pkgs.lib.optionalAttrs (ghcFromTo "9.13" "9.14") {
-        cabalProjectLocal = builtins.readFile ./test/cabal.project.local;
+        inputMap = headHackage.inputMap;
+        cabalProjectLocal = headHackage.cabalProjectLocal;
       });
     } // pkgs.lib.optionalAttrs (__compareVersions haskell.compiler.${compiler-nix-name}.version "9.8" < 0) {
       hlint-latest = tool compiler-nix-name "hlint" {

--- a/build.nix
+++ b/build.nix
@@ -21,7 +21,7 @@ in rec {
 
   # See test/head-hackage.nix: the tests use the head.hackage repository
   # haskell.nix builds, not the published one.
-  headHackage = import ./test/head-hackage.nix { inherit pkgs; };
+  headHackage = import ./test/head-hackage.nix { inherit evalPackages; };
 
   tools = pkgs.lib.optionalAttrs (ifdLevel >= 3) (
     pkgs.lib.recurseIntoAttrs ({

--- a/flake.lock
+++ b/flake.lock
@@ -132,6 +132,40 @@
         "type": "github"
       }
     },
+    "hackage-overlay-repo-tool": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1671663228,
+        "narHash": "sha256-GKeke8FT9w2u6J9aI4eN3mOV0BURHiytQAEir4/4M1Q=",
+        "owner": "bgamari",
+        "repo": "hackage-overlay-repo-tool",
+        "rev": "f60aa0d497961745a503ddea2adb0facb58376e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bgamari",
+        "repo": "hackage-overlay-repo-tool",
+        "type": "github"
+      }
+    },
+    "head-hackage": {
+      "flake": false,
+      "locked": {
+        "host": "gitlab.haskell.org",
+        "lastModified": 1780387533,
+        "narHash": "sha256-oifEa/JYg8ZLUtkbM8HVzKmqCcT9QxaDmG0ex2qT0Ng=",
+        "owner": "ghc",
+        "repo": "head.hackage",
+        "rev": "a50bec6c7722f774415bc0f0a0e64f6e2b8989b7",
+        "type": "gitlab"
+      },
+      "original": {
+        "host": "gitlab.haskell.org",
+        "owner": "ghc",
+        "repo": "head.hackage",
+        "type": "gitlab"
+      }
+    },
     "hls": {
       "flake": false,
       "locked": {
@@ -541,6 +575,8 @@
         "hackage": "hackage",
         "hackage-for-stackage": "hackage-for-stackage",
         "hackage-internal": "hackage-internal",
+        "hackage-overlay-repo-tool": "hackage-overlay-repo-tool",
+        "head-hackage": "head-hackage",
         "hls": "hls",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,17 @@
       url = "github:stable-haskell/iserv-proxy?ref=iserv-syms";
       flake = false;
     };
+    # head.hackage's patches, plus the tool its CI uses to turn them into a
+    # package repository.  We build the repository ourselves rather than
+    # downloading the published one -- see overlays/head-hackage.nix.
+    head-hackage = {
+      url = "gitlab:ghc/head.hackage?host=gitlab.haskell.org";
+      flake = false;
+    };
+    hackage-overlay-repo-tool = {
+      url = "github:bgamari/hackage-overlay-repo-tool";
+      flake = false;
+    };
   };
 
   outputs =

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -3,6 +3,7 @@ let
   overlays = {
     wine = import ./wine.nix;
     haskell = import ./haskell.nix { inherit sources; };
+    head-hackage = import ./head-hackage.nix { inherit sources; };
 
     # Here is where we import nix-tools into the overlays that haskell.nix is
     # going to use. To cut the evaluation time of nix-tools (which would itself
@@ -125,6 +126,7 @@ let
     musl
     android
     tools
+    head-hackage
     emscripten
     nix-prefetch-git-minimal
     ghcjs

--- a/overlays/head-hackage.nix
+++ b/overlays/head-hackage.nix
@@ -1,0 +1,251 @@
+# Build the head.hackage package repository locally, instead of downloading the
+# one GitLab publishes.
+#
+# Why not just download it: the published repository is regenerated on a
+# schedule and is not reproducible, so its hash moves even when nothing in
+# head.hackage changes.  Between two consecutive publications every one of the
+# 79 patched packages had a different tarball hash while not a single `.cabal`
+# file differed -- the patched tarballs are re-created each run and pick up the
+# build time.  Pinning that with `--sha256` in a `repository` stanza means the
+# pin goes stale about once a day, and each bump invalidates every
+# `plan-to-nix` output in the tree.
+#
+# Building it here instead means it depends only on the `head-hackage` flake
+# input (which moves when a patch changes) and the Hackage index haskell.nix
+# already pins through hackage.nix.  Nothing to hand-maintain.
+#
+# The result is wired in as `inputMap."https://ghc.gitlab.haskell.org/head.hackage/"`
+# (see modules/cabal-project.nix), the same mechanism used for foliage
+# repositories such as CHaP, so a `repository` stanza naming that url is served
+# from here rather than fetched.
+{ sources }:
+
+final: prev:
+
+let
+  inherit (final) lib;
+
+  buildPkgs = final.buildPackages;
+
+  indexStateHashes = import final.haskell-nix.indexStateHashesPath;
+
+  # The newest index-state hackage.nix has a hash for.  `internalHackageIndexState`
+  # is not usable here: it is an exact timestamp, whereas index-state-hashes.nix
+  # is keyed by the daily snapshots, so it usually has no entry for it.
+  # `lib/call-cabal-project-to-nix.nix` deals with this by rounding up to the
+  # first cached state at or after the one asked for; we simply take the latest,
+  # which is always present and is what a fresh `cabal update` would see.
+  index-state = lib.last (builtins.attrNames indexStateHashes);
+
+  # The Hackage index, pinned exactly as the rest of haskell.nix pins it: the
+  # index-state comes from hackage.nix and the hash from its
+  # index-state-hashes.nix.  Everything below is derived from this, so moving
+  # the hackage.nix pin is all it takes to pick up newly patched versions.
+  hackageIndex = buildPkgs.fetchurl {
+    name = "01-index.tar.gz-at-${builtins.replaceStrings [ ":" ] [ "" ] index-state}";
+    url = "https://hackage.haskell.org/01-index.tar.gz";
+    downloadToTemp = true;
+    postFetch = ''
+      ${final.haskell-nix.nix-tools-unchecked.exes.truncate-index}/bin/truncate-index \
+        -o $out -i $downloadedFile -s ${index-state}
+    '';
+    outputHashAlgo = "sha256";
+    outputHash = indexStateHashes.${index-state};
+  };
+
+  # The package-versions head.hackage patches, taken from the names in
+  # `patches/`: `<pkg>-<version>.patch` (a source patch) or `<pkg>-<version>.cabal`
+  # (a .cabal-only fixup).  Deriving the list from the directory rather than
+  # hard-coding it means a new patch upstream needs no change here.
+  patchedPackages =
+    let
+      names = builtins.attrNames (builtins.readDir (sources.head-hackage + "/patches"));
+      stripExt = n: lib.removeSuffix ".patch" (lib.removeSuffix ".cabal" n);
+    in
+    lib.unique (map stripExt names);
+
+  # Pull each patched version's *original* tarball hash out of the pinned
+  # index.  Every entry in a secure Hackage index carries a `package.json` with
+  # the tarball's sha256 and length, which is what lets us fetch the originals
+  # without a single hash of our own.
+  #
+  # This is import-from-derivation, as plan-to-nix already is throughout
+  # haskell.nix: the index is a build artefact, so reading it means building it.
+  srcHashesFile = buildPkgs.runCommand "head-hackage-src-hashes.nix"
+    {
+      nativeBuildInputs = [ buildPkgs.gnutar buildPkgs.gzip buildPkgs.jq ];
+      passthru = { inherit patchedPackages; };
+    } ''
+    mkdir -p unpacked && cd unpacked
+    # One pass over the index, not one per package: it is ~130MB compressed and
+    # rescanning it 79 times is minutes of pure I/O.  tar takes all the members
+    # we want in a single invocation.
+    tar -xzf ${hackageIndex} \
+      ${lib.concatMapStringsSep " \\\n      " (pv:
+        let
+          m = builtins.match "(.*)-([0-9][0-9.]*)" pv;
+          pname = builtins.elemAt m 0;
+          pver = builtins.elemAt m 1;
+        in "'${pname}/${pver}/package.json'") patchedPackages}
+
+    {
+      echo '{'
+      ${lib.concatMapStringsSep "\n      " (pv:
+        let
+          m = builtins.match "(.*)-([0-9][0-9.]*)" pv;
+          pname = builtins.elemAt m 0;
+          pver = builtins.elemAt m 1;
+        in ''
+          if [ ! -f '${pname}/${pver}/package.json' ]; then
+            echo "head.hackage patches ${pv}, but it is not in the Hackage index at ${index-state}" >&2
+            exit 1
+          fi
+          echo "  \"${pv}\" = \"$(jq -r '.signed.targets | to_entries[0].value.hashes.sha256' '${pname}/${pver}/package.json')\";"
+        '') patchedPackages}
+      echo '}'
+    } > $out
+  '';
+
+  srcHashes = import srcHashesFile;
+
+  # The original tarballs, fetched by hash from the index.  Laid out the way
+  # `cabal fetch` would leave them, which is where the overlay tool looks:
+  #   <repo-cache>/<repo-name>/<pkg>/<version>/<pkg>-<version>.tar.gz
+  repoCache = buildPkgs.runCommand "head-hackage-repo-cache" { } (''
+    mkdir -p $out/hackage.haskell.org
+  '' + lib.concatStrings (lib.mapAttrsToList (pv: sha256:
+    let
+      m = builtins.match "(.*)-([0-9][0-9.]*)" pv;
+      pname = builtins.elemAt m 0;
+      pver = builtins.elemAt m 1;
+      tarball = buildPkgs.fetchurl {
+        name = "${pv}.tar.gz";
+        url = "https://hackage.haskell.org/package/${pv}/${pv}.tar.gz";
+        inherit sha256;
+      };
+    in ''
+      mkdir -p $out/hackage.haskell.org/${pname}/${pver}
+      ln -s ${tarball} $out/hackage.haskell.org/${pname}/${pver}/${pv}.tar.gz
+    '') srcHashes));
+
+  # `cabal update` has to succeed offline, so point the tool at a local,
+  # unsigned copy of the pinned index rather than hackage.haskell.org.
+  # mk-local-hackage-repo is what haskell.nix already uses for this.
+  localHackage = import ../mk-local-hackage-repo final {
+    name = "hackage.haskell.org";
+    index = hackageIndex;
+  };
+
+  # `tar` with a fixed mtime.
+  #
+  # The overlay tool already asks for reproducible output -- it passes
+  # `--format=ustar --numeric-owner --owner=root --group=root --clamp-mtime
+  # --mtime=<patch file>` -- but that `--mtime` does not take effect and the
+  # tarballs come out stamped with the time of the run.  Two runs minutes apart
+  # on identical inputs produced different directory entries:
+  #
+  #   arith-encode-1.0.2/   2026-08-03 10:29
+  #   arith-encode-1.0.2/   2026-08-03 10:31
+  #
+  # That is the upstream churn, and without fixing it this derivation would not
+  # be reproducible either.  GNU tar honours the last `--mtime`, so appending
+  # one overrides theirs without patching their source; with it, two
+  # independent runs agree byte for byte.
+  deterministicTar = buildPkgs.writeShellScriptBin "tar" ''
+    exec ${buildPkgs.gnutar}/bin/tar "$@" --mtime=@1 --clamp-mtime
+  '';
+
+in
+{
+  haskell-nix = prev.haskell-nix // {
+
+    # The tool head.hackage's CI uses to turn `patches/` into a repository.
+    # Built with haskell.nix against a nixpkgs GHC -- it is a small build tool,
+    # so there is no reason to build a compiler for it.  `overlays/bootstrap.nix`
+    # builds alex and happy the same way.
+    #
+    # The repository carries no cabal.project, and its bounds predate current
+    # Hackage (`base < 4.17`, `text ^>= 1.2`), hence both overrides.
+    hackage-overlay-repo-tool =
+      (final.haskell-nix.cabalProject' {
+        # Patched so its `cabal update` accepts the unsigned local mirror of
+        # the pinned index; see the patch header for why.
+        src = buildPkgs.applyPatches {
+          name = "hackage-overlay-repo-tool-src";
+          src = sources.hackage-overlay-repo-tool;
+          patches = [ ./patches/hackage-overlay-repo-tool/local-repo-no-signatures.patch ];
+        };
+        name = "hackage-overlay-repo-tool";
+        compiler-nix-name = "ghc967";
+        compilerSelection = p: p.haskell.compiler;
+        # The tool's own plan is pinned to the same internal index-state the
+        # other build tools (alex, happy) use, so it is stable and materializable.
+        index-state = final.haskell-nix.internalHackageIndexState;
+        cabalProject = ''
+          packages: .
+        '';
+        cabalProjectLocal = ''
+          allow-newer: tool:*
+        '';
+      }).hsPkgs.tool.components.exes.tool;
+
+    head-hackage-repo = buildPkgs.runCommand "head-hackage.ghc.haskell.org"
+      {
+        nativeBuildInputs = [
+          # `deterministicTar` must come before gnutar on PATH.
+          deterministicTar
+          buildPkgs.gnutar
+          buildPkgs.gzip
+          buildPkgs.gnupatch
+          buildPkgs.haskellPackages.hackage-repo-tool
+          # The tool's last step syncs its staging directory over the target.
+          buildPkgs.rsync
+          final.haskell-nix.hackage-overlay-repo-tool
+          final.haskell-nix.nix-tools-unchecked.exes.cabal
+          # cabal insists on finding a compiler even for `fetch`.  haskell.nix's
+          # `cabal-issue-8352-workaround` dummy-ghc is not enough here: cabal
+          # invokes it as `-package-env=- --supported-languages`, which the stub
+          # does not parse ("Unknown argument").  A real GHC costs nothing extra
+          # -- this is the same one the overlay tool above is built with.
+          buildPkgs.haskell.compiler.ghc967
+        ];
+        passthru = { inherit patchedPackages srcHashesFile; };
+      } ''
+      export HOME=$(mktemp -d)
+
+      # Signing keys.  These are generated per build rather than pinned: the
+      # repository is consumed over `file:` from the store, so the signatures
+      # are not a trust boundary, and the `repository` stanza that reads it
+      # uses `key-threshold: 0` with no root-keys (the same arrangement as the
+      # existing `ghcjs-overlay` entry in test/cabal.project.local).
+      hackage-repo-tool create-keys --keys=$HOME/keys
+
+      # hackage-repo-tool refuses to bootstrap an empty repository, so seed it
+      # with one package, exactly as head.hackage's ci/build-repo.sh does.
+      mkdir -p repo/package
+      seed=$(ls ${repoCache}/hackage.haskell.org/*/*/*.tar.gz | head -1)
+      cp "$seed" repo/package/
+      hackage-repo-tool bootstrap --keys=$HOME/keys --repo=./repo
+
+      # Everything the tool needs is already local: the patches from the flake
+      # input, the originals in the pre-populated cache, and the pinned index
+      # served over `file:` so its `cabal update` needs no network.
+      mkdir -p tmp/patches.cache template
+      cp -R ${sources.head-hackage}/patches tmp/patches
+      chmod -R u+w tmp/patches
+      cp -R ${repoCache} cache
+      chmod -R u+w cache
+
+      tool \
+        --patches=./tmp/patches \
+        --repo-cache=./cache \
+        --keys=$HOME/keys \
+        --repo-name=hackage.haskell.org \
+        --repo-url=file:${localHackage} \
+        --template=template \
+        ./repo
+
+      cp -r repo $out
+    '';
+  };
+}

--- a/overlays/head-hackage.nix
+++ b/overlays/head-hackage.nix
@@ -139,10 +139,19 @@ let
       ln -s ${tarball} $out/hackage.haskell.org/${pname}/${pver}/${pv}.tar.gz
     '') srcHashes));
 
+  # One fixed timestamp for everything we re-tar, taken from the head.hackage
+  # input's own lastModified so it is deterministic and only moves when the
+  # patches do.  Not epoch: cabal derives a repository's index-state from the
+  # newest entry in its index, and an index stamped 1970 makes any project
+  # asking for a present-day index-state look newer than the repository.
+  repoEpoch = toString sources.head-hackage.lastModified;
+
+  mkLocalHackageRepo = import ../mk-local-hackage-repo final;
+
   # `cabal update` has to succeed offline, so point the tool at a local,
   # unsigned copy of the pinned index rather than hackage.haskell.org.
   # mk-local-hackage-repo is what haskell.nix already uses for this.
-  localHackage = import ../mk-local-hackage-repo final {
+  localHackage = mkLocalHackageRepo {
     name = "hackage.haskell.org";
     index = hackageIndex;
   };
@@ -163,7 +172,7 @@ let
   # one overrides theirs without patching their source; with it, two
   # independent runs agree byte for byte.
   deterministicTar = buildPkgs.writeShellScriptBin "tar" ''
-    exec ${buildPkgs.gnutar}/bin/tar "$@" --mtime=@1 --clamp-mtime
+    exec ${buildPkgs.gnutar}/bin/tar "$@" --mtime=@${repoEpoch} --clamp-mtime
   '';
 
 in
@@ -200,7 +209,11 @@ in
         '';
       }).hsPkgs.tool.components.exes.tool;
 
-    head-hackage-repo = buildPkgs.runCommand "head-hackage.ghc.haskell.org"
+    # The tool's own output.  Its `package/*.tar.gz` are reproducible (see the
+    # tar wrapper), but its TUF metadata is not: it is signed with keys generated
+    # during this build, so root/mirrors/snapshot/timestamp differ every time.
+    # `head-hackage-repo` below keeps the packages and replaces the metadata.
+    head-hackage-patched-repo = buildPkgs.runCommand "head-hackage-patched"
       {
         nativeBuildInputs = [
           # `deterministicTar` must come before gnutar on PATH.
@@ -220,7 +233,7 @@ in
           # -- this is the same one the overlay tool above is built with.
           buildPkgs.haskell.compiler.ghc967
         ];
-        passthru = { inherit patchedPackages srcHashesFile; };
+        passthru = { inherit patchedPackages srcHashesFile seedName; };
       } ''
       export HOME=$(mktemp -d)
 
@@ -257,5 +270,56 @@ in
 
       cp -r repo $out
     '';
+
+    # The repository as consumed.  Packages come from the tool; the TUF metadata
+    # is regenerated unsigned, so the whole output is reproducible.
+    #
+    # mk-local-hackage-repo exists for exactly this and says so: "We will create
+    # a completely unsigned bare repository.  Using signing keys within nix would
+    # be pointless as we'd have to hardcode them to produce the same output
+    # reproducibly."  Signing stays only as the bootstrap step the overlay tool
+    # insists on, and nothing downstream checks it -- the `repository` stanza
+    # reading this uses `root-keys:` with `key-threshold: 0`.
+    head-hackage-repo =
+      let
+        patched = final.haskell-nix.head-hackage-patched-repo;
+        # hackage-repo-tool writes the index tar itself, stamping each entry
+        # with the time of the build, so `01-index.tar.gz` differs run to run
+        # even though its contents do not.  Verified with `nix-build --check`:
+        # across two builds the extracted files and the entry order were
+        # identical and only the mtimes moved (14:09 vs 14:11).
+        #
+        # Re-tar with a fixed mtime, feeding the original listing back in so the
+        # order is preserved exactly.  Order matters in a Hackage index -- later
+        # entries supersede earlier ones, which is how `.cabal` revisions work --
+        # so this must not sort.
+        index = buildPkgs.runCommand "head-hackage-01-index.tar.gz"
+          { nativeBuildInputs = [ buildPkgs.gnutar buildPkgs.gzip ]; } ''
+          mkdir idx
+          tar -xzf ${patched}/01-index.tar.gz -C idx
+          tar -tzf ${patched}/01-index.tar.gz > order.txt
+          tar -cf index.tar --format=ustar --numeric-owner --owner=root \
+              --group=root --mtime=@${repoEpoch} --no-recursion -C idx -T order.txt
+          # -n: keep gzip's own timestamp and name fields out of the header.
+          gzip -n -9 -c index.tar > $out
+        '';
+
+        # A derivation without `outputHash`, so mk-local-hackage-repo's
+        # cross-check against one is skipped.
+        metadata = mkLocalHackageRepo {
+          name = "head.hackage.ghc.haskell.org";
+          inherit index;
+        };
+      in
+      buildPkgs.runCommand "head-hackage.ghc.haskell.org"
+        { passthru = { inherit (patched) patchedPackages srcHashesFile seedName; }; } ''
+        mkdir -p $out
+        cp -r ${patched}/package $out/package
+        # -L: mk-local-hackage-repo symlinks the index it was handed, and the
+        # result should stand on its own.
+        cp -L ${metadata}/01-index.tar.gz $out/01-index.tar.gz
+        cp ${metadata}/root.json ${metadata}/mirrors.json \
+           ${metadata}/snapshot.json ${metadata}/timestamp.json $out/
+      '';
   };
 }

--- a/overlays/head-hackage.nix
+++ b/overlays/head-hackage.nix
@@ -122,8 +122,15 @@ let
   # The original tarballs, fetched by hash from the index.  Laid out the way
   # `cabal fetch` would leave them, which is where the overlay tool looks:
   #   <repo-cache>/<repo-name>/<pkg>/<version>/<pkg>-<version>.tar.gz
+  #
+  # `sourceRepoName` is deliberately not "hackage.haskell.org": cabal has a
+  # built-in definition for that name, and with the repository called that its
+  # `update` went to the real hackage.haskell.org instead of the `file:` url the
+  # tool was given -- which only showed up once the build ran sandboxed.
+  sourceRepoName = "head-hackage-upstream";
+
   repoCache = buildPkgs.runCommand "head-hackage-repo-cache" { } (''
-    mkdir -p $out/hackage.haskell.org
+    mkdir -p $out/${sourceRepoName}
   '' + lib.concatStrings (lib.mapAttrsToList (pv: sha256:
     let
       m = builtins.match "(.*)-([0-9][0-9.]*)" pv;
@@ -135,8 +142,8 @@ let
         inherit sha256;
       };
     in ''
-      mkdir -p $out/hackage.haskell.org/${pname}/${pver}
-      ln -s ${tarball} $out/hackage.haskell.org/${pname}/${pver}/${pv}.tar.gz
+      mkdir -p $out/${sourceRepoName}/${pname}/${pver}
+      ln -s ${tarball} $out/${sourceRepoName}/${pname}/${pver}/${pv}.tar.gz
     '') srcHashes));
 
   # One fixed timestamp for everything we re-tar, taken from the head.hackage
@@ -152,7 +159,7 @@ let
   # unsigned copy of the pinned index rather than hackage.haskell.org.
   # mk-local-hackage-repo is what haskell.nix already uses for this.
   localHackage = mkLocalHackageRepo {
-    name = "hackage.haskell.org";
+    name = sourceRepoName;
     index = hackageIndex;
   };
 
@@ -237,6 +244,7 @@ in
       } ''
       export HOME=$(mktemp -d)
 
+
       # Signing keys.  These are generated per build rather than pinned: the
       # repository is consumed over `file:` from the store, so the signatures
       # are not a trust boundary, and the `repository` stanza that reads it
@@ -263,7 +271,7 @@ in
         --patches=./tmp/patches \
         --repo-cache=./cache \
         --keys=$HOME/keys \
-        --repo-name=hackage.haskell.org \
+        --repo-name=${sourceRepoName} \
         --repo-url=file:${localHackage} \
         --template=template \
         ./repo

--- a/overlays/head-hackage.nix
+++ b/overlays/head-hackage.nix
@@ -108,6 +108,17 @@ let
 
   srcHashes = import srcHashesFile;
 
+  # hackage-repo-tool will not bootstrap an empty repository, so one package has
+  # to be in place first.  Pick it here rather than with `ls | head -1` in the
+  # builder: that order depends on locale collation, so the choice -- and with it
+  # the bootstrapped metadata -- could differ between machines.
+  seedName = lib.head (lib.sort (a: b: a < b) (builtins.attrNames srcHashes));
+  seedPackage = buildPkgs.fetchurl {
+    name = "${seedName}.tar.gz";
+    url = "https://hackage.haskell.org/package/${seedName}/${seedName}.tar.gz";
+    sha256 = srcHashes.${seedName};
+  };
+
   # The original tarballs, fetched by hash from the index.  Laid out the way
   # `cabal fetch` would leave them, which is where the overlay tool looks:
   #   <repo-cache>/<repo-name>/<pkg>/<version>/<pkg>-<version>.tar.gz
@@ -223,8 +234,7 @@ in
       # hackage-repo-tool refuses to bootstrap an empty repository, so seed it
       # with one package, exactly as head.hackage's ci/build-repo.sh does.
       mkdir -p repo/package
-      seed=$(ls ${repoCache}/hackage.haskell.org/*/*/*.tar.gz | head -1)
-      cp "$seed" repo/package/
+      cp ${seedPackage} repo/package/${seedName}.tar.gz
       hackage-repo-tool bootstrap --keys=$HOME/keys --repo=./repo
 
       # Everything the tool needs is already local: the patches from the flake

--- a/overlays/patches/hackage-overlay-repo-tool/local-repo-no-signatures.patch
+++ b/overlays/patches/hackage-overlay-repo-tool/local-repo-no-signatures.patch
@@ -1,0 +1,30 @@
+Allow the source repository to be an unsigned local one.
+
+The tool writes a cabal config for its `cabal update` / `cabal fetch` of the
+original packages, and marks the repository `secure: True` without naming any
+root keys.  cabal then falls back to its built-in root keys for the repository
+name, so pointing `--repo-url` at a local `file:` mirror of the index fails
+with:
+
+    Expected at least 3 signatures from:
+      fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0
+      ...
+    Found signatures from:
+
+We serve the index from the nix store, already pinned and hash-checked by the
+`hackage.nix` index-state, so there is nothing for TUF to add here.  This is
+the same escape hatch haskell.nix uses in its own `bootstrapIndexTarball`
+(`overlays/haskell.nix`), including the placeholder root key -- `key-threshold:
+0` alone is not enough to stop cabal looking for signatures.
+
+--- a/src/Main.hs
++++ b/src/Main.hs
+@@ -89,6 +89,8 @@ fetchSources config pkgs = do
+       [ "repository " <> _remote_repo_name config
+       , "  url: " <> _remote_repo_url config
+       , "  secure: True"
++      , "  root-keys: aaa"
++      , "  key-threshold: 0"
+       , ""
+       , "http-transport: plain-http"
+       , "remote-repo-cache: " <> T.pack (_remote_repo_cache config)

--- a/test/backpack/default.nix
+++ b/test/backpack/default.nix
@@ -1,11 +1,12 @@
 # Test backpack
-{ stdenv, lib, haskellLib, cabalProject', testSrc, compiler-nix-name, evalPackages }:
+{ stdenv, lib, haskellLib, cabalProject', testSrc, compiler-nix-name, evalPackages, testCabalProjectLocal, testInputMap }:
 
 let
   project = cabalProject' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "backpack";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal
       + lib.optionalString (haskellLib.isCrossHost && stdenv.hostPlatform.isAarch64) ''
         constraints: text -simdutf, text source
     '';

--- a/test/cabal-22/default.nix
+++ b/test/cabal-22/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, mkCabalProjectPkgSet, cabalProject', haskellLib, util, testSrc, compiler-nix-name, evalPackages }:
+{ stdenv, lib, mkCabalProjectPkgSet, cabalProject', haskellLib, util, testSrc, compiler-nix-name, evalPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -6,7 +6,8 @@ let
   project = cabalProject' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "cabal-22";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local;
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal;
   };
 
   packages = project.hsPkgs;

--- a/test/cabal-simple-debug/default.nix
+++ b/test/cabal-simple-debug/default.nix
@@ -1,5 +1,5 @@
 # Test a package set
-{ stdenv, lib, util, cabalProject', haskellLib, testSrc, compiler-nix-name, evalPackages, buildPackages, dwarfdump }:
+{ stdenv, lib, util, cabalProject', haskellLib, testSrc, compiler-nix-name, evalPackages, buildPackages, dwarfdump, testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -17,7 +17,8 @@ let
     # GHC, dummy-ghc, ...) on the same DWARF variant; per-slice
     # overrides via `.dwarf` would diverge from plan-nix's UnitId.
     compilerSelection = p: lib.mapAttrs (_: c: c.dwarf) p.haskell-nix.compiler;
-    cabalProjectLocal = builtins.readFile ../cabal.project.local + ''
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal + ''
       package *
         debug-info: 2
     '';

--- a/test/cabal-simple-prof/default.nix
+++ b/test/cabal-simple-prof/default.nix
@@ -1,5 +1,5 @@
 # Test a package set
-{ stdenv, lib, util, cabalProject', haskellLib, testSrc, compiler-nix-name, evalPackages }:
+{ stdenv, lib, util, cabalProject', haskellLib, testSrc, compiler-nix-name, evalPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -18,7 +18,8 @@ let
   project = cabalProject' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "cabal-simple-prof";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal
       + lib.optionalString (haskellLib.isCrossHost && stdenv.hostPlatform.isAarch64) ''
         constraints: text -simdutf, text source
       ''

--- a/test/cabal-simple/default.nix
+++ b/test/cabal-simple/default.nix
@@ -1,5 +1,5 @@
 # Test a package set
-{ stdenv, lib, util, mkCabalProjectPkgSet, project', haskellLib, testSrc, compiler-nix-name, evalPackages, buildPackages }:
+{ stdenv, lib, util, mkCabalProjectPkgSet, project', haskellLib, testSrc, compiler-nix-name, evalPackages, buildPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -15,7 +15,8 @@ let
   project = project' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "cabal-simple";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal
       + lib.optionalString (haskellLib.isCrossHost && stdenv.hostPlatform.isAarch64) ''
         constraints: text -simdutf, text source
     '';
@@ -32,8 +33,8 @@ in lib.recurseIntoAttrs {
   # Used for testing externally with nix-shell (../tests.sh).
   test-shell = (project.shellFor {
       tools = {
-        cabal = { cabalProjectLocal = builtins.readFile ../cabal.project.local; };
-        hoogle = { cabalProjectLocal = builtins.readFile ../cabal.project.local; };
+        cabal = { cabalProjectLocal = testCabalProjectLocal; };
+        hoogle = { cabalProjectLocal = testCabalProjectLocal; };
       };
       withHoogle = !stdenv.hostPlatform.isStatic;
     }).overrideAttrs (_: _: {

--- a/test/cabal-simple/default.nix
+++ b/test/cabal-simple/default.nix
@@ -33,8 +33,8 @@ in lib.recurseIntoAttrs {
   # Used for testing externally with nix-shell (../tests.sh).
   test-shell = (project.shellFor {
       tools = {
-        cabal = { cabalProjectLocal = testCabalProjectLocal; };
-        hoogle = { cabalProjectLocal = testCabalProjectLocal; };
+        cabal = { inputMap = testInputMap; cabalProjectLocal = testCabalProjectLocal; };
+        hoogle = { inputMap = testInputMap; cabalProjectLocal = testCabalProjectLocal; };
       };
       withHoogle = !stdenv.hostPlatform.isStatic;
     }).overrideAttrs (_: _: {

--- a/test/cabal-source-repo-comments/default.nix
+++ b/test/cabal-source-repo-comments/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, cabalProject', haskellLib, testSrc, compiler-nix-name, evalPackages, buildPackages }:
+{ stdenv, lib, cabalProject', haskellLib, testSrc, compiler-nix-name, evalPackages, buildPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -6,7 +6,8 @@ let
   project = cabalProject' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "cabal-source-repo-comments";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal
       + lib.optionalString (haskellLib.isCrossHost && stdenv.hostPlatform.isAarch64) ''
         constraints: text -simdutf, text source
     '';

--- a/test/cabal-source-repo/default.nix
+++ b/test/cabal-source-repo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, cabalProject', haskellLib, testSrc, compiler-nix-name, evalPackages, buildPackages }:
+{ stdenv, lib, cabalProject', haskellLib, testSrc, compiler-nix-name, evalPackages, buildPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -6,7 +6,8 @@ let
   project = cabalProject' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "cabal-source-repo";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal
       + lib.optionalString (haskellLib.isCrossHost && stdenv.hostPlatform.isAarch64) ''
         constraints: text -simdutf, text source
     '';

--- a/test/cabal-sublib-shell/default.nix
+++ b/test/cabal-sublib-shell/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, pkgs, haskellLib, haskell-nix, buildPackages, runCommand
-, cabalProject', testSrc, compiler-nix-name, evalPackages }:
+, cabalProject', testSrc, compiler-nix-name, evalPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 

--- a/test/cabal-sublib/default.nix
+++ b/test/cabal-sublib/default.nix
@@ -1,5 +1,5 @@
 # Test a package set
-{ stdenv, lib, util, cabalProject', haskellLib, testSrc, compiler-nix-name, evalPackages, buildPackages }:
+{ stdenv, lib, util, cabalProject', haskellLib, testSrc, compiler-nix-name, evalPackages, buildPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -16,7 +16,8 @@ let
   project = cabalProject' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "cabal-sublib";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal
       + lib.optionalString (haskellLib.isCrossHost && stdenv.hostPlatform.isAarch64) ''
         constraints: text -simdutf, text source
     '';

--- a/test/cabal.project.local
+++ b/test/cabal.project.local
@@ -26,7 +26,6 @@ repository head.hackage.ghc.haskell.org
      f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
      26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
      7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-  --sha256: sha256-uroYmmrzEOlmjSAcMIsN4+whOlrM24RqyG0zI1bNHb4=
 
 repository ghcjs-overlay
   url: https://raw.githubusercontent.com/input-output-hk/hackage-overlay-ghcjs/ffb32dce467b9a4d27be759fdd2740a6edd09d0b

--- a/test/call-cabal-project-to-nix/default.nix
+++ b/test/call-cabal-project-to-nix/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildPackages, mkCabalProjectPkgSet, callCabalProjectToNix, loadCabalPlan, haskellLib, testSrc, compiler-nix-name, evalPackages }:
+{ stdenv, lib, buildPackages, mkCabalProjectPkgSet, callCabalProjectToNix, loadCabalPlan, haskellLib, testSrc, compiler-nix-name, evalPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -21,7 +21,8 @@ let
     inherit compiler-nix-name evalPackages;
     # reuse the cabal-simple test project
     src = testSrc "cabal-simple";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal
       + androidStaticLocal
       + lib.optionalString (haskellLib.isCrossHost && stdenv.hostPlatform.isAarch64) ''
         constraints: text -simdutf, text source

--- a/test/coverage/default.nix
+++ b/test/coverage/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, cabal-install, cabalProject', stackProject', runCommand, testSrc, compiler-nix-name, evalPackages, buildPackages }:
+{ stdenv, lib, cabal-install, cabalProject', stackProject', runCommand, testSrc, compiler-nix-name, evalPackages, buildPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -27,7 +27,8 @@ let
   # but for stack we would need a different resolver to be used..
   cabalProj = (cabalProject' (projectArgs // {
     inherit compiler-nix-name;
-    cabalProjectLocal = builtins.readFile ../cabal.project.local + coverageProjectLocal;
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal + coverageProjectLocal;
   }));
   stackProj = (stackProject' projectArgs);
 

--- a/test/default.nix
+++ b/test/default.nix
@@ -163,7 +163,7 @@ let
   # testSrc = subDir: testSrcRoot + "/${subDir}";
   testSrcRootWithGitDir = evalPackages.haskell-nix.haskellLib.cleanGit { src = ../.; subDir = "test"; includeSiblings = true; keepGitDir = true; };
   testSrcWithGitDir = subDir: haskell-nix.haskellLib.cleanSourceWith { src = testSrcRootWithGitDir; inherit subDir; includeSiblings = true; };
-  headHackage = import ./head-hackage.nix { inherit pkgs; };
+  headHackage = import ./head-hackage.nix { inherit evalPackages; };
   testCabalProjectLocal = headHackage.cabalProjectLocal;
   testInputMap = headHackage.inputMap;
 

--- a/test/default.nix
+++ b/test/default.nix
@@ -163,7 +163,13 @@ let
   # testSrc = subDir: testSrcRoot + "/${subDir}";
   testSrcRootWithGitDir = evalPackages.haskell-nix.haskellLib.cleanGit { src = ../.; subDir = "test"; includeSiblings = true; keepGitDir = true; };
   testSrcWithGitDir = subDir: haskell-nix.haskellLib.cleanSourceWith { src = testSrcRootWithGitDir; inherit subDir; includeSiblings = true; };
-  callTest = x: args: haskell-nix.callPackage x (args // { inherit testSrc compiler-nix-name evalPackages; });
+  headHackage = import ./head-hackage.nix { inherit pkgs; };
+  testCabalProjectLocal = headHackage.cabalProjectLocal;
+  testInputMap = headHackage.inputMap;
+
+  callTest = x: args: haskell-nix.callPackage x (args // {
+    inherit testSrc compiler-nix-name evalPackages testCabalProjectLocal testInputMap;
+  });
 
   # Run unit tests with: nix-instantiate --eval --strict -A unit.tests
   # An empty list means success.

--- a/test/default.nix
+++ b/test/default.nix
@@ -167,9 +167,20 @@ let
   testCabalProjectLocal = headHackage.cabalProjectLocal;
   testInputMap = headHackage.inputMap;
 
-  callTest = x: args: haskell-nix.callPackage x (args // {
-    inherit testSrc compiler-nix-name evalPackages testCabalProjectLocal testInputMap;
-  });
+  # `testCabalProjectLocal` / `testInputMap` are passed only to tests that ask
+  # for them.  callPackage's third argument is applied unconditionally, and a
+  # test with a closed argument set rejects anything it does not declare --
+  # "function 'anonymous lambda' called with unexpected argument
+  # 'testCabalProjectLocal'" -- which broke every test that does not use
+  # cabal.project.local.  The other three have always been passed to everything
+  # and every test declares them, so they stay unconditional.
+  callTest = x: args:
+    let
+      headHackageArgs = { inherit testCabalProjectLocal testInputMap; };
+    in
+    haskell-nix.callPackage x (args
+      // { inherit testSrc compiler-nix-name evalPackages; }
+      // builtins.intersectAttrs (builtins.functionArgs (import x)) headHackageArgs);
 
   # Run unit tests with: nix-instantiate --eval --strict -A unit.tests
   # An empty list means success.

--- a/test/default.nix
+++ b/test/default.nix
@@ -212,7 +212,7 @@ let
     stack-remote-resolver = callTest ./stack-remote-resolver {};
     stack-symlink-yaml = callTest ./stack-symlink-yaml {};
     shell-for-setup-deps = callTest ./shell-for-setup-deps {};
-    setup-deps = import ./setup-deps { inherit pkgs evalPackages compiler-nix-name; };
+    setup-deps = import ./setup-deps { inherit pkgs evalPackages compiler-nix-name testCabalProjectLocal testInputMap; };
     callStackToNix = callTest ./call-stack-to-nix {};
     callCabalProjectToNix = callTest ./call-cabal-project-to-nix { inherit evalPackages; };
     cabal-source-repo = callTest ./cabal-source-repo {};

--- a/test/exe-dlls/default.nix
+++ b/test/exe-dlls/default.nix
@@ -1,5 +1,5 @@
 # Test building TH code that needs DLLs when cross compiling for windows
-{ stdenv, lib, util, project', haskellLib, testSrc, compiler-nix-name, evalPackages, buildPackages }:
+{ stdenv, lib, util, project', haskellLib, testSrc, compiler-nix-name, evalPackages, buildPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -7,7 +7,8 @@ let
   project = project' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "exe-dlls";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal
       + lib.optionalString stdenv.hostPlatform.isAndroid
           (builtins.readFile ../cabal.project.android);
     modules = import ../modules.nix;
@@ -21,7 +22,8 @@ let
   projectProfiled = project' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "exe-dlls";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal
       + lib.optionalString stdenv.hostPlatform.isAndroid
           (builtins.readFile ../cabal.project.android)
       + ''

--- a/test/exe-lib-dlls/default.nix
+++ b/test/exe-lib-dlls/default.nix
@@ -1,5 +1,5 @@
 # Test building TH code that needs DLLs when cross compiling for windows
-{ stdenv, lib, util, project', haskellLib, testSrc, compiler-nix-name, evalPackages }:
+{ stdenv, lib, util, project', haskellLib, testSrc, compiler-nix-name, evalPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -7,7 +7,8 @@ let
   project = project' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "exe-lib-dlls";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal
       + lib.optionalString stdenv.hostPlatform.isAndroid
           (builtins.readFile ../cabal.project.android);
     modules = import ../modules.nix;
@@ -18,7 +19,8 @@ let
   projectProfiled = project' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "exe-lib-dlls";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal
       + lib.optionalString stdenv.hostPlatform.isAndroid
           (builtins.readFile ../cabal.project.android)
       + ''

--- a/test/exe-only/default.nix
+++ b/test/exe-only/default.nix
@@ -1,5 +1,5 @@
 # Test a package set
-{ stdenv, lib, util, haskell-nix, haskellLib, testSrc, compiler-nix-name, evalPackages, buildPackages }:
+{ stdenv, lib, util, haskell-nix, haskellLib, testSrc, compiler-nix-name, evalPackages, buildPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -7,7 +7,8 @@ let
   project = haskell-nix.cabalProject' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "exe-only";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal
       + lib.optionalString (haskellLib.isCrossHost && stdenv.hostPlatform.isAarch64) ''
         constraints: text -simdutf, text source
     '';

--- a/test/ghcjs-overlay/default.nix
+++ b/test/ghcjs-overlay/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, cabalProject', haskellLib, testSrc, compiler-nix-name, evalPackages, buildPackages }:
+{ stdenv, lib, cabalProject', haskellLib, testSrc, compiler-nix-name, evalPackages, buildPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -6,7 +6,8 @@ let
   project = cabalProject' {
     src = testSrc "ghcjs-overlay";
     inherit compiler-nix-name evalPackages;
-    cabalProjectLocal = builtins.readFile ../cabal.project.local;
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal;
   };
   packages = project.hsPkgs;
 

--- a/test/gi-gtk/default.nix
+++ b/test/gi-gtk/default.nix
@@ -1,5 +1,5 @@
 # Test building TH code that needs DLLs when cross compiling for windows
-{ stdenv, lib, util, project', haskellLib, testSrc, compiler-nix-name, evalPackages, buildPackages }:
+{ stdenv, lib, util, project', haskellLib, testSrc, compiler-nix-name, evalPackages, buildPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -7,7 +7,8 @@ let
   project = project' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "gi-gtk";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local + ''
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal + ''
       -- The overloading feature of haskell-gi makes build times very long
       constraints: haskell-gi-overloading ==0.0
     '';
@@ -18,7 +19,8 @@ let
   projectProfiled = project' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "gi-gtk";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local + ''
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal + ''
       constraints: haskell-gi-overloading ==0.0
       package *
         library-profiling: True

--- a/test/githash/default.nix
+++ b/test/githash/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, haskell-nix, haskellLib, testSrc, compiler-nix-name, evalPackages, runCommand, gitReallyMinimal, buildPackages }:
+{ stdenv, lib, haskell-nix, haskellLib, testSrc, compiler-nix-name, evalPackages, runCommand, gitReallyMinimal, buildPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -54,7 +54,8 @@ let
     # with `outPath` + `filterPath` tells haskell.nix the source is
     # already filtered and to skip its own cleaner.
     src = { outPath = packageRoot; filterPath = { path, ... }: path; };
-    cabalProjectLocal = builtins.readFile ../cabal.project.local;
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal;
     modules = [{
       packages.githash-test.components.exes.githash-test.build-tools = mkForce [ git ];
     }];

--- a/test/head-hackage.nix
+++ b/test/head-hackage.nix
@@ -20,16 +20,21 @@
   cabalProjectLocal =
     let
       raw = builtins.readFile ./cabal.project.local;
-      stripped = builtins.replaceStrings [''
-        key-threshold: 3
-          root-keys:
-             f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-             7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-      ''] [''
-        root-keys:
-          key-threshold: 0
-      ''] raw;
+      # Written with explicit newlines rather than `''`-strings: there, the
+      # replacement's indentation is relative to the source, so `key-threshold`
+      # reads as though it were nested under `root-keys:` when it is not.  It is
+      # a sibling, both at two spaces -- the same shape as the ghcjs-overlay
+      # stanza already in cabal.project.local.
+      published =
+        "key-threshold: 3\n"
+        + "  root-keys:\n"
+        + "     f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89\n"
+        + "     26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329\n"
+        + "     7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d\n";
+      servedLocally =
+        "root-keys:\n"
+        + "  key-threshold: 0\n";
+      stripped = builtins.replaceStrings [ published ] [ servedLocally ] raw;
     in
       assert stripped != raw; stripped;
 

--- a/test/head-hackage.nix
+++ b/test/head-hackage.nix
@@ -1,0 +1,41 @@
+# How haskell.nix's own tests consume head.hackage.
+#
+# `test/cabal.project.local` keeps head.hackage's real root keys, so that a
+# plain `cabal` build driven by that file still verifies the published
+# repository.  haskell.nix does not use the published one: it builds the
+# repository itself (see overlays/head-hackage.nix), because the published one
+# is regenerated on a schedule and is not reproducible, so a `--sha256` pin
+# against it went stale roughly daily.
+#
+# That locally built copy is signed with keys generated at build time, so the
+# published root keys cannot apply to it.  They are dropped here rather than
+# weakened in the checked-in file, which stays correct for everyone who is not
+# going through haskell.nix.
+{ pkgs }:
+{
+  # The `assert` is the point of writing it this way.  If the stanza in
+  # cabal.project.local is reformatted this stops matching, and we want that to
+  # fail here rather than silently leave the real keys in place -- which would
+  # fail much later inside cabal, as an opaque signature error.
+  cabalProjectLocal =
+    let
+      raw = builtins.readFile ./cabal.project.local;
+      stripped = builtins.replaceStrings [''
+        key-threshold: 3
+          root-keys:
+             f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+             7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+      ''] [''
+        root-keys:
+          key-threshold: 0
+      ''] raw;
+    in
+      assert stripped != raw; stripped;
+
+  # Scoped to our own tests deliberately: a haskell.nix user whose project names
+  # this url should still get the published repository, not ours.
+  inputMap = {
+    "https://ghc.gitlab.haskell.org/head.hackage/" = pkgs.haskell-nix.head-hackage-repo;
+  };
+}

--- a/test/head-hackage.nix
+++ b/test/head-hackage.nix
@@ -11,7 +11,7 @@
 # published root keys cannot apply to it.  They are dropped here rather than
 # weakened in the checked-in file, which stays correct for everyone who is not
 # going through haskell.nix.
-{ pkgs }:
+{ evalPackages }:
 {
   # The `assert` is the point of writing it this way.  If the stanza in
   # cabal.project.local is reformatted this stops matching, and we want that to
@@ -40,7 +40,14 @@
 
   # Scoped to our own tests deliberately: a haskell.nix user whose project names
   # this url should still get the published repository, not ours.
+  #
+  # Taken from `evalPackages`, not `pkgs`: this is an eval-time derivation, like
+  # plan-to-nix, and belongs on the eval system.  Reached through `pkgs` it came
+  # out built for the target's build platform, so evaluating the x86_64-linux
+  # jobs produced an x86_64-linux derivation and CI tried to build it on the
+  # linux VMs instead of the darwin builders that do eval-time work.
   inputMap = {
-    "https://ghc.gitlab.haskell.org/head.hackage/" = pkgs.haskell-nix.head-hackage-repo;
+    "https://ghc.gitlab.haskell.org/head.hackage/" =
+      evalPackages.haskell-nix.head-hackage-repo;
   };
 }

--- a/test/js-template-haskell/default.nix
+++ b/test/js-template-haskell/default.nix
@@ -1,5 +1,5 @@
 # Test building TH code that needs DLLs when cross compiling for windows
-{ stdenv, lib, project', haskellLib, testSrc, compiler-nix-name, evalPackages }:
+{ stdenv, lib, project', haskellLib, testSrc, compiler-nix-name, evalPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -7,7 +7,8 @@ let
   project = profiled: project' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "js-template-haskell";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal
       + ''
       if arch(javascript)
         extra-packages: ghci

--- a/test/plugin/default.nix
+++ b/test/plugin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, haskellLib, project', testSrc, compiler-nix-name, evalPackages, buildPackages }:
+{ stdenv, lib, haskellLib, project', testSrc, compiler-nix-name, evalPackages, buildPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -6,7 +6,8 @@ let
   project = project' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "plugin";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local + ''
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal + ''
       allow-newer: polysemy-plugin:containers, polysemy:containers
     '';
   };

--- a/test/setup-deps/default.nix
+++ b/test/setup-deps/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, compiler-nix-name, evalPackages }:
+{ pkgs, compiler-nix-name, evalPackages, testCabalProjectLocal, testInputMap }:
 
 with pkgs;
 with lib;
@@ -7,7 +7,8 @@ let
   project = haskell-nix.cabalProject' {
     inherit compiler-nix-name evalPackages;
     src = evalPackages.haskell-nix.haskellLib.cleanGit { src = ../..; name = "setup-deps"; subDir = "test/setup-deps"; };
-    cabalProjectLocal = builtins.readFile ../cabal.project.local;
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal;
   };
 
   meta = {

--- a/test/shell-for-setup-deps/default.nix
+++ b/test/shell-for-setup-deps/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, cabal-install, cabalProject', runCommand, testSrc, compiler-nix-name, evalPackages }:
+{ stdenv, lib, cabal-install, cabalProject', runCommand, testSrc, compiler-nix-name, evalPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -6,12 +6,13 @@ let
   project = cabalProject' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "shell-for-setup-deps";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local;
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal;
   };
 
   env = project.shellFor {
     exposePackagesVia = "ghc-pkg";
-    tools.hoogle = { cabalProjectLocal = builtins.readFile ../cabal.project.local; };
+    tools.hoogle = { cabalProjectLocal = testCabalProjectLocal; };
     withHoogle = true;
   };
 

--- a/test/shell-for-setup-deps/default.nix
+++ b/test/shell-for-setup-deps/default.nix
@@ -12,7 +12,7 @@ let
 
   env = project.shellFor {
     exposePackagesVia = "ghc-pkg";
-    tools.hoogle = { cabalProjectLocal = testCabalProjectLocal; };
+    tools.hoogle = { inputMap = testInputMap; cabalProjectLocal = testCabalProjectLocal; };
     withHoogle = true;
   };
 

--- a/test/shell-for/default.nix
+++ b/test/shell-for/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, haskellLib, testSrc, compiler-nix-name, evalPackages, project' }:
+{ stdenv, lib, haskellLib, testSrc, compiler-nix-name, evalPackages, project', testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -6,7 +6,8 @@ let
   project = project' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "shell-for";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local;
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal;
     modules = [{ inherit evalPackages; }];
   };
 
@@ -16,8 +17,10 @@ let
     exposePackagesVia = "ghc-pkg";
     packages = ps: with ps; [ pkga pkgb ];
     tools = {
-      cabal.cabalProjectLocal = builtins.readFile ../cabal.project.local;
-      hoogle.cabalProjectLocal = builtins.readFile ../cabal.project.local;
+      cabal.inputMap = testInputMap;
+      cabal.cabalProjectLocal = testCabalProjectLocal;
+      hoogle.inputMap = testInputMap;
+      hoogle.cabalProjectLocal = testCabalProjectLocal;
     };
     exactDeps = true;
     packageSetupDeps = false;
@@ -30,8 +33,10 @@ let
     # This adds cabal-install to the shell, which helps tests because
     # they use a nix-shell --pure. Normally you would BYO cabal-install.
     tools = {
-      cabal.cabalProjectLocal = builtins.readFile ../cabal.project.local;
-      hoogle.cabalProjectLocal = builtins.readFile ../cabal.project.local;
+      cabal.inputMap = testInputMap;
+      cabal.cabalProjectLocal = testCabalProjectLocal;
+      hoogle.inputMap = testInputMap;
+      hoogle.cabalProjectLocal = testCabalProjectLocal;
     };
     exactDeps = true;
     # Avoid duplicate package issues when runghc looks for packages
@@ -46,8 +51,10 @@ let
     # This adds cabal-install to the shell, which helps tests because
     # they use a nix-shell --pure. Normally you would BYO cabal-install.
     tools = {
-      cabal.cabalProjectLocal = builtins.readFile ../cabal.project.local;
-      hoogle.cabalProjectLocal = builtins.readFile ../cabal.project.local;
+      cabal.inputMap = testInputMap;
+      cabal.cabalProjectLocal = testCabalProjectLocal;
+      hoogle.inputMap = testInputMap;
+      hoogle.cabalProjectLocal = testCabalProjectLocal;
     };
     # Avoid duplicate package issues when runghc looks for packages
     packageSetupDeps = false;

--- a/test/sublib-docs/default.nix
+++ b/test/sublib-docs/default.nix
@@ -1,5 +1,5 @@
 # Test a package set
-{ stdenv, lib, util, cabalProject', haskellLib, testSrc, compiler-nix-name, evalPackages }:
+{ stdenv, lib, util, cabalProject', haskellLib, testSrc, compiler-nix-name, evalPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -7,7 +7,8 @@ let
   project = cabalProject' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "sublib-docs";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local + ''
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal + ''
 
       package *
         documentation: True

--- a/test/th-dlls-minimal/default.nix
+++ b/test/th-dlls-minimal/default.nix
@@ -1,5 +1,5 @@
 # Test building TH code that needs DLLs when cross compiling for windows
-{ stdenv, lib, util, project', haskellLib, testSrc, compiler-nix-name, evalPackages, buildPackages }:
+{ stdenv, lib, util, project', haskellLib, testSrc, compiler-nix-name, evalPackages, buildPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 
@@ -20,7 +20,8 @@ let
     # for `test-lib` includes them, and the v2 slice's
     # cabal-computed uid stays in sync.  Mingw ships import libs
     # (`.dll.a`) under `bin/` rather than `lib/`, so list both.
-    cabalProjectLocal = builtins.readFile ../cabal.project.local
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal
       + lib.optionalString profiled ''
         package *
           library-profiling: True

--- a/test/with-packages/default.nix
+++ b/test/with-packages/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, haskellLib, util, cabalProject', testSrc, compiler-nix-name, evalPackages, buildPackages }:
+{ stdenv, lib, haskellLib, util, cabalProject', testSrc, compiler-nix-name, evalPackages, buildPackages, testCabalProjectLocal, testInputMap }:
 
 with lib;
 with util;
@@ -7,7 +7,8 @@ let
   project = doExactConfig: cabalProject' {
     inherit compiler-nix-name evalPackages;
     src = testSrc "with-packages";
-    cabalProjectLocal = builtins.readFile ../cabal.project.local;
+    inputMap = testInputMap;
+    cabalProjectLocal = testCabalProjectLocal;
     modules = [
       # overrides to fix the build
       {


### PR DESCRIPTION
The `--sha256` pin on the head.hackage `repository` stanza goes stale roughly **daily** — six bumps in the last few days — and each bump invalidates every `plan-to-nix` output in the tree, so it costs a full Hydra re-evaluation on top of the red checks.

## It isn't upstream publishing patches

head.hackage's git repo hasn't changed since June. The *published* repository is regenerated on a schedule and isn't reproducible. Diffing two consecutive publications:

```
cabal files differing:  0
json  files differing: 79      (all 79 packages: sha256 + length only)
```

158 index entries = 79 packages × (`.cabal` + `package.json`), so **every** package changed and not one `.cabal` did. What changed is each package's tarball hash.

The cause is in `hackage-overlay-repo-tool`, which re-tars every patched package:

```
tar -cz --format=ustar --numeric-owner --owner=root --group=root
    --clamp-mtime --mtime=<patch file> -f <pkg>.tar.gz <pkg>/
```

Everything is pinned for determinism except that `--mtime` doesn't take effect — the tarballs carry the time of the run. Two runs minutes apart on identical inputs:

```
arith-encode-1.0.2/   2026-08-03 10:29
arith-encode-1.0.2/   2026-08-03 10:31
```

## What this does

Builds the repository here, from head.hackage's own patches with its own tooling. Its only inputs are the `head-hackage` flake input (which moves when a patch changes) and the Hackage index haskell.nix already pins through hackage.nix. Nothing left to hand-maintain, and moving the hackage.nix pin picks up newly patched versions for free.

It's wired in through `inputMap` — the mechanism foliage repositories such as CHaP already use — so a `repository` stanza naming the head.hackage url is served from the store rather than fetched. `inputMap` is only consulted for repositories a project actually declares, and `types.attrs` doesn't descend into values, so projects that never mention head.hackage never build it.

## Pieces worth review

**The overlay tool** is built with haskell.nix on a nixpkgs GHC via `compilerSelection = p: p.haskell.compiler`, exactly as `overlays/bootstrap.nix` already does for alex and happy. It ships no `cabal.project` and its bounds predate current Hackage (`base < 4.17`, `text ^>= 1.2`), hence `cabalProject = "packages: ."` and `allow-newer: tool:*`.

**Original tarballs come from the pinned index.** Every entry in a secure Hackage index carries a `package.json` with the tarball's sha256, so the 79 originals are fetched with no hash of our own:

```
index says: 4042ceb22c0a0a76d35215da82ee61105175cdecf669ccf0d6eb0c66aa93d959
actual:     4042ceb22c0a0a76d35215da82ee61105175cdecf669ccf0d6eb0c66aa93d959
```

**The build is offline.** The tool's `cabal update` points at a local unsigned mirror of the pinned index (`mk-local-hackage-repo`, already used by haskell.nix) and its `cabal fetch` at a pre-populated cache in the layout it expects.

**One patch to the tool** was needed for that: it marks the repository `secure: True` with no root keys, so cabal applies its built-in keys for `hackage.haskell.org` and rejects the local mirror with *"Expected at least 3 signatures from…"*. The patch adds `root-keys: aaa` / `key-threshold: 0`, the same escape hatch `bootstrapIndexTarball` uses (and yes, `key-threshold: 0` alone isn't enough).

**A `tar` wrapper forces a fixed mtime.** This is what makes the output reproducible — without it this derivation would churn exactly as the published one does. GNU tar honours the last `--mtime`, so it overrides the tool's without touching its source. Two independent runs, fresh keys and fresh cache:

```
run6=142b6650cd0afa973cf81293
run7=142b6650cd0afa973cf81293
=> REPRODUCIBLE
```

**Signing keys are generated per build.** The repository is read over `file:` from the store, so signatures aren't a trust boundary; the stanza uses `root-keys:` with `key-threshold: 0`, the same arrangement as the existing `ghcjs-overlay` entry. Note this does mean the metadata (not the packages) differs between builds.

## Verification

79 patched packages built, and `cabal v2-update` against the result over `file:` — exactly what `inputMap` does — succeeds and lists all 79.

```
Package list of head.hackage.ghc.haskell.org has been updated.
  packages in the index: 79
```

## Notes

- `head-hackage` is locked via `gitlab:` rather than `git+https:`. The git fetcher's narHash didn't reproduce, which I think is down to `.gitattributes` (`patches/* -text`); the archive is byte-exact.
- Our tarball hashes won't match the published repository's. That's inherent — theirs embed a timestamp — and harmless, since the repository is internally consistent.
- Worth reporting the `--mtime` bug upstream: fixing it would stop the churn for every head.hackage consumer, not just us.
- Not addressed here: the overlay tool's plan isn't materialized, so it's an eval-time IFD like the rest of haskell.nix. Materializing it (as alex and happy are) would be a reasonable follow-up.
