### PR TITLE
nix-tools: take the stable-haskell changes from PR 2528

### DIFF
--- a/nix-tools/cabal-install-patches.nix
+++ b/nix-tools/cabal-install-patches.nix
@@ -18,8 +18,16 @@
 # it, plan-nix unit-ids fork from slice-build unit-ids whenever the
 # eval system differs from the build system (e.g. evaluating on
 # Darwin while building x86_64-linux derivations).
+#
+# The `Cabal-syntax-json` patch ports that package (source of the
+# `cabal2json` exe, pulled via source-repository-package) to the
+# stable-haskell cabal fork's Cabal-syntax 3.17 API, which dropped
+# the constraint type parameter from CondTree/CondBranch.
 {
   packages.cabal-install.patches = [
     ./cabal-install-patches/installed-package-id-os-override.patch
+  ];
+  packages.Cabal-syntax-json.patches = [
+    ./cabal-install-patches/cabal-syntax-json-condtree-3.17.patch
   ];
 }

--- a/nix-tools/cabal-install-patches/cabal-syntax-json-condtree-3.17.patch
+++ b/nix-tools/cabal-install-patches/cabal-syntax-json-condtree-3.17.patch
@@ -1,0 +1,159 @@
+Port Cabal-syntax-json to the Cabal-syntax 3.17 API (stable-haskell fork).
+
+3.17 dropped the constraint type parameter from CondTree/CondBranch
+(CondTree v c a -> CondTree v a; CondNode lost its middle field), turned the
+*Sources build-info fields into [ExtraSource Pkg], and split Verbosity
+(silent/normal are now VerbosityFlags).  Update all upstream CondTree uses,
+add ToJSON for ExtraSource, and wrap the verbosity for readGenericPackageDescription.
+
+--- a/src/Cabal/Syntax/Json.hs
++++ b/src/Cabal/Syntax/Json.hs
+@@ -35,6 +35,11 @@
+ import Distribution.Types.BuildType (BuildType)
+ import Distribution.Types.CondTree (CondBranch (..), CondTree (..))
+ import Distribution.Types.Condition (Condition (..))
++-- Cabal-syntax 3.17: the *Sources build-info fields became [ExtraSource Pkg]
++-- (was [SymbolicPath ...]).  Serialize as the underlying path string so the
++-- JSON matches the old SymbolicPath output.
++import Distribution.Types.ExtraSource (ExtraSource, ExtraSourceClass (extraSourceFile))
++import Distribution.Utils.Path (Build, Pkg)
+ import Distribution.Types.ConfVar (ConfVar (..))
+ import Distribution.Types.Dependency (Dependency (..))
+ import Distribution.Types.ExeDependency (ExeDependency (..))
+@@ -211,13 +216,22 @@
+     toJSON (COr l r) = JsonObject ["or" .= JsonArray [toJSON l, toJSON r]]
+     toJSON (CAnd l r) = JsonObject ["and" .= JsonArray [toJSON l, toJSON r]]
+ 
+-instance (ToJSON v, ToJSON c, ToJSON a) => ToJSON (CondTree v c a) where
+-    toJSON (CondNode a _ []) =
++instance ToJSON (ExtraSource Pkg) where
++    toJSON = JsonString . prettyShow . extraSourceFile
++
++instance ToJSON (ExtraSource Build) where
++    toJSON = JsonString . prettyShow . extraSourceFile
++
++-- Cabal-syntax 3.17 dropped the constraint type parameter from CondTree /
++-- CondBranch (CondTree v c a -> CondTree v a) and CondNode lost its middle
++-- (constraints) field.
++instance (ToJSON v, ToJSON a) => ToJSON (CondTree v a) where
++    toJSON (CondNode a []) =
+         toJSON a
+-    toJSON (CondNode a _ bs) =
++    toJSON (CondNode a bs) =
+         JsonArray $ toJSON a : map toJSON bs
+ 
+-instance (ToJSON v, ToJSON c, ToJSON a) => ToJSON (CondBranch v c a) where
++instance (ToJSON v, ToJSON a) => ToJSON (CondBranch v a) where
+     toJSON (CondBranch a t Nothing) =
+         JsonObject
+             [ ("_if", toJSON a)
+--- a/src/Cabal/Syntax/Pretty.hs
++++ b/src/Cabal/Syntax/Pretty.hs
+@@ -24,10 +24,10 @@
+ class PrettyFieldClass a where
+     prettyField :: a -> [PrettyField ()]
+ 
+-instance PrettyFieldClass a => PrettyFieldClass (CondTree ConfVar c a) where
+-    prettyField (CondNode a _ bs) = prettyField a <> concatMap prettyField bs
++instance PrettyFieldClass a => PrettyFieldClass (CondTree ConfVar a) where
++    prettyField (CondNode a bs) = prettyField a <> concatMap prettyField bs
+ 
+-instance PrettyFieldClass a => PrettyFieldClass (CondBranch ConfVar c a) where
++instance PrettyFieldClass a => PrettyFieldClass (CondBranch ConfVar a) where
+     prettyField (CondBranch c thenTree Nothing) =
+         [ prettySection "if" [ppCondition c] (prettyField thenTree)
+         ]
+--- a/src/Cabal/Syntax/Simplify.hs
++++ b/src/Cabal/Syntax/Simplify.hs
+@@ -34,13 +34,13 @@
+ 
+ -- | Simplifies a CondTree using a partial flag assignment. Conditions that cannot be evaluated are left untouched.
+ simplifyCondTree
+-    :: forall v c a
+-     . (Monoid a, Monoid c)
++    :: forall v a
++     . (Monoid a)
+     => (v -> Either v Bool)
+-    -> CondTree v c a
+-    -> CondTree v c a
+-simplifyCondTree eval (CondNode a c ifs) =
+-    CondNode a c branches <> mconcat trees
++    -> CondTree v a
++    -> CondTree v a
++simplifyCondTree eval (CondNode a ifs) =
++    CondNode a branches <> mconcat trees
+   where
+     (trees, branches) = partitionEithers $ map (simplifyCondBranch eval) ifs
+ 
+@@ -49,10 +49,10 @@
+ -- transforming the CondBranch into a CondTree. Therefore this function returns either a CondTree or
+ -- a CondBranch.
+ simplifyCondBranch
+-    :: (Monoid a, Monoid c)
++    :: (Monoid a)
+     => (v -> Either v Bool)
+-    -> CondBranch v c a
+-    -> Either (CondTree v c a) (CondBranch v c a)
++    -> CondBranch v a
++    -> Either (CondTree v a) (CondBranch v a)
+ simplifyCondBranch eval (CondBranch cv t me) =
+     case fst (simplifyCondition cv eval) of
+         Lit True -> Left $ simplifyCondTree eval t
+--- a/src/Cabal/Syntax/GenericPackageDescription.hs
++++ b/src/Cabal/Syntax/GenericPackageDescription.hs
+@@ -53,7 +53,7 @@
+ import Cabal.Syntax.Pretty (PrettyFieldClass (..), prettySection)
+ import Cabal.Syntax.Utils (FoldableWithIndex (..), Semialign (..))
+ 
+-type CondTree' a = CondTree ConfVar [Dependency] a
++type CondTree' a = CondTree ConfVar a
+ 
+ data GPD a b = GPD (FieldMap a) (ComponentMap b)
+     deriving (Show, Eq)
+@@ -108,7 +108,7 @@
+     -> GenericPackageDescription
+     -> GPD
+         (Fragment Json)
+-        (CondTree ConfVar [Dependency] (FieldMap (Fragment Json)))
++        (CondTree ConfVar (FieldMap (Fragment Json)))
+ runGenericPackageDescription v gpd =
+     GPD (FieldMap meta) (ComponentMap components)
+   where
+--- a/src/Cabal/Syntax/CondTree.hs
++++ b/src/Cabal/Syntax/CondTree.hs
+@@ -139,11 +139,11 @@
+                 Just ts' -> [CondIfThen c' (CondTree ts')]
+ 
+ -- | Convert 'Distribution.Types.CondTree.CondTree' from Cabal-syntax into our 'CondTree'.
+-convertCondTree :: C.CondTree v c a -> CondTree v a
+-convertCondTree (C.CondNode a _ ifs) =
++convertCondTree :: C.CondTree v a -> CondTree v a
++convertCondTree (C.CondNode a ifs) =
+     CondTree (CondNode a :| map convertCondBranch ifs)
+ 
+-convertCondBranch :: C.CondBranch v c a -> CondNode v a
++convertCondBranch :: C.CondBranch v a -> CondNode v a
+ convertCondBranch (C.CondBranch c thenTree Nothing) =
+     CondIfThen
+         c
+--- a/app/Main.hs
++++ b/app/Main.hs
+@@ -184,7 +184,8 @@
+         Just (OtherOS os) -> putWarn $ "Specialising to unknown operating system: " ++ os ++ "."
+         _ -> pure ()
+ 
+-    gpd <- readGenericPackageDescription Verbosity.silent Nothing (makeSymbolicPath fn)
++    -- Cabal-syntax 3.17: `silent` is a VerbosityFlags; readGenericPackageDescription wants a Verbosity.
++    gpd <- readGenericPackageDescription (Verbosity.mkVerbosity Verbosity.defaultVerbosityHandles Verbosity.silent) Nothing (makeSymbolicPath fn)
+ 
+     let env = Env optsOs optsArch optsCompiler optsFlags
+         GPD top components0 =
+@@ -214,7 +215,7 @@
+     renderJson . toJSON
+ 
+ process
+-    :: ComponentMap (C.CondTree ConfVar c (FieldMap (Fragment Json)))
++    :: ComponentMap (C.CondTree ConfVar (FieldMap (Fragment Json)))
+     -> ComponentMap (FieldMap (Fragment Json))
+ process components0 = components4
+   where

--- a/nix-tools/cabal-install-patches/installed-package-id-os-override.patch
+++ b/nix-tools/cabal-install-patches/installed-package-id-os-override.patch
@@ -22,27 +22,24 @@ which system happens to evaluate the plan-nix derivation.
 
 --- a/src/Distribution/Client/PackageHash.hs
 +++ b/src/Distribution/Client/PackageHash.hs
-@@ -65,6 +65,8 @@ import Distribution.Types.PkgconfigVersion (PkgconfigVersion)
+@@ -65,6 +65,8 @@
  import qualified Data.ByteString.Lazy.Char8 as LBS
  import qualified Data.Map as Map
  import qualified Data.Set as Set
 +import System.Environment (lookupEnv)
 +import System.IO.Unsafe (unsafePerformIO)
-
+ 
  -------------------------------
  -- Calculating package hashes
-@@ -77,10 +79,23 @@ import qualified Data.Set as Set
- -- a different method on Windows that produces shorted package ids.
+@@ -78,9 +80,22 @@
  -- See 'hashedInstalledPackageIdLong' vs 'hashedInstalledPackageIdShort'.
  hashedInstalledPackageId :: PackageHashInputs -> InstalledPackageId
--hashedInstalledPackageId
+ hashedInstalledPackageId
 -  | buildOS == Windows = hashedInstalledPackageIdShort
--  | buildOS == OSX = hashedInstalledPackageIdVeryShort
--  | otherwise = hashedInstalledPackageIdLong
-+hashedInstalledPackageId inputs
-+  | os == Windows = hashedInstalledPackageIdShort inputs
-+  | os == OSX     = hashedInstalledPackageIdVeryShort inputs
-+  | otherwise     = hashedInstalledPackageIdLong inputs
+-  | buildOS == OSX = hashedInstalledPackageIdLong
++  | os == Windows = hashedInstalledPackageIdShort
++  | os == OSX = hashedInstalledPackageIdLong
+   | otherwise = hashedInstalledPackageIdLong
 +  where
 +    os = effectiveInstalledPackageIdOS
 +
@@ -56,6 +53,6 @@ which system happens to evaluate the plan-nix derivation.
 +effectiveInstalledPackageIdOS = unsafePerformIO $ do
 +  m <- lookupEnv "CABAL_INSTALLED_PACKAGE_ID_OS"
 +  pure $ fromMaybe buildOS (m >>= simpleParsec)
-
+ 
  -- | Calculate a 'InstalledPackageId' for a package using our nix-style
  -- inputs hashing method.

--- a/nix-tools/cabal.project
+++ b/nix-tools/cabal.project
@@ -16,6 +16,13 @@ extra-packages: cabal-install, hpack, Cabal-syntax-json
 test-show-details: direct
 
 allow-newer:
+    -- nix-tools (and its deps) bound Cabal/Cabal-syntax to ^>=3.16;
+    -- the stable-haskell fork below is 3.17.  Relax the upper bound on
+    -- these deps project-wide so make-install-plan links the fork.
+    Cabal,
+    Cabal-syntax,
+    cabal-install,
+    cabal-install-solver,
     algebraic-graphs:deepseq,
     hackage-db:base,
     hackage-db:Cabal,
@@ -44,3 +51,33 @@ source-repository-package
     location: https://github.com/andreabedini/Cabal-syntax-json.git
     tag: b0033ed4d00a09340c64f4290cc649f4009deabd
     --sha256: sha256-Aymi25AQLSMextVeXbsMnaOppxAO93qVbwo7Vt44ej4=
+
+-- Build make-install-plan against the stable-haskell cabal fork
+-- (branch hkm/installed-sublibs — stable-haskell/master plus the
+-- installed-sublib solver support, plan-node dedupe, unit receipts,
+-- and Host-stage scoping of executable-static; the SAME rev the v2
+-- builder's cabal-install is pinned to in builder/default.nix, so
+-- plan-time and slice-time elaboration can never skew).  This is the
+-- cabal that ships the cross-compilation "stage" system
+-- (haskell/cabal#11179: ProjectConfigToolchain /
+-- --with-build-compiler / build:/host: stage-qualified constraints),
+-- which lets the solver break the Win32 -> hsc2hs -> process -> Win32
+-- build-tool cycle by resolving build-tool-depends in the build scope
+-- instead of relying on a full Hackage "older universe".
+source-repository-package
+    type: git
+    location: https://github.com/stable-haskell/Cabal.git
+    tag: 74047a6c520fb8e05882416ce9cfe9c8391b23c6
+    --sha256: sha256-19WHVPEDSagAl3HuiO8vxc48FYCeXf5mdVlhLhRi4rY=
+    subdir: Cabal
+            Cabal-syntax
+            cabal-install
+            cabal-install-solver
+            hooks-exe
+
+source-repository-package
+    type: git
+    location: https://github.com/stable-haskell/hackage-security.git
+    tag: baaad2e189a8203966f7d3f752a348f02eefd1b2
+    --sha256: sha256-mVWZCWGJKsSjQSqb5iw0Q8fmV+4aFZVL4zOmMaNnEhA=
+    subdir: hackage-security

--- a/nix-tools/flake.nix
+++ b/nix-tools/flake.nix
@@ -7,6 +7,12 @@
   
   outputs = inputs@{ self, nixpkgs, haskellNix, ... }:
     let
+      # NB: x86_64-darwin is kept here even though nixpkgs unstable (26.11)
+      # dropped it: this subflake resolves pkgs via its OWN pinned haskellNix
+      # (see flake.lock), whose unstable nixpkgs predates the drop and still
+      # supports x86_64-darwin.  `legacyPackages` here is consumed per-system by
+      # the main overlay (overlays/default.nix) for the from-source nix-tools,
+      # so x86_64-darwin must remain present.
       systems = [
         "x86_64-linux"
         "x86_64-darwin"

--- a/nix-tools/nix-tools/lib-cabal2nix/Cabal2Nix.hs
+++ b/nix-tools/nix-tools/lib-cabal2nix/Cabal2Nix.hs
@@ -6,8 +6,13 @@
 module Cabal2Nix (cabal2nix, gpd2nix, Src(..), CabalFile(..), CabalFileGenerator(..), cabalFilePath, cabalFilePkgName, CabalDetailLevel(..)) where
 
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
+-- Cabal-syntax 3.17: parse errors are `NonEmpty (PErrorWithSource src)` with a
+-- polymorphic src; showPErrorWithSource pins src to String and renders them.
+import Distribution.Parsec.Error (showPErrorWithSource)
 import Distribution.Simple.PackageDescription (readGenericPackageDescription)
-import Distribution.Verbosity (normal)
+-- Cabal-syntax 3.17 (stable-haskell fork) split verbosity: `normal` is now a
+-- VerbosityFlags, and readGenericPackageDescription wants a rich Verbosity.
+import Distribution.Verbosity (normal, mkVerbosity, defaultVerbosityHandles)
 import Distribution.Pretty ( pretty, prettyShow )
 import Distribution.Utils.ShortText (fromShortText)
 import Distribution.Utils.Path (getSymbolicPath, makeSymbolicPath)
@@ -97,10 +102,10 @@ data CabalDetailLevel = MinimalDetails | FullDetails deriving (Show, Eq)
 cabal2nix :: Bool -> CabalDetailLevel -> Maybe Src -> CabalFile -> IO NExpr
 cabal2nix isLocal fileDetails src = \case
   (OnDisk path) -> gpd2nix isLocal fileDetails src Nothing
-    <$> readGenericPackageDescription normal Nothing (makeSymbolicPath path)
+    <$> readGenericPackageDescription (mkVerbosity defaultVerbosityHandles normal) Nothing (makeSymbolicPath path)
   (InMemory gen _ body) -> gpd2nix isLocal fileDetails src (genExtra <$> gen)
     <$> case runParseResult (parseGenericPackageDescription body) of
-        (_, Left (_, err)) -> error ("Failed to parse in-memory cabal file: " ++ show err)
+        (_, Left (_, err)) -> error ("Failed to parse in-memory cabal file: " ++ foldMap showPErrorWithSource err)
         (_, Right desc) -> pure desc
 
 gpd2nix :: Bool -> CabalDetailLevel -> Maybe Src -> Maybe NExpr -> GenericPackageDescription -> NExpr
@@ -149,13 +154,17 @@ instance IsComponent Benchmark where
 
 --- Clean the Tree from empty nodes
 -- CondBranch is empty if the true and false branch are empty.
-shakeTree :: (Foldable t, Foldable f) => CondTree v (t c) (f a) -> Maybe (CondTree v (t c) (f a))
-shakeTree (CondNode d c bs) = case (null d, null bs') of
+-- NB: Cabal-syntax 3.17 (the stable-haskell fork) dropped the constraint
+-- type parameter from CondTree/CondBranch: `CondTree v c a` -> `CondTree v a`
+-- and `CondNode` lost its middle (constraints) field.  These signatures and
+-- patterns are updated accordingly.
+shakeTree :: (Foldable f) => CondTree v (f a) -> Maybe (CondTree v (f a))
+shakeTree (CondNode d bs) = case (null d, null bs') of
                                 (True, True) -> Nothing
-                                _            -> Just (CondNode d c bs')
+                                _            -> Just (CondNode d bs')
   where bs' = catMaybes (shakeBranch <$> bs)
 
-shakeBranch :: (Foldable t, Foldable f) => CondBranch v (t c) (f a) -> Maybe (CondBranch v (t c) (f a))
+shakeBranch :: (Foldable f) => CondBranch v (f a) -> Maybe (CondBranch v (f a))
 shakeBranch (CondBranch c t f) = case (shakeTree t, f >>= shakeTree) of
   (Nothing, Nothing) -> Nothing
   (Nothing, Just f') -> shakeBranch (CondBranch (CNot c) f' Nothing)
@@ -322,7 +331,7 @@ toNixGenericPackageDescription isLocal detailLevel gpd = mkNonRecSet
                           , "components"    $= components ]
     where _packageName :: IsString a => a
           _packageName = fromString . show . pretty . pkgName . package . packageDescription $ gpd
-          component :: IsComponent comp => UnqualComponentName -> CondTree ConfVar [Dependency] comp -> Binding NExpr
+          component :: IsComponent comp => UnqualComponentName -> CondTree ConfVar comp -> Binding NExpr
           component unQualName comp
             = quoted name $=
                 mkNonRecSet (
@@ -336,11 +345,11 @@ toNixGenericPackageDescription isLocal detailLevel gpd = mkNonRecSet
                     then []
                     else
                       [ "modules"      $= toNix mods | Just mods <- [shakeTree . fmap (fmap ModuleName.toFilePath . modules) $ comp ] ] ++
-                      [ "asmSources"   $= toNix (fmap getSymbolicPath <$> src)  | Just src  <- [shakeTree . fmap (asmSources   . getBuildInfo) $ comp ] ] ++
-                      [ "cmmSources"   $= toNix (fmap getSymbolicPath <$> src)  | Just src  <- [shakeTree . fmap (cmmSources   . getBuildInfo) $ comp ] ] ++
-                      [ "cSources"     $= toNix (fmap getSymbolicPath <$> src)  | Just src  <- [shakeTree . fmap (cSources     . getBuildInfo) $ comp ] ] ++
-                      [ "cxxSources"   $= toNix (fmap getSymbolicPath <$> src)  | Just src  <- [shakeTree . fmap (cxxSources   . getBuildInfo) $ comp ] ] ++
-                      [ "jsSources"    $= toNix (fmap getSymbolicPath <$> src)  | Just src  <- [shakeTree . fmap (jsSources    . getBuildInfo) $ comp ] ] ++
+                      [ "asmSources"   $= toNix (fmap (getSymbolicPath . extraSourceFile) <$> src)  | Just src  <- [shakeTree . fmap (asmSources   . getBuildInfo) $ comp ] ] ++
+                      [ "cmmSources"   $= toNix (fmap (getSymbolicPath . extraSourceFile) <$> src)  | Just src  <- [shakeTree . fmap (cmmSources   . getBuildInfo) $ comp ] ] ++
+                      [ "cSources"     $= toNix (fmap (getSymbolicPath . extraSourceFile) <$> src)  | Just src  <- [shakeTree . fmap (cSources     . getBuildInfo) $ comp ] ] ++
+                      [ "cxxSources"   $= toNix (fmap (getSymbolicPath . extraSourceFile) <$> src)  | Just src  <- [shakeTree . fmap (cxxSources   . getBuildInfo) $ comp ] ] ++
+                      [ "jsSources"    $= toNix (fmap (getSymbolicPath . extraSourceFile) <$> src)  | Just src  <- [shakeTree . fmap (jsSources    . getBuildInfo) $ comp ] ] ++
                       [ "hsSourceDirs" $= toNix (fmap getSymbolicPath <$> dir)  | Just dir  <- [shakeTree . fmap (hsSourceDirs . getBuildInfo) $ comp ] ] ++
                       [ "includeDirs"  $= toNix (fmap getSymbolicPath <$> dir)  | Just dir  <- [shakeTree . fmap (includeDirs  . getBuildInfo) $ comp] ] ++
                       [ "includes"     $= toNix (fmap getSymbolicPath <$> dir)  | Just dir  <- [shakeTree . fmap (includes     . getBuildInfo) $ comp] ] ++
@@ -457,6 +466,16 @@ fixSystem "isDragonfly" = "isDragonFly"
 fixSystem "isHpux" = "isHPUX"
 fixSystem "isIos" = "isIOS"
 fixSystem "isIrix" = "isIRIX"
+-- PowerPC: cabal arch(ppc)/arch(ppc64) → capitalize → isPpc/isPpc64
+-- nixpkgs uses isPPC/isPPC64
+fixSystem "isPpc"   = "isPPC"
+fixSystem "isPpc64" = "isPPC64"
+-- RISC-V: cabal arch(riscv64) → capitalize → isRiscv64
+-- nixpkgs uses isRiscV64 (capital V)
+fixSystem "isRiscv64" = "isRiscV64"
+-- LoongArch: cabal arch(loongarch64) → capitalize → isLoongarch64
+-- nixpkgs uses isLoongArch64 (capital A) if/when supported
+fixSystem "isLoongarch64" = "isLoongArch64"
 fixSystem s = s
 
 instance ToNixExpr ConfVar where
@@ -486,27 +505,27 @@ instance ToNixExpr a => ToNixExpr (Condition a) where
   toNix (COr l r) = toNix l $|| toNix r
   toNix (CAnd l r) = toNix l $&& toNix r
 
-instance (Foldable t, ToNixExpr (t a), ToNixExpr v, ToNixExpr c) => ToNixExpr (CondBranch v c (t a)) where
+instance (Foldable t, ToNixExpr (t a), ToNixExpr v) => ToNixExpr (CondBranch v (t a)) where
   toNix (CondBranch c t Nothing) = case toNix t of
     (Fix (NList [e])) -> (mkSym pkgs @. "lib") @. "optional" @@ toNix c @@ e
     e -> (mkSym pkgs @. "lib") @. "optionals" @@ toNix c @@ e
   toNix (CondBranch _c t (Just f)) | toNix t == toNix f = toNix t
   toNix (CondBranch c  t (Just f)) = mkIf (toNix c) (toNix t) (toNix f)
 
-instance (Foldable t, ToNixExpr (t a), ToNixExpr v, ToNixExpr c) => ToNixExpr (CondTree v c (t a)) where
-  toNix (CondNode d _c []) = toNix d
-  toNix (CondNode d _c bs) | null d = foldl1 ($++) (fmap toNix bs)
-                           | otherwise = foldl ($++) (toNix d) (fmap toNix bs)
+instance (Foldable t, ToNixExpr (t a), ToNixExpr v) => ToNixExpr (CondTree v (t a)) where
+  toNix (CondNode d []) = toNix d
+  toNix (CondNode d bs) | null d = foldl1 ($++) (fmap toNix bs)
+                        | otherwise = foldl ($++) (toNix d) (fmap toNix bs)
 
-boolBranchToNix :: (ToNixExpr v, ToNixExpr c) => CondBranch v c Bool -> NExpr
+boolBranchToNix :: (ToNixExpr v) => CondBranch v Bool -> NExpr
 boolBranchToNix (CondBranch _c t Nothing) | boolTreeToNix t == mkBool True = mkBool True
 boolBranchToNix (CondBranch c  t Nothing) = mkIf (toNix c) (boolTreeToNix t) (mkBool True)
 boolBranchToNix (CondBranch _c t (Just f)) | boolTreeToNix t == boolTreeToNix f = boolTreeToNix t
 boolBranchToNix (CondBranch c  t (Just f)) = mkIf (toNix c) (boolTreeToNix t) (boolTreeToNix f)
 
-boolTreeToNix :: (ToNixExpr v, ToNixExpr c) => CondTree v c Bool -> NExpr
-boolTreeToNix (CondNode False _c _bs) = mkBool False
-boolTreeToNix (CondNode True _c bs) =
+boolTreeToNix :: (ToNixExpr v) => CondTree v Bool -> NExpr
+boolTreeToNix (CondNode False _bs) = mkBool False
+boolTreeToNix (CondNode True bs) =
   case filter (/= mkBool True) (fmap boolBranchToNix bs) of
     [] -> mkBool True
     bs' -> foldl1 ($&&) bs'

--- a/nix-tools/nix-tools/make-install-plan/Freeze.hs
+++ b/nix-tools/nix-tools/make-install-plan/Freeze.hs
@@ -7,7 +7,9 @@ import Distribution.Client.IndexUtils
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import Distribution.Client.ProjectConfig
 import Distribution.Client.ProjectPlanning
-import Distribution.Client.Targets (UserConstraint (UserConstraint), UserConstraintScope (UserAnyQualifier, UserQualified), UserQualifier (UserQualToplevel))
+-- cabal 3.17: UserAnyQualifier/UserQualified moved from UserConstraintScope to the
+-- new UserConstraintQualifier type (UserConstraintScope now also carries a Maybe Stage).
+import Distribution.Client.Targets (UserConstraint (UserConstraint), UserConstraintQualifier (UserAnyQualifier, UserQualified), UserQualifier (UserQualToplevel))
 import Distribution.Package
 import Distribution.Simple.Flag (Flag, pattern Flag)
 import Distribution.Solver.Types.ConstraintSource (ConstraintSource (ConstraintSourceFreeze))
@@ -130,5 +132,6 @@ projectFreezeConstraints plan =
       Map.fromList
         [ (packageName elab, ())
           | InstallPlan.Configured elab <- InstallPlan.toList plan,
-            elabLocalToProject elab
+            -- cabal 3.17: elabLocalToProject was renamed elabIsSourcePackage.
+            elabIsSourcePackage elab
         ]

--- a/nix-tools/nix-tools/make-install-plan/MakeInstallPlan.hs
+++ b/nix-tools/nix-tools/make-install-plan/MakeInstallPlan.hs
@@ -3,6 +3,7 @@
 
 import Cabal2Nix (Src, gpd2nix)
 import qualified Cabal2Nix hiding (gpd2nix)
+import Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as BSL
 import Data.Foldable (for_)
 import qualified Data.Text.Encoding as T
@@ -14,12 +15,14 @@ import Distribution.Client.NixStyleOptions (NixStyleFlags (..), defaultNixStyleF
 import Distribution.Client.ProjectConfig
 import Distribution.Client.ProjectOrchestration
 import Distribution.Client.ProjectPlanning (ElaboratedConfiguredPackage (..), availableTargets, rebuildInstallPlan)
+import Distribution.Client.ProjectPlanning.Stage (WithStage (..))
 import Distribution.Client.Setup
 import Distribution.Client.Types.PackageLocation (PackageLocation (..))
 import Distribution.Client.Types.Repo (LocalRepo (..), RemoteRepo (..), Repo (..))
 import Distribution.Client.Types.SourceRepo (SourceRepositoryPackage (..))
 import Distribution.Package (pkgName)
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription, runParseResult)
+import Distribution.Parsec.Error (showPErrorWithSource)
 import Distribution.Pretty (prettyShow)
 import Distribution.Simple.Command
 import Distribution.Simple.Flag
@@ -48,9 +51,14 @@ main = do
     CommandReadyToGo (mkflags, _commandParse) ->
       let globalFlags = defaultGlobalFlags
           flags@NixStyleFlags{configFlags} = mkflags (commandDefaultFlags cmdUI)
-          verbosity = fromFlagOrDefault Verbosity.normal (configVerbosity configFlags)
+          -- cabal 3.17: configVerbosity is now a Flag VerbosityFlags and `normal`
+          -- is a VerbosityFlags; wrap it into a Verbosity for the API below.
+          verbosity = Verbosity.mkVerbosity Verbosity.defaultVerbosityHandles
+            (fromFlagOrDefault Verbosity.normal (configVerbosity configFlags))
           cliConfig = commandLineFlagsToProjectConfig globalFlags flags mempty
-       in topHandler (installPlanAction verbosity cliConfig)
+          -- cabal 3.17: topHandler now takes a predicate selecting which exceptions
+          -- are "user" (friendly) exceptions; we treat none specially.
+       in topHandler (const False) (installPlanAction verbosity cliConfig)
 
 cmdUI :: CommandUI (NixStyleFlags ())
 cmdUI =
@@ -64,14 +72,20 @@ cmdUI =
     , commandOptions = nixStyleOptions (const [])
     }
 
+-- cabal 3.17: many plan values are now tagged with the build Stage; this drops it.
+dropStage :: WithStage a -> a
+dropStage (WithStage _ a) = a
+
 -- The following is adapted from cabal-install's Distribution.Client.CmdFreeze
 installPlanAction :: Verbosity -> ProjectConfig -> IO ()
 installPlanAction verbosity cliConfig = do
-  ProjectBaseContext{distDirLayout, cabalDirLayout, projectConfig, localPackages} <-
+  ProjectBaseContext{distDirLayout, projectConfig, localPackages} <-
     establishProjectBaseContext verbosity cliConfig OtherCommand
 
-  (_improvedPlan, elaboratedPlan, elaboratedSharedConfig, totalIndexState, activeRepos) <-
-    rebuildInstallPlan verbosity distDirLayout cabalDirLayout projectConfig localPackages Nothing
+  -- cabal 3.17: rebuildInstallPlan no longer takes the CabalDirLayout argument and
+  -- returns a 4-tuple (the improved plan is no longer returned separately).
+  (elaboratedPlan, elaboratedSharedConfig, totalIndexState, activeRepos) <-
+    rebuildInstallPlan verbosity distDirLayout projectConfig localPackages Nothing
 
   -- Write plan.json
   Cabal.notice verbosity $ "Writing plan.json to " ++ distProjectCacheFile distDirLayout "plan.json"
@@ -79,7 +93,9 @@ installPlanAction verbosity cliConfig = do
     distDirLayout
     elaboratedPlan
     elaboratedSharedConfig
-    (availableTargets elaboratedPlan)
+    -- cabal 3.17: availableTargets keys are now WithStage-qualified unit ids;
+    -- drop the stage so plan.json keeps its (UnitId, ComponentName) shape.
+    ((fmap . fmap . fmap) (first dropStage) (availableTargets elaboratedPlan))
 
   -- Write cabal.freeze
   let freezeConfig = projectFreezeConfig elaboratedPlan totalIndexState activeRepos
@@ -91,14 +107,15 @@ installPlanAction verbosity cliConfig = do
   Cabal.createDirectoryIfMissingVerbose verbosity True cabalFilesDir
   Cabal.notice verbosity $ "Writing cabal files to " ++ cabalFilesDir
 
-  let ecps = [ecp | InstallPlan.Configured ecp <- InstallPlan.toList elaboratedPlan, not $ elabLocalToProject ecp]
+  -- cabal 3.17: elabLocalToProject was renamed elabIsSourcePackage.
+  let ecps = [ecp | InstallPlan.Configured ecp <- InstallPlan.toList elaboratedPlan, not $ elabIsSourcePackage ecp]
 
   for_ ecps $
     \ElaboratedConfiguredPackage
       { elabPkgSourceId
       , elabPkgSourceLocation
       , elabPkgSourceHash
-      , elabLocalToProject
+      , elabIsSourcePackage
       , elabPkgDescriptionOverride
       } -> do
         let nixFile = cabalFilesDir </> prettyShow (pkgName elabPkgSourceId) <.> "nix"
@@ -109,10 +126,10 @@ installPlanAction verbosity cliConfig = do
           let gpdText = BSL.toStrict pkgTxt
           let src = packageLocation2Src elabPkgSourceLocation elabPkgSourceHash
           let gpd = case runParseResult (parseGenericPackageDescription gpdText) of
-                (_, Left (_, err)) -> error ("Failed to parse in-memory cabal file: " ++ show err)
+                (_, Left (_, err)) -> error ("Failed to parse in-memory cabal file: " ++ foldMap showPErrorWithSource err)
                 (_, Right desc) -> desc
           let extra = mkNonRecSet ["package-description-override" $= mkStr (T.decodeUtf8 gpdText)]
-          let nix = gpd2nix elabLocalToProject Cabal2Nix.MinimalDetails (Just src) (Just extra) gpd
+          let nix = gpd2nix elabIsSourcePackage Cabal2Nix.MinimalDetails (Just src) (Just extra) gpd
           writeDoc nixFile $ prettyNix nix
 
 packageLocation2Src :: PackageLocation local -> Maybe HashValue -> Cabal2Nix.Src

--- a/nix-tools/nix-tools/make-install-plan/ProjectPlanOutput.hs
+++ b/nix-tools/nix-tools/make-install-plan/ProjectPlanOutput.hs
@@ -51,6 +51,9 @@ import Distribution.ModuleName hiding (components)
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import qualified Distribution.Client.Utils.Json as J
 import qualified Distribution.Solver.Types.ComponentDeps as ComponentDeps
+-- cabal 3.17: compiler/platform now live per stage in a Staged Toolchain.
+import qualified Distribution.Solver.Types.Stage as Stage
+import Distribution.Solver.Types.Toolchain (Toolchain (..))
 import qualified GHC.IsList as IL
 
 import Distribution.Client.Compat.Prelude
@@ -96,16 +99,21 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig targ
     [ "cabal-version" J..= jdisplay cabalInstallVersion
     , "cabal-lib-version" J..= jdisplay cabalVersion
     , "compiler-id"
-        J..= (J.String . showCompilerId . pkgConfigCompiler)
-          elaboratedSharedConfig
+        J..= J.String (showCompilerId (toolchainCompiler hostToolchain))
     , "os" J..= jdisplay os
     , "arch" J..= jdisplay arch
     , "install-plan" J..= installPlanToJ elaboratedInstallPlan
     , "targets" J..= targetsToJ targets
     ]
  where
+  -- cabal 3.17: ElaboratedSharedConfig no longer carries a single compiler/platform
+  -- (pkgConfigCompiler/pkgConfigPlatform are gone). They now live per stage in
+  -- pkgConfigToolchains; the Host toolchain is the target and matches the old values.
+  toolchains = pkgConfigToolchains elaboratedSharedConfig
+  hostToolchain = Stage.getStage toolchains Stage.Host
+
   plat :: Platform
-  plat@(Platform arch os) = pkgConfigPlatform elaboratedSharedConfig
+  plat@(Platform arch os) = toolchainPlatform hostToolchain
 
   installPlanToJ :: ElaboratedInstallPlan -> [J.Value]
   installPlanToJ = map planPackageToJ . InstallPlan.toList
@@ -147,7 +155,11 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig targ
   -- that case, but the code supports it in case we want to use this
   -- later in some use case where we want the status of the build.
 
-  installedPackageInfoToJ :: InstalledPackageInfo -> J.Value
+  -- cabal 3.17: pre-existing packages are now carried as WithStage
+  -- InstalledPackageInfo. installedUnitId/packageId still return the underlying
+  -- (unstaged) ids via the HasUnitId/Package instances; installedDepends is
+  -- lifted over the stage with traverse.
+  installedPackageInfoToJ :: WithStage InstalledPackageInfo -> J.Value
   installedPackageInfoToJ ipi =
     -- Pre-existing packages lack configuration information such as their flag
     -- settings or non-lib components. We only get pre-existing packages for
@@ -159,7 +171,8 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig targ
       , "id" J..= (jdisplay . installedUnitId) ipi
       , "pkg-name" J..= (jdisplay . pkgName . packageId) ipi
       , "pkg-version" J..= (jdisplay . pkgVersion . packageId) ipi
-      , "depends" J..= map jdisplay (installedDepends ipi)
+      -- strip the stage so ids match the bare component "id" fields
+      , "depends" J..= map (jdisplay . dropStage) (traverse installedDepends ipi)
       ]
 
   elaboratedPackageToJ :: Bool -> ElaboratedConfiguredPackage -> J.Value
@@ -179,9 +192,9 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig targ
               [ PD.unFlagName fn J..= v
               | (fn, v) <- PD.unFlagAssignment (elabFlagAssignment elab)
               ]
-        , "style" J..= J.String (style2str (elabLocalToProject elab) (elabBuildStyle elab))
+        , "style" J..= J.String (style2str (elabIsSourcePackage elab) (elabIsSourcePackageClosure elab))
         , "pkg-src" J..= packageLocationToJ (elabPkgSourceLocation elab)
-        , "instantiated-with" J..= instantiationsToJ (elabInstantiatedWith elab)
+        , "instantiated-with" J..= instantiationsToJ instantiatedWith
         ]
       ++ [ "pkg-cabal-sha256" J..= J.String (showHashValue hash)
          | Just hash <- [fmap hashValue (elabPkgDescriptionOverride elab)]
@@ -189,11 +202,12 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig targ
       ++ [ "pkg-src-sha256" J..= J.String (showHashValue hash)
          | Just hash <- [elabPkgSourceHash elab]
          ]
-      ++ ( case elabBuildStyle elab of
-            BuildInplaceOnly _ ->
-              ["dist-dir" J..= J.String dist_dir, buildInfoFileLocation]
-            BuildAndInstall ->
-              -- TODO: install dirs?
+      -- cabal 3.17 removed BuildStyle; a package is built in place (has a
+      -- dist-dir) iff it is a project source package or in that closure,
+      -- otherwise it is installed to the store (formerly BuildAndInstall).
+      ++ ( if isInplaceStyle
+            then ["dist-dir" J..= J.String dist_dir, buildInfoFileLocation]
+            else -- TODO: install dirs?
               []
          )
       ++ case elabPkgOrComp elab of
@@ -203,7 +217,10 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig targ
                   $ [ comp2str c
                         J..= J.object (
                                   [ "depends" J..= map ((jdisplay . confInstId) . fst) ldeps
-                                  , "exe-depends" J..= map (jdisplay . confInstId) edeps
+                                  -- cabal 3.17: pkgExeDependencies elements are now
+                                  -- WithStage ConfiguredId; drop the stage so the emitted
+                                  -- id matches the bare component "id".
+                                  , "exe-depends" J..= map (jdisplay . confInstId . dropStage) edeps
                                   ] ++ bin_file c)
                     | (c, (ldeps, edeps)) <-
                         ComponentDeps.toList
@@ -214,7 +231,9 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig targ
            in ["components" J..= components]
         ElabComponent comp ->
           [ "depends" J..= map jdisplay (compOrderLibDependencies comp)
-          , "exe-depends" J..= map jdisplay (elabExeDependencies elab)
+          -- cabal 3.17: elabExeDependencies elements are WithStage ComponentId;
+          -- drop the stage so the emitted id matches the bare component "id".
+          , "exe-depends" J..= map (jdisplay . dropStage) (elabExeDependencies elab)
           , "component-name" J..= J.String (comp2str (compSolverName comp))
           ]
             ++ bin_file (compSolverName comp)
@@ -245,11 +264,12 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig targ
     configArgs = setupHsConfigureArgs elab
     configFlags =
         runIdentity $
+        -- cabal 3.17: setupHsConfigureFlags dropped the install-plan and
+        -- shared-config arguments; it now takes just the path transform,
+        -- the ready package and the common flags.
         setupHsConfigureFlags
           (fmap makeSymbolicPath . Identity)
-          elaboratedInstallPlan
           (ReadyPackage elab)
-          elaboratedSharedConfig
           commonFlags
 
     buildArgs = setupHsBuildArgs elab
@@ -290,9 +310,9 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig targ
 
     haddockArgs = setupHsHaddockArgs elab
     haddockFlags =
+      -- cabal 3.17: setupHsHaddockFlags dropped the shared-config argument.
       setupHsHaddockFlags
           elab
-          elaboratedSharedConfig
           buildTimeSettings
           commonFlags
 
@@ -305,7 +325,9 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig targ
       buildSettingOnlyDownload = False,
       buildSettingSummaryFile = mempty,
       buildSettingLogFile = Nothing,
-      buildSettingLogVerbosity = Verbosity.normal,
+      -- cabal 3.17: buildSettingLogVerbosity is a Verbosity, but `normal` is now a
+      -- VerbosityFlags; wrap it with mkVerbosity/defaultVerbosityHandles.
+      buildSettingLogVerbosity = Verbosity.mkVerbosity Verbosity.defaultVerbosityHandles Verbosity.normal,
       buildSettingBuildReports = NoReports,
       buildSettingSymlinkBinDir = [],
       buildSettingNumJobs = ParStrat.Serial,
@@ -407,11 +429,25 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig targ
           , "subdir" J..= fmap J.String srpSubdir
           ]
 
+    -- cabal 3.17 replacement for the old @isInplaceBuildStyle (elabBuildStyle elab)@:
+    -- a package builds in place (rather than being installed to the store) when it
+    -- is a project source package, or lives in the project source-package closure.
+    isInplaceStyle :: Bool
+    isInplaceStyle = elabIsSourcePackage elab || elabIsSourcePackageClosure elab
+
+    -- cabal 3.17: the (former) elabInstantiatedWith field moved onto the component
+    -- as compInstantiatedWith. Whole packages are never Backpack-instantiated.
+    instantiatedWith :: Map ModuleName Module
+    instantiatedWith = case elabPkgOrComp elab of
+      ElabComponent comp -> compInstantiatedWith comp
+      ElabPackage _ -> Map.empty
+
     dist_dir :: FilePath
     dist_dir =
       distBuildDirectory
         distDirLayout
-        (elabDistDirParams elaboratedSharedConfig elab)
+        -- cabal 3.17: elabDistDirParams no longer takes the shared config.
+        (elabDistDirParams elab)
 
     bin_file :: ComponentDeps.Component -> [J.Pair]
     bin_file c = case c of
@@ -424,30 +460,43 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig targ
       ["bin-file" J..= J.String bin]
      where
       bin =
-        if isInplaceBuildStyle (elabBuildStyle elab)
+        if isInplaceStyle
           then dist_dir </> "build" </> prettyShow s </> prettyShow s <.> exeExtension plat
-          else InstallDirs.bindir (elabInstallDirs elab) </> prettyShow s <.> exeExtension plat
+          -- cabal 3.17: elabInstallDirs is now templated; elabBinDir resolves the
+          -- absolute bindir FilePath.
+          else elabBinDir elab </> prettyShow s <.> exeExtension plat
 
     flib_file' :: (Pretty a, Show a) => a -> [J.Pair]
     flib_file' s =
       ["bin-file" J..= J.String bin]
      where
       bin =
-        if isInplaceBuildStyle (elabBuildStyle elab)
+        if isInplaceStyle
           then dist_dir </> "build" </> prettyShow s </> ("lib" ++ prettyShow s) <.> dllExtension plat
-          else InstallDirs.bindir (elabInstallDirs elab) </> ("lib" ++ prettyShow s) <.> dllExtension plat
+          else elabBinDir elab </> ("lib" ++ prettyShow s) <.> dllExtension plat
 
 comp2str :: ComponentDeps.Component -> String
 comp2str = prettyShow
 
-style2str :: Bool -> BuildStyle -> String
+-- cabal 3.17 removed the BuildStyle type. The first Bool is elabIsSourcePackage
+-- (was elabLocalToProject); the second is elabIsSourcePackageClosure, i.e. the
+-- package is rebuilt in place because it is in the project source closure.
+style2str :: Bool -> Bool -> String
 style2str True _ = "local"
-style2str False (BuildInplaceOnly OnDisk) = "inplace"
-style2str False (BuildInplaceOnly InMemory) = "interactive"
-style2str False BuildAndInstall = "global"
+style2str False True = "inplace"
+style2str False False = "global"
 
 jdisplay :: (Pretty a) => a -> J.Value
 jdisplay = J.String . prettyShow
+
+-- cabal 3.17: dependency/id values now come wrapped in WithStage, and rendering
+-- a WithStage via jdisplay prints a "build:"/"host:" qualifier. plan.json's
+-- component "id" fields are bare, and haskell.nix's Nix-side consumer looks
+-- dependencies up by that bare id, so every emitted id must be unqualified.
+-- Stripping the stage is safe: cross ids already carry a distinct platform hash
+-- (so build vs host stay distinct) and native ids are identical across stages.
+dropStage :: WithStage a -> a
+dropStage (WithStage _ a) = a
 
 renderFlags :: CommandUI flags -> flags -> [String] -> [String]
 renderFlags cmd flags extraArgs =

--- a/nix-tools/nix-tools/setup-ghcjs/Setup.hs
+++ b/nix-tools/nix-tools/setup-ghcjs/Setup.hs
@@ -12,7 +12,14 @@ import System.Directory (doesFileExist)
 import Distribution.Types.Library (libBuildInfo, Library(..))
 import Distribution.Types.BuildInfo (cSources, jsSources, includeDirs, options, extraBundledLibs)
 import Distribution.Simple.BuildTarget (readBuildTargets, BuildTarget(..))
-import Distribution.Verbosity (silent, verbose)
+-- Cabal 3.17: `silent`/`verbose` are now VerbosityFlags; mkVerbosity turns them
+-- into a Verbosity for the Cabal API calls below.
+import Distribution.Verbosity (silent, verbose, mkVerbosity, defaultVerbosityHandles)
+-- Cabal 3.17: cSources/jsSources are [ExtraSource Pkg]; extraSourceFile gets the path.
+-- Imported via Distribution.PackageDescription because this setup exe only depends on
+-- the Cabal package (Cabal-syntax is hidden), and Cabal re-exports PackageDescription,
+-- which in turn re-exports the ExtraSource module.
+import Distribution.PackageDescription (extraSourceFile)
 import Distribution.Types.ComponentName
 import Distribution.Simple.Program.Types (programPath)
 import Distribution.Simple.Program.Db (lookupProgram)
@@ -34,7 +41,7 @@ emarProgram = simpleProgram "emar"
 
 buildEMCCLib :: PackageDescription -> LocalBuildInfo -> IO ()
 buildEMCCLib desc lbi = do
-    let verbosity = verbose
+    let verbosity = mkVerbosity defaultVerbosityHandles verbose
     -- get build dir
     createDirectoryIfMissingVerbose verbosity True ((getSymbolicPath (buildDir lbi)) </> "emcc")
     --
@@ -43,22 +50,22 @@ buildEMCCLib desc lbi = do
             -- Let's see if we are going to export anything. If not there is likely no point in compiling anything
             -- from the C code.
             names <- forM (jsSources . libBuildInfo $ lib) $ \src -> do
-                unwords . concatMap (drop 2 . words) . filter (isPrefixOf "// EMCC:EXPORTED_FUNCTIONS") . lines <$> readFile (getSymbolicPath src)
+                unwords . concatMap (drop 2 . words) . filter (isPrefixOf "// EMCC:EXPORTED_FUNCTIONS") . lines <$> readFile (getSymbolicPath (extraSourceFile src))
 
             unless (null names) $ do
                 let depIncludeDirs = concatMap IPI.includeDirs (topologicalOrder $ installedPkgs lbi)
                 -- alright, let's compile all .c files into .o files with emcc, which is the `gcc` program.
                 forM_ (cSources . libBuildInfo $ lib) $ \src -> do
-                    let dst = (getSymbolicPath (buildDir lbi)) </> "emcc" </> (getSymbolicPath src -<.> "o")
+                    let dst = (getSymbolicPath (buildDir lbi)) </> "emcc" </> (getSymbolicPath (extraSourceFile src) -<.> "o")
                     createDirectoryIfMissingVerbose verbosity True (takeDirectory dst)
                     runDbProgram verbosity gccProgram (withPrograms lbi) $
-                        ["-c", getSymbolicPath src, "-o", dst] ++ ["-I" <> getSymbolicPath incDir | incDir <- (includeDirs . libBuildInfo $ lib) ++ map makeSymbolicPath depIncludeDirs]
+                        ["-c", getSymbolicPath (extraSourceFile src), "-o", dst] ++ ["-I" <> getSymbolicPath incDir | incDir <- (includeDirs . libBuildInfo $ lib) ++ map makeSymbolicPath depIncludeDirs]
 
                 -- and now construct a canonical `.js_a` file, *if* we have any cSources we turned into objects.
                 unless (null . cSources . libBuildInfo $ lib) $ do
                     let dstLib = (getSymbolicPath (buildDir lbi)) </> "libEMCC" <> (unPackageName . pkgName . package $ desc) <> ".js_a"
                     runDbProgram verbosity emarProgram (withPrograms lbi) $
-                        [ "-r",  dstLib ] ++ [ getSymbolicPath (buildDir lbi) </> "emcc" </> (getSymbolicPath src -<.> "o") | src <- cSources . libBuildInfo $ lib ]
+                        [ "-r",  dstLib ] ++ [ getSymbolicPath (buildDir lbi) </> "emcc" </> (getSymbolicPath (extraSourceFile src) -<.> "o") | src <- cSources . libBuildInfo $ lib ]
 
                 let expLib = getSymbolicPath (buildDir lbi) </> "libEMCC" <> (unPackageName . pkgName . package $ desc) <> ".exported.js_a"
                 writeFile expLib (unwords names)
@@ -83,7 +90,7 @@ linkCLib libname desc lbi = do
                                     , l /= "dl" ]
             libDirs = [ "-L" <> path | path <- concatMap IPI.libraryDirs (topologicalOrder $ installedPkgs lbi) ]
 
-        let verbosity = verbose
+        let verbosity = mkVerbosity defaultVerbosityHandles verbose
         libs0 <- filterM doesFileExist $
                 concatMap (\x -> [ libDir </> "libEMCC" <> (unPackageName . pkgName . sourcePackageId $ x) <> ".js_a"
                                 | libDir <- libraryDirs x ])
@@ -126,7 +133,7 @@ postBuildHook :: Args -> BuildFlags -> PackageDescription -> LocalBuildInfo -> I
 postBuildHook _args flags desc lbi = do
     case (takeFileName . programPath <$> lookupProgram ghcProgram (withPrograms lbi)) of
         Just "js-unknown-ghcjs-ghc" ->
-            readBuildTargets silent desc (buildTargets flags) >>= \case
+            readBuildTargets (mkVerbosity defaultVerbosityHandles silent) desc (buildTargets flags) >>= \case
                 [BuildTargetComponent (CLibName _)] -> print "OK. Lib (Build)" >> buildEMCCLib desc lbi
                 [BuildTargetComponent (CExeName _)] -> print "OK. Exe"
                 [BuildTargetComponent (CTestName _)] -> print "OK. Test"
@@ -142,7 +149,9 @@ postConfHook args flags desc lbi = do
             -- this is technically only needed if the package uses TH somewhere.
             linkEMCCTHLib desc lbi
             -- only link the final lib if we want to produce an output.
-            readBuildTargets silent desc (configureArgs False flags) >>= \case
+            -- Cabal 3.17: configureArgs dropped its leading Bool; it is now
+            -- configureArgs :: ConfigFlags -> [String].
+            readBuildTargets (mkVerbosity defaultVerbosityHandles silent) desc (configureArgs flags) >>= \case
                 [BuildTargetComponent (CLibName _)] -> print "OK. Lib" >> postConf simpleUserHooks args flags desc lbi
                 [BuildTargetComponent (CExeName _)] -> print "OK. Exe (Link)" >> linkEMCCLib desc lbi
                 [BuildTargetComponent (CTestName _)] -> print "OK. Test (Link)" >> linkEMCCLib desc lbi
@@ -168,7 +177,9 @@ emccBuildHook desc lbi hooks flags = do
 
   where
     jsLib = "dist/build" </> "emcc" </> "lib.js"
-    extraOpts = PerCompilerFlavor [jsLib] []
+    -- Cabal 3.17: BuildInfo.options is now a flat [String] (the
+    -- PerCompilerFlavor wrapper was removed), so extraOpts is just a list.
+    extraOpts = [jsLib]
     -- don't inject it for libraries, only for exe, test, bench.
     updateLibrary :: Library -> Library
     updateLibrary = id -- lib@Library{ libBuildInfo = bi } = lib { libBuildInfo = bi { options = options bi <> extraOpts } }


### PR DESCRIPTION
Lifts the `nix-tools` subflake changes out of #2528 onto master on their own, so they can be built and captured as a **static nix-tools** release. The `nix-tools` tree here is byte-identical to 2528's (tree `e4cb8f9b98eb3142ca335488ecf9743ed05c967b`).

## Why

On master every `plan-nix` IFD depends on a single prebuilt `nix-tools` derivation — the static bundle from `nix-tools/static/zipped.nix`. On #2528 it instead depends on individually-built Haskell components. `nix-diff` on the *same* plan-nix derivation, master vs 2528:

```
- nix-tools                                <- one prebuilt bundle
+ nix-tools-exe-plan-to-nix-0.1.0.0        <- built per component
+ nix-tools-exe-make-install-plan-0.1.0.0
+ cabal-install-exe-cabal-3.17.0.1
```

`plan-nix` is the universal IFD, so this multiplies across the whole compiler × platform matrix. Measured per-job **evaluation** cost of the `ghc-lib-reinstallable` jobs, 2528 vs master:

| compiler | 2528 | master | ratio |
|---|---:|---:|---:|
| ghc967 | 124.8 s/job | 1.4 s | **89×** |
| ghc9141 | 57.0 s/job | 0.8 s | **71×** |
| ghc9103 | 53.0 s/job | 0.9 s | **59×** |
| ghc984 | 51.1 s/job | 1.4 s | **36×** |
| ghc9141llvm | 10.2 s/job | 0.5 s | **20×** |
| ghc9124 | 9.5 s/job | 1.5 s | 6× |

The regression lands on the **pre-existing** compilers, not on `ghc914-sh` itself — its own reinstallable jobs cost 0 s because they never reach this path. No 2528 evaluation has completed since 2026-07-23.

## What changed

The substantive change is `nix-tools/cabal.project`: `make-install-plan` is now built against the stable-haskell Cabal fork (3.17, branch `hkm/installed-sublibs`) rather than Cabal 3.16, with `allow-newer` relaxing the `^>=3.16` bounds project-wide, plus `stable-haskell/hackage-security`. Along with it, the `cabal-syntax-json-condtree-3.17` patch and the Haskell-side changes in `Cabal2Nix` / `MakeInstallPlan` / `ProjectPlanOutput` / `Freeze` / `setup-ghcjs`. The `nix-tools/flake.nix` change is a comment only.

## ⚠️ Compatibility is unverified

This moves *all* of nix-tools onto the Cabal 3.17 fork — it is **not** scoped to stable-haskell. Since `plan-to-nix` and `make-install-plan` generate the plan-nix for every compiler, any output change reaches ghc9.6 through ghc9.14 alike.

If it does change output for the older compilers, the answer is **two static nix-tools** — one for stable-haskell, one for everything else — rather than forcing all compilers onto the fork.

Cheap way to find out: build this branch's `plan-to-nix` and diff its output against master's for one old compiler. Identical ⇒ one bundle suffices; different ⇒ we need the split.

## Next step

Once a static nix-tools carrying these patches exists, #2528 should be updated to consume it instead of building its own components — which is what should bring its evaluation time back in line.
