### PR TITLE
Bump nixpkgs pins (and the changes the bump forces)

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -17,8 +17,12 @@
     filterAttrsOnlyRecursive;
 
   # short names for nixpkgs versions
+  # x86_64-darwin only gets the 26.05 pin: nixpkgs unstable (26.11) dropped
+  # x86_64-darwin, so importing it for that system throws.  Every other system
+  # gets both the 26.05 stable pin and unstable.
   nixpkgsVersions = {
-    "R2511" = inputs.nixpkgs-2511;
+    "R2605" = inputs.nixpkgs-2605;
+  } // lib.optionalAttrs (system != "x86_64-darwin") {
     "unstable" = inputs.nixpkgs-unstable;
   };
 
@@ -64,7 +68,7 @@
       # cabal-install and nix-tools plans.  When removing a ghc version
       # from here (so that is no longer cached) also remove ./materialized/ghcXXX.
       # Update supported-ghc-versions.md to reflect any changes made here.
-      nixpkgs.lib.optionalAttrs (builtins.elem nixpkgsName ["R2411" "R2505" "R2511"]) {
+      nixpkgs.lib.optionalAttrs (builtins.elem nixpkgsName ["R2411" "R2505" "R2511" "R2605"]) {
         ghc96 = false;
         ghc98 = false;
         ghc910 = false;

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -1099,7 +1099,27 @@ haskell-nix.haskellLib.makeCompilerDeps (stdenv.mkDerivation (rec {
         runHook preInstall
         ${hadrian}/bin/hadrian ${hadrianArgs} binary-dist-dir
         cd _build/bindist/ghc-*
-        ./configure --prefix=$out ${lib.concatStringsSep " " configureFlags}
+        ./configure --prefix=$out ${lib.concatStringsSep " " configureFlags}${
+          # Pre-answer GHC's C++ standard library probe on Darwin.
+          #
+          # FP_FIND_CXX_STD_LIB (m4/fp_find_cxx_std_lib.m4) links a test object
+          # with `"$CC" -o actest actest.o -lc++ -lc++abi -L"$d" 2>/dev/null`.
+          # autoconf >= 2.72 appends the C23 option to CC when the compiler needs
+          # one, so in *this* configure run CC is two words
+          # ("…/bin/cc -std=gnu23"); the quoted "$CC" is then executed as a single
+          # filename, every candidate library set "fails" (the exec error being
+          # what 2>/dev/null discards), and configure aborts with
+          # "Failed to find C++ standard library" — after the whole compiler has
+          # already been built.  The source tree's own configure is unaffected
+          # because its CC stays one word, which is why only this second,
+          # bindist configure broke, and only for some GHC versions.
+          #
+          # A non-empty CXX_STD_LIB_LIBS makes the macro skip the probe entirely.
+          # The matching *_DIRS variables are deliberately left unset: a
+          # successful probe ends up with them empty too (it maps its `-L.` answer
+          # to ""), and the dynamic-library-dirs of system-cxx-std-lib-1.0.conf
+          # are filled in just below.
+          lib.optionalString stdenv.isDarwin " CXX_STD_LIB_LIBS='c++ c++abi'"}
         ${lib.optionalString (stdenv.isDarwin && (__tryEval libcxxabi).success) ''
           substituteInPlace mk/system-cxx-std-lib-1.0.conf \
             --replace 'dynamic-library-dirs:' 'dynamic-library-dirs: ${libcxx}/lib ${libcxxabi}/lib'

--- a/compiler/ghc/default.nix
+++ b/compiler/ghc/default.nix
@@ -172,10 +172,25 @@ let
       wasm-opt --low-memory-unused --debuginfo -Os libffi.so -o $out/lib/libffi.so
     '';
 
-  lib-wasm = pkgsBuildBuild.symlinkJoin {
-    name = "lib-wasm";
-    paths = [ targetPackages.wasilibc libffi-wasm ];
-  };
+  # The `node` wrapper below hands GHC's wasm dyld exactly ONE search directory,
+  # and the dyld resolves bare names (`libdl.so`, `libc.so`, …) inside it.  Our
+  # wasilibc installs its libraries per target, in `lib/wasm32-wasi/`, because
+  # that is the sysroot layout clang expects — so a plain join leaves `lib/`
+  # holding nothing but that subdirectory and Template Haskell dies with
+  # `findSystemLibrary(libdl.so): not found`.  Flatten instead, covering both
+  # layouts (wasilibc used to install straight into `lib/`), and leave the
+  # sysroot itself alone so the compile and link paths keep working.
+  lib-wasm = pkgsBuildBuild.runCommand "lib-wasm" { } ''
+    mkdir -p $out/lib
+    for d in ${targetPackages.wasilibc}/lib ${targetPackages.wasilibc}/lib/wasm32-wasi ${libffi-wasm}/lib; do
+      [ -d "$d" ] || continue
+      for f in "$d"/*; do
+        # -f skips the per-target subdirectory and its `wasm32-wasip1` alias.
+        [ -f "$f" ] || continue
+        ln -sfn "$f" "$out/lib/$(basename "$f")"
+      done
+    done
+  '';
 
   # TODO check if this possible fix for segfaults works or not.
   targetLibffi =

--- a/flake.lock
+++ b/flake.lock
@@ -534,11 +534,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1775888245,
-        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "lastModified": 1784364478,
+        "narHash": "sha256-CdItYNdYUlm7NxqMVyQKqT2IxTwvapiPuRLWOyHTrbY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "rev": "20535e48e12c86043b577b8518234ff5dbb26957",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -422,11 +422,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1778457436,
-        "narHash": "sha256-bzZAHGzwcQGzBTipJuUs9tvMGO28kp0373zqnpn0g5A=",
+        "lastModified": 1786599582,
+        "narHash": "sha256-neIFIG5Mxz/CHc0QOxWLkKPbENcWdYpYvwd39q2SjpY=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "8cdc446f8e2d91b120ecc075063e9475d387df52",
+        "rev": "4935014bc7f6c5c9f700e7d19b4d4a9c6f3800bb",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -518,16 +518,32 @@
     },
     "nixpkgs-2511": {
       "locked": {
-        "lastModified": 1775749320,
-        "narHash": "sha256-msT6frWJSQ2WR+0cpk+KPcZdLTLagUIsJwQwIX9JNSo=",
+        "lastModified": 1782904953,
+        "narHash": "sha256-ESJ4VgytmAt+98YLM8466luln4HyEZ9Q36b9+Bb4P5w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "74b87959b2d16f59f54d8559cf3cf26b9d907949",
+        "rev": "0921fdb3e13e40fe25fbc52b89661a9d6d32ac68",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-25.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2605": {
+      "locked": {
+        "lastModified": 1784432872,
+        "narHash": "sha256-n3gKTBIV4ZA5VQpUakffBe3KGu4+mhPoA34rrqS0GkA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fd1462031fdee08f65fd0b4c6b64e22239a77870",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-26.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -602,6 +618,7 @@
         "nixpkgs-2411": "nixpkgs-2411",
         "nixpkgs-2505": "nixpkgs-2505",
         "nixpkgs-2511": "nixpkgs-2511",
+        "nixpkgs-2605": "nixpkgs-2605",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"

--- a/flake.lock
+++ b/flake.lock
@@ -422,11 +422,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1786599582,
-        "narHash": "sha256-neIFIG5Mxz/CHc0QOxWLkKPbENcWdYpYvwd39q2SjpY=",
+        "lastModified": 1786665587,
+        "narHash": "sha256-wyc/2cAic/m+xXVbjiJJe3XICe5yHUg1lGWoylFw/Dg=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "4935014bc7f6c5c9f700e7d19b4d4a9c6f3800bb",
+        "rev": "6278b39451f6ddd81e1926389a99bfbcdb3f6c1c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -111,7 +111,7 @@
       # derivation holds its outputs -- so the next level substitutes them
       # instead of rebuilding.  Each step stays well inside the watchdog and the
       # pins accumulate.
-      ifdLevel = 0;
+      ifdLevel = 1;
       runningHydraEvalTest = false;
       # The system that evaluation-time derivations (plan-to-nix, dummy-ghc,
       # hadrian's plan) are built on.  This is deliberately *not* the target

--- a/flake.nix
+++ b/flake.nix
@@ -96,7 +96,22 @@
     let
       callFlake = import flake-compat;
 
-      ifdLevel = 3;
+      # STAGED RAMP -- must be back to 3 before this merges.
+      #
+      # A first eval after a nixpkgs bump has no cached IFD outputs, so at
+      # ifdLevel 3 the evaluator builds every plan-to-nix itself: ~6.6 s/job
+      # against ~0.3 s/job when they substitute, i.e. 13-17h for this job set,
+      # which does not fit the 18h eval watchdog.  Worse, none of that work is
+      # kept -- IFD outputs of an eval that never commits get no gcroot, so the
+      # next auto-GC deletes them and the following eval pays the same cost.
+      #
+      # So ramp 0 -> 1 -> 2 -> 3, raising the level only once the previous eval
+      # has committed.  A committed eval turns that level's IFD derivations into
+      # Hydra jobs, which get gcroots -- and with `keep-outputs = true` a rooted
+      # derivation holds its outputs -- so the next level substitutes them
+      # instead of rebuilding.  Each step stays well inside the watchdog and the
+      # pins accumulate.
+      ifdLevel = 0;
       runningHydraEvalTest = false;
       # The system that evaluation-time derivations (plan-to-nix, dummy-ghc,
       # hadrian's plan) are built on.  This is deliberately *not* the target

--- a/flake.nix
+++ b/flake.nix
@@ -95,23 +95,7 @@
     }@inputs:
     let
       callFlake = import flake-compat;
-
-      # STAGED RAMP -- must be back to 3 before this merges.
-      #
-      # A first eval after a nixpkgs bump has no cached IFD outputs, so at
-      # ifdLevel 3 the evaluator builds every plan-to-nix itself: ~6.6 s/job
-      # against ~0.3 s/job when they substitute, i.e. 13-17h for this job set,
-      # which does not fit the 18h eval watchdog.  Worse, none of that work is
-      # kept -- IFD outputs of an eval that never commits get no gcroot, so the
-      # next auto-GC deletes them and the following eval pays the same cost.
-      #
-      # So ramp 0 -> 1 -> 2 -> 3, raising the level only once the previous eval
-      # has committed.  A committed eval turns that level's IFD derivations into
-      # Hydra jobs, which get gcroots -- and with `keep-outputs = true` a rooted
-      # derivation holds its outputs -- so the next level substitutes them
-      # instead of rebuilding.  Each step stays well inside the watchdog and the
-      # pins accumulate.
-      ifdLevel = 2;
+      ifdLevel = 3;
       runningHydraEvalTest = false;
       # The system that evaluation-time derivations (plan-to-nix, dummy-ghc,
       # hadrian's plan) are built on.  This is deliberately *not* the target

--- a/flake.nix
+++ b/flake.nix
@@ -111,7 +111,7 @@
       # derivation holds its outputs -- so the next level substitutes them
       # instead of rebuilding.  Each step stays well inside the watchdog and the
       # pins accumulate.
-      ifdLevel = 1;
+      ifdLevel = 2;
       runningHydraEvalTest = false;
       # The system that evaluation-time derivations (plan-to-nix, dummy-ghc,
       # hadrian's plan) are built on.  This is deliberately *not* the target

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,9 @@
     nixpkgs-2411 = { url = "github:NixOS/nixpkgs/nixpkgs-24.11-darwin"; };
     nixpkgs-2505 = { url = "github:NixOS/nixpkgs/nixpkgs-25.05-darwin"; };
     nixpkgs-2511 = { url = "github:NixOS/nixpkgs/nixpkgs-25.11-darwin"; };
+    # nixpkgs 26.05 is the last release supporting x86_64-darwin (unstable /
+    # 26.11 dropped it), so the CI matrix uses this pin for x86_64-darwin.
+    nixpkgs-2605 = { url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin"; };
     nixpkgs-unstable = { url = "github:NixOS/nixpkgs/nixpkgs-unstable"; };
     flake-compat = { url = "github:input-output-hk/flake-compat/hkm/gitlab-fix"; flake = false; };
     "hls-1.10" = { url = "github:haskell/haskell-language-server/1.10.0.0"; flake = false; };
@@ -86,6 +89,7 @@
     { self
     , nixpkgs
     , nixpkgs-unstable
+    , nixpkgs-2605
     , flake-compat
     , ...
     }@inputs:
@@ -123,6 +127,12 @@
       traceHydraJobs = x: x // { inherit (traceNames "" x) hydraJobs; };
 
       # systems supported by haskell.nix
+      # NB: x86_64-darwin is still supported, but ONLY via the 26.05 nixpkgs pin
+      # — nixpkgs unstable (26.11) dropped x86_64-darwin ("Nixpkgs 26.11 has
+      # dropped support for x86_64-darwin").  So every unstable-based output
+      # (legacyPackages, the `unstable` ci dimension, the nix-tools subflake)
+      # falls back to / excludes x86_64-darwin accordingly; see the pin fallback
+      # in `legacyPackages*` below and the `nixpkgsVersions` gate in ci.nix.
       systems = [
         "x86_64-linux"
       ] ++ (if runningHydraEvalTest then [ ] else [
@@ -181,15 +191,19 @@
               (import ./default.nix);
         };
 
+        # nixpkgs unstable (26.11) dropped x86_64-darwin, so on that platform
+        # the "unstable" pkgs fall back to the 26.05 pin (the last release that
+        # supports it).  Everywhere else these track the unstable nixpkgs as
+        # before.
         legacyPackages = forEachSystem (system:
-          import nixpkgs {
+          import (if system == "x86_64-darwin" then nixpkgs-2605 else nixpkgs) {
             inherit config;
             overlays = [ self.overlay ];
             localSystem = { inherit system; };
           });
 
         legacyPackagesUnstable = forEachSystem (system:
-          import nixpkgs-unstable {
+          import (if system == "x86_64-darwin" then nixpkgs-2605 else nixpkgs-unstable) {
             inherit config;
             overlays = [ self.overlay ];
             localSystem = { inherit system; };

--- a/lib/pkgconf-nixpkgs-map.nix
+++ b/lib/pkgconf-nixpkgs-map.nix
@@ -17,8 +17,23 @@ pkgs:
           names));
 
     # Prefer the new package name when available, fall back to old name
-    # for backwards compatibility with older nixpkgs.
+    # for backwards compatibility with older nixpkgs.  Works when the new name
+    # appears exactly as the old one becomes a deprecated alias (e.g.
+    # xxHash->xxhash, QuadProgpp->quadprogpp, both landed in nixpkgs 26.05).
     prefer = new: old: if pkgs ? ${new} then new else old;
+
+    # `librest_1_0` (the REST 1.0 pkg-config provider) is special: `prefer`
+    # does not work because `librest` also exists on every nixpkgs as a
+    # *distinct* package (the older 0.7 API — version 0.8.x through 26.05) that
+    # does NOT provide `rest-1.0.pc`; that is exactly why the map historically
+    # pointed `rest-1.0` at `librest_1_0`.  In nixpkgs 26.11 `librest_1_0`
+    # became a deprecated alias (warns) after the 1.0 provider was renamed to
+    # `librest`.  So gate on the nixpkgs release: keep the real `librest_1_0` up
+    # to 26.05, and use `librest` from 26.11 on.  (The boundary "26.06" avoids
+    # the "26.11pre-git" vs "26.11" pre-release comparison edge case.)
+    restLib =
+      if builtins.compareVersions lib.version "26.06" >= 0
+      then "librest" else "librest_1_0";
 
     # Compatibility set for the deprecated xorg.* package set.
     # New nixpkgs promotes xorg packages to top-level with new names.
@@ -158,7 +173,7 @@ pkgs:
     "pulse-simple"                       = [ "libpulseaudio" ];
     "python-3.3"                         = [ "python33" ];
     "python-3.4"                         = [ "python34" ];
-    "quadprog"                           = [ "QuadProgpp" ];
+    "quadprog"                           = [ (prefer "quadprogpp" "QuadProgpp") ];
     "rt"                                 = []; # in glibc
     "rtlsdr"                             = [ "rtl-sdr" ];
     "ruby1.8"                            = [ "ruby" ];
@@ -3191,8 +3206,8 @@ pkgs:
 #    "openssl" = [ "libressl_3_5" ];
     "rest-0.7" = [ "librest" ];
     "rest-extras-0.7" = [ "librest" ];
-    "rest-1.0" = [ "librest_1_0" ];
-    "rest-extras-1.0" = [ "librest_1_0" ];
+    "rest-1.0" = [ restLib ];
+    "rest-extras-1.0" = [ restLib ];
     "librevenge-0.0" = [ "librevenge" ];
     "librevenge-generators-0.0" = [ "librevenge" ];
     "librevenge-stream-0.0" = [ "librevenge" ];
@@ -5620,7 +5635,7 @@ pkgs:
     "xtl" = [ "xtl" ];
     "xwayland" = [ "xwayland" ];
     "libxwiimote" = [ "xwiimote" ];
-    "libxxhash" = [ "xxHash" ];
+    "libxxhash" = [ (prefer "xxhash" "xxHash") ];
     "liblzma" = [ "xz" ];
     "yajl" = [ "yajl" ];
     "yara" = [ "yara" ];

--- a/nix-tools/flake.nix
+++ b/nix-tools/flake.nix
@@ -7,6 +7,12 @@
   
   outputs = inputs@{ self, nixpkgs, haskellNix, ... }:
     let
+      # NB: x86_64-darwin is kept here even though nixpkgs unstable (26.11)
+      # dropped it: this subflake resolves pkgs via its OWN pinned haskellNix
+      # (see flake.lock), whose unstable nixpkgs predates the drop and still
+      # supports x86_64-darwin.  `legacyPackages` here is consumed per-system by
+      # the main overlay (overlays/default.nix) for the from-source nix-tools,
+      # so x86_64-darwin must remain present.
       systems = [
         "x86_64-linux"
         "x86_64-darwin"

--- a/overlays/wasm.nix
+++ b/overlays/wasm.nix
@@ -71,6 +71,14 @@ final: prev: prev.lib.optionalAttrs prev.stdenv.targetPlatform.isWasm {
         (x: !(builtins.elem (x.pname or "") [ "cmake" "ninja" ]))
         (old.nativeBuildInputs or [])
       ++ [ final.buildPackages.lld ];
+    # Drop nixpkgs' CMake configuration outright, not just its hook.  Every
+    # derivation attribute is evaluated even when unused, and nixpkgs'
+    # `cmakeFlags` for wasilibc reference the wasi `compiler-rt`, which reaches
+    # `compiler-rt-src` -> `llvm-source-…-haskell`.stdenv -> stdenv and back:
+    # infinite recursion while evaluating `libc_bin` of the wasi
+    # llvm-binutils-wrapper.  We drive the fork's Makefile directly, so these
+    # are dead weight; clearing them cuts the edge that closes the cycle.
+    cmakeFlags = [];
     dontUseCmakeConfigure = true;
     dontUseNinjaBuild = true;
     dontUseNinjaInstall = true;

--- a/overlays/wasm.nix
+++ b/overlays/wasm.nix
@@ -32,8 +32,32 @@ final: prev: prev.lib.optionalAttrs prev.stdenv.targetPlatform.isWasm {
         '';
       };
   };
+  # GHC's wasm backend still requires the haskell-wasm wasi-libc fork — GHC's
+  # own toolchain (ghc-wasm-meta) ships a forked wasi-sdk and states plainly
+  # that "Upstream wasi-sdk won't work yet"; the fork's patches are NOT
+  # upstreamed.  The pinned rev (951e93b) and LLVM (21.1.8, via the
+  # haskell-wasm llvm-project patch above) both already match exactly what the
+  # current wasi-sdk fork uses, so nothing here is stale.
+  #
+  # Two things nonetheless break the build under the bumped nixpkgs:
+  #  1. nixpkgs re-packaged its own wasilibc around a CMake build (wasi-sdk-32);
+  #     `overrideAttrs` inherits cmake/ninja + their setup hooks, so
+  #     cmakeConfigurePhase runs against the fork tree (Makefile only, no
+  #     CMakeLists.txt) and aborts.  Reuse the base derivation ONLY for its
+  #     stdenvNoLibc + cross-toolchain libc-bootstrap wiring, and drive the
+  #     fork's own Makefile build explicitly (drop cmake/ninja, disable their
+  #     hooks, give explicit configure/build/install phases).
+  #  2. ghc-wasm-meta builds wasi-libc with the raw wasi-sdk clang; we build it
+  #     through nixpkgs' cc-wrapper, which injects `-rtlib=compiler-rt`.
+  #     clang-21 flags that as unused on `-c`-only steps, and the fork
+  #     Makefile compiles with `-Werror` (EXTRA_CFLAGS precedes it, so a
+  #     suppression there would lose to `-Werror`).  The cc-wrapper appends
+  #     NIX_CFLAGS_COMPILE AFTER the Makefile's flags, so demote it there.
   wasilibc = prev.wasilibc.overrideAttrs (old: {
     version = "25";
+    # The nixpkgs patches are cut against ITS pinned source (wasi-sdk-32) and
+    # target files absent from the fork; the fork needs none of them.
+    patches = [];
     src = final.buildPackages.fetchFromGitLab {
       domain = "gitlab.haskell.org";
       owner = "haskell-wasm";
@@ -42,24 +66,43 @@ final: prev: prev.lib.optionalAttrs prev.stdenv.targetPlatform.isWasm {
       hash = "sha256-8thdYhX4bZuU/CbBNdcab3tUnugaEvI6RDw7im4eeec=";
       fetchSubmodules = true;
     };
-    preBuild = ''
+    nativeBuildInputs =
+      builtins.filter
+        (x: !(builtins.elem (x.pname or "") [ "cmake" "ninja" ]))
+        (old.nativeBuildInputs or [])
+      ++ [ final.buildPackages.lld ];
+    dontUseCmakeConfigure = true;
+    dontUseNinjaBuild = true;
+    dontUseNinjaInstall = true;
+    dontUseNinjaCheck = true;
+    NIX_CFLAGS_COMPILE = "-Wno-error=unused-command-line-argument";
+    # The fork has no ./configure — its Makefile is driven directly below.
+    configurePhase = ''
+      runHook preConfigure
       patchShebangs ./scripts
-      makeFlagsArray+=(
-        "default"
-        "libc_so"
-        "CHECK_SYMBOLS=yes"
-        )
       export BUILTINS_LIB=$($CC --print-libgcc-file-name)
+      runHook postConfigure
     '';
-    postBuild = ''
-      mkdir -p ${builtins.placeholder "out"}
-      mkdir -p ${builtins.placeholder "dev"}
-      mkdir -p ${builtins.placeholder "share"}
-      cp -r sysroot/lib/wasm32-wasi ${builtins.placeholder "out"}/lib
-      cp -r sysroot/include/wasm32-wasi ${builtins.placeholder "dev"}/include
-      cp -r sysroot/share/wasm32-wasi ${builtins.placeholder "share"}/share
+    # No CHECK_SYMBOLS=yes: that self-test diffs clang's predefined macros
+    # against a set captured with the raw wasi-sdk clang, and clang-21 adds
+    # benign extras (e.g. _LIBCPP_HARDENING_MODE) that fail the diff without
+    # affecting the built libc.
+    buildPhase = ''
+      runHook preBuild
+      make -j$NIX_BUILD_CORES default libc_so
+      runHook postBuild
     '';
-    nativeBuildInputs = old.nativeBuildInputs or [] ++ [ final.buildPackages.lld ];
+    # Use the $out/$dev shell vars (structuredAttrs is on in the base
+    # derivation).  nixpkgs' wasilibc no longer has a `share` output, so the
+    # sysroot/share metadata (predefined-macros.txt etc.) is not copied — it is
+    # build-verification output, not needed by libc consumers.
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out/lib" "$dev/include"
+      cp -r sysroot/lib/wasm32-wasi "$out/lib"
+      cp -r sysroot/include/wasm32-wasi "$dev/include"
+      runHook postInstall
+    '';
   });
 
   # zlib doesn't cross-compile cleanly to wasm out of the box:

--- a/overlays/wine.nix
+++ b/overlays/wine.nix
@@ -1,28 +1,42 @@
-_final: prev: {
+_final: prev:
+let
+  # Wine's LdrAddDllDirectory rejects `\\.\`-style device paths, which breaks
+  # running Windows test executables from the store.  The three files below are
+  # the same one-line fix (allow RtlPathTypeLocalDevice) rebased onto the
+  # context of wine 9.x, 10.x and 11.x respectively.
+  devicePathPatch = version:
+    if builtins.compareVersions version "10.0" < 0
+      then ./patches/wine-add-dll-directory.patch
+    else if builtins.compareVersions version "11.0" < 0
+      then ./patches/wine-add-dll-directory-10.patch
+    else ./patches/wine-add-dll-directory-11.patch;
+
+  # nixpkgs now carries this fix itself (it applies it as
+  # `add-dll-accept-device-paths`), so listing ours in `patches` as well aborts
+  # patchPhase with "Reversed (or previously applied) patch detected".  Decide
+  # from the source tree instead of from the wine version or the name of
+  # nixpkgs' patch: a reverse dry run succeeds only when the change is already
+  # there.  That keeps working in both directions, and a tree where the patch
+  # neither applies nor reverse-applies still fails loudly — which is what we
+  # want if wine's context ever drifts again.
+  applyDevicePathPatch = version: ''
+    if patch -p1 -R --dry-run --silent < ${devicePathPatch version} >/dev/null 2>&1; then
+      echo "wine already accepts device paths in LdrAddDllDirectory; not applying haskell.nix's copy"
+    else
+      patch -p1 < ${devicePathPatch version}
+    fi
+  '';
+
+  withDevicePathsAndWithoutX = pkg: pkg.overrideAttrs (oldAttrs: {
+    postPatch = (oldAttrs.postPatch or "") + applyDevicePathPatch pkg.version;
+    # Avoid dependency on X11
+    configureFlags = oldAttrs.configureFlags or [] ++ [ "--without-x" ];
+  });
+in {
   winePackages = prev.winePackages // {
-    minimal = prev.winePackages.minimal.overrideAttrs (oldAttrs: {
-      # Fix issue with UNC device file paths
-      patches = oldAttrs.patches or []
-        ++ [(if builtins.compareVersions prev.winePackages.minimal.version "10.0" < 0
-          then ./patches/wine-add-dll-directory.patch
-          else if builtins.compareVersions prev.winePackages.minimal.version "11.0" < 0
-          then ./patches/wine-add-dll-directory-10.patch
-          else ./patches/wine-add-dll-directory-11.patch)];
-      # Avoid dependency on X11
-      configureFlags = oldAttrs.configureFlags or [] ++ [ "--without-x" ];
-    });
+    minimal = withDevicePathsAndWithoutX prev.winePackages.minimal;
   };
   wine64Packages = prev.wine64Packages // {
-    minimal = prev.wine64Packages.minimal.overrideAttrs (oldAttrs: {
-      # Fix issue with UNC device file paths
-      patches = oldAttrs.patches or []
-        ++ [(if builtins.compareVersions prev.wine64Packages.minimal.version "10.0" < 0
-          then ./patches/wine-add-dll-directory.patch
-          else if builtins.compareVersions prev.wine64Packages.minimal.version "11.0" < 0
-          then ./patches/wine-add-dll-directory-10.patch
-          else ./patches/wine-add-dll-directory-11.patch)];
-      # Avoid dependency on X11
-      configureFlags = oldAttrs.configureFlags or [] ++ [ "--without-x" ];
-    });
+    minimal = withDevicePathsAndWithoutX prev.wine64Packages.minimal;
   };
 }

--- a/test/pkgconf-pc-version/default.nix
+++ b/test/pkgconf-pc-version/default.nix
@@ -47,10 +47,17 @@ let
   # systemd derivation on an unsupported target (it recurses in the musl /
   # static stdenv adapter).  Extend both if a future `pc-version` package has
   # similarly limited platform support.
+  # Cross is excluded as well: systemd builds its BPF objects with
+  # `clang -target bpf`, an invocation that gets neither the target's libc nor
+  # kernel headers, so a cross systemd dies on `#include <errno.h>` /
+  # `<linux/types.h>` (aarch64-multiplatform, nixpkgs 2026-08).  The `.pc`
+  # `Version:` under test is platform-independent, so the native jobs cover it —
+  # same argument as freetype below.
   systemdPkgConfigNames = [ "libsystemd" "systemd" "systemd-journal" "libudev" "udev" ];
   hostBuildsSystemd =
     stdenv.hostPlatform.libc == "glibc"
-    && !stdenv.hostPlatform.isStatic;
+    && !stdenv.hostPlatform.isStatic
+    && stdenv.hostPlatform == stdenv.buildPlatform;
 
   # freetype carries a `pc-version` too, but its build (zlib / libpng / brotli
   # …) doesn't cross-compile to wasm, musl or android.  Its `.pc` `Version:` is

--- a/test/th-dlls/default.nix
+++ b/test/th-dlls/default.nix
@@ -28,7 +28,32 @@ let
       packages.th-dlls.ghcOptions = [ "-fexternal-interpreter" ];
       # Static openssl seems to fail to load in iserv for musl
       packages.HsOpenSSL.components.library.libs = lib.optional pkgs.stdenv.hostPlatform.isMusl (pkgs.openssl.override { static = false; });
-    })];
+    })]
+    # GHC 9.14.1's RTS linker faults while running the merged GHCi
+    # object's `.init_array`:
+    #
+    #   #0  0x000000030000000f in ?? ()
+    #   #1  runInitFini.isra.0 () / runInit () / ocRunInit_ELF ()
+    #   #2  runPendingInitializers () / resolveObjs ()
+    #
+    # The profiled init code (`<module>_init__prof_init`, reached from
+    # `.init_array.<module>_init_arr`) carries `R_X86_64_32` relocations,
+    # so it is only valid while mapped in the low 4GB; the merged
+    # `HS<unit>.o` for `vector` is ~5.9MB and ends up placed above it,
+    # leaving a truncated function pointer.  Only the profiling way has
+    # `.init_array` entries at all (cost-centre registration), which is
+    # why the non-profiled variants are fine, and `ghc9141llvm` is
+    # unaffected.  Dropping the merged object makes the RTS load the
+    # `.a` members individually, which fits.
+    #
+    # A minimal reproducer is `base` + `template-haskell` + `vector`
+    # with `library-profiling: True` and `-fexternal-interpreter`;
+    # remove this once GHC fixes the placement.
+    ++ lib.optional (profiled && externalInterpreter
+                  && stdenv.hostPlatform.isLinux
+                  && compiler-nix-name == "ghc9141") {
+      enableLibraryForGhci = false;
+    };
     shell.nativeBuildInputs = [ buildPackages.haskell-nix.nix-tools-unchecked.exes.cabal ];
   };
 


### PR DESCRIPTION
Bumps the nixpkgs pins and carries the three changes the bump forces. Split out
of `hkm/stable-haskell` so it can land on its own.

## Why

`hkm/stable-haskell` had drifted from master on the nixpkgs axis, and that alone
invalidates the whole job set: bumping `nixpkgs-unstable` changes bash, stdenv
and therefore every `plan-to-nix` derivation, so no plan-nix IFD can be
substituted and the evaluator rebuilds all of them. Measured on a plain
non-stable-haskell job, `unstable.ghc9103.native.tests.cabal-simple`:

| tree | plan-nix drvPath |
| --- | --- |
| master | `54qd8f17pkv922c9bqcxfg1j5yfdn4kp` |
| branch | `as86zp75lbnbd79p5ikxzlrjk5ifxr57` |
| branch with master's `nixpkgs-unstable` | `fqgjkxphj5634hh7xc4ypl3migghj50x` |

Landing the bump on master first means both sides share these outputs again,
instead of every branch that bumps nixpkgs paying to rebuild them.

## What is in it

| commit | why |
| --- | --- |
| `flake: bump nixpkgs-unstable` | the bump: `13043924` → `20535e48` |
| `wasm: build the wasi-libc fork with its Makefile` | wasi-libc no longer builds the old way under the new nixpkgs |
| `ci: keep x86_64-darwin on the 26.05 pin` | **unstable/26.11 dropped x86_64-darwin**; adds `nixpkgs-2605` and routes x86_64-darwin to it, and bumps `nixpkgs-2511` |
| `pkgconf-map: silence renamed-attr warnings` | pkgconf attribute renames, with the older-nixpkgs fallback kept |

So this is not a lock-only change: without the 26.05 pin, x86_64-darwin has no
nixpkgs to evaluate against at all.

Deliberately **not** included, though they sit next to these on the branch:
`hyper-linux` (separate feature), the ghc914-sh work, `cabal2nix` arch predicate
names (needs a nix-tools release), `system-nixpkgs-map` GHC 9.14 libraries.

## Behaviour change to note

`hydraJobs.x86_64-darwin.unstable` goes away and `hydraJobs.x86_64-darwin.R2605`
takes its place — a consequence of upstream dropping the platform, not a choice
made here. x86_64-darwin static nix-tools still build: they come from the
`./nix-tools` subflake, which resolves pkgs via its own pinned haskellNix whose
unstable nixpkgs predates the drop.

## Verified locally (aarch64-darwin)

- all four commits GPG-signed
- `flake.lock` carries exactly the three intended pins and **no** `hyper-linux`
- `hydraJobs.aarch64-darwin.unstable` → `ghc9103 ghc9124 ghc9141 ghc9141llvm ghc967 ghc984`
- `hydraJobs.x86_64-darwin` → `R2605 meta nix-tools nix-tools-sh`, and
  `.R2605` → `ghc9103 ghc9124 ghc9141 ghc967 ghc984`

Not verified locally: the linux job sets and any actual builds — this needs a
full Hydra eval, which is the point of the PR.
