### PR TITLE
nix-tools: don't list a whole directory to match a literal file glob

### DIFF
--- a/nix-tools/cabal-install-patches.nix
+++ b/nix-tools/cabal-install-patches.nix
@@ -12,14 +12,32 @@
 # outside that copy resolves to `/nix/store/...` and trips
 # `pure evaluation mode` on aarch64-darwin's static build.
 #
-# The patch makes `Distribution.Client.PackageHash`'s
+# installed-package-id-os-override makes `Distribution.Client.PackageHash`'s
 # `hashedInstalledPackageId` consult `CABAL_INSTALLED_PACKAGE_ID_OS`,
 # pinning the unit-id format to the *build* platform's OS.  Without
 # it, plan-nix unit-ids fork from slice-build unit-ids whenever the
 # eval system differs from the build system (e.g. evaluating on
 # Darwin while building x86_64-linux derivations).
+#
+# glob-literal-fast-path stops `runDirFileGlob` listing a whole directory
+# to resolve a glob that is a literal filename.  Every `packages:` entry
+# goes through it, so a cabal.project holding absolute paths into
+# /nix/store rescans the entire store once PER ENTRY (31 entries x ~362k
+# store entries for the ghc914-sh stage2 plan).  Page-cached locally that
+# only wastes a second or two; inside a nix-linux-builder VM, where
+# /nix/store is virtiofs, every 2KB getdents64 is a round trip to the
+# macOS host and `make-install-plan` stops progressing entirely — 77s
+# natively vs killed by max-silent-time on the builder.  This one is a
+# plain upstream bug (the code comment there already promises the
+# behaviour) and should go to cabal rather than live here forever.
+#
+# NB this second patch is against the `Cabal` library, not `cabal-install`
+# — Distribution.Simple.Glob lives there — hence the separate attribute.
 {
   packages.cabal-install.patches = [
     ./cabal-install-patches/installed-package-id-os-override.patch
+  ];
+  packages.Cabal.patches = [
+    ./cabal-install-patches/glob-literal-fast-path.patch
   ];
 }

--- a/nix-tools/cabal-install-patches/glob-literal-fast-path.patch
+++ b/nix-tools/cabal-install-patches/glob-literal-fast-path.patch
@@ -1,0 +1,77 @@
+Skip the directory listing when a file glob is a literal name.
+
+`runDirFileGlob`'s `GlobFile` branch always calls `listDirectory` on the
+parent and filters the result, even when the pattern is a single
+`Literal` and so can match at most one entry.  The cost is therefore
+O(entries in the parent directory) per pattern, regardless of how
+specific the pattern is.
+
+That is invisible on a small tree and ruinous on a large one.
+cabal-install resolves every `packages:` entry through this path
+(ProjectConfig.checkIsFileGlobPackage -> RebuildMonad.matchFileGlob ->
+Glob.matchFileGlob -> runDirFileGlob).  A project whose `packages:`
+stanza holds absolute paths into one big directory therefore rescans
+that whole directory once per entry.  Concretely, a generated
+cabal.project with 31 `/nix/store/<hash>-<name>-src` entries lists a
+/nix/store of ~362k entries 31 times.  Page-cached on a local disk that
+is merely wasteful; over a virtiofs share (a Linux builder VM on a macOS
+host) each 2KB getdents64 is a round trip to the host and the build
+stops making observable progress -- no CPU, no major faults, just
+permanent `request_wait_answer`.
+
+Add the missing literal case: stat the one candidate path instead of
+enumerating its parent.  The result is identical, since at most one
+directory entry can match a literal.  The new branch mirrors the general
+one exactly (same `mspec` file-vs-directory handling, same
+`doesGlobMatch` call, so `GlobWarnMultiDot` and `GlobMatchesDirectory`
+are produced as before); it only replaces the listing with a lookup.
+
+Note the block comment above `splitConstantPrefix` already promises this
+behaviour -- "and only walk as much as we need to: ... and just the
+specific file if it's a literal".  That was implemented for the constant
+directory prefix but never for the file component itself.
+
+diff --git a/src/Distribution/Simple/Glob.hs b/src/Distribution/Simple/Glob.hs
+--- a/src/Distribution/Simple/Glob.hs	2026-08-17 12:12:03
++++ b/src/Distribution/Simple/Glob.hs	2026-08-17 12:12:21
+@@ -388,6 +388,40 @@
+       Just spec -> checkNameMatches spec glob str
+       Nothing -> if matchGlobPieces glob str then Just (GlobMatch ()) else Nothing
+ 
++    -- Fast path: a literal file name needs no directory listing at all.
++    -- Listing costs O(entries in the parent directory), so a pattern naming
++    -- one exact file inside a large directory pays for a full scan -- and
++    -- callers such as cabal-install's `packages:` resolution do that once per
++    -- entry.  With absolute paths into a directory holding hundreds of
++    -- thousands of entries (e.g. `packages: /nix/store/<hash>-foo-src`) the
++    -- scan dominates everything else, and on a network or virtualised
++    -- filesystem it can stop a build making progress at all.  Stat the single
++    -- candidate instead: the result is identical, because at most one entry
++    -- of the directory can match a literal.
++    --
++    -- The comment above already promises "just the specific file if it's a
++    -- literal".  splitConstantPrefix implements that for the directory part;
++    -- this is the GlobFile half, which was missing.
++    go (GlobFile [Literal fname]) dir = do
++      let path = root </> dir </> fname
++      exists <- doesPathExist path
++      if not exists
++        then return []
++        else do
++          -- Mirrors the general branch below exactly, minus the listing.
++          isFile <- maybe (return True) (const $ doesFileExist path) mspec
++          let match = (dir </> fname <$) <$> doesGlobMatch [Literal fname] fname
++          return $
++            catMaybes
++              [ if isFile
++                  then match
++                  else case match of
++                    Just (GlobMatch x) -> Just $ GlobMatchesDirectory x
++                    Just (GlobWarnMultiDot x) -> Just $ GlobMatchesDirectory x
++                    Just (GlobMatchesDirectory x) -> Just $ GlobMatchesDirectory x
++                    Just (GlobMissingDirectory x) -> Just $ GlobMissingDirectory x
++                    Nothing -> Nothing
++              ]
+     go (GlobFile glob) dir = do
+       entries <- listDirectory (root </> dir)
+       catMaybes


### PR DESCRIPTION
## Problem

`x86_64-linux.unstable.ghc914-sh.native.roots.plan-stage2` never completes on the M4 builders — [build 1927610](https://ci.zw3rk.com/build/1927610) ran ~2h producing no output and was killed by `max-silent-time`, twice. The truncated log ends mid-clone with no error, which reads like a hang rather than a failure.

It is neither hung nor CPU-bound. The identical derivation takes **77 seconds** on a native x86_64 machine.

## Cause

`runDirFileGlob`'s `GlobFile` branch always lists the parent directory and filters it, even when the pattern is one `Literal`:

```haskell
go (GlobFile glob) dir = do
  entries <- listDirectory (root </> dir)   -- unconditional
  ... filter entries by doesGlobMatch glob
```

Every `packages:` entry resolves through this (`checkIsFileGlobPackage` → `RebuildMonad.matchFileGlob` → `Glob.matchFileGlob` → `runDirFileGlob`). The stage2 plan's `replace-hackage-tarball-urls` rewrites 31 boot libraries to `/nix/store/<hash>-<name>-src`, so `make-install-plan` lists a **~362k-entry `/nix/store` 31 times**.

Locally that is page-cached and costs a second or two. In the `nix-linux-builder` VM `/nix/store` is a virtiofs share from the macOS host, so every 2 KB `getdents64` is a round trip.

Measured inside the VM while stalled:

| signal | value |
|---|---|
| blocking syscall | `getdents64`, fd 8 = `/nix/store`, every sample |
| `wchan` | `request_wait_answer` (FUSE) |
| CPU | 0.84 s per 180 s wall |
| `min/majflt` | 44338/163 → 192396/183 — **not** demand paging |
| `rchar` | +140 kB in 180 s |

Ruled out by measurement: Rosetta translation (27 ms startup, cold == warm), the Rosetta AOT cache, virtiofs bulk throughput (32 MB in 38 ms), demand paging, the hackage index (`CABAL_DIR` is 15 K), CPU and RAM.

## Fix

Add the missing literal case: stat the one candidate instead of enumerating its parent. At most one entry can match a literal, so the result is identical, and the new branch mirrors the general one exactly — same `mspec` file-vs-directory handling and the same `doesGlobMatch` call, so `GlobWarnMultiDot` and `GlobMatchesDirectory` are produced as before.

The block comment above `splitConstantPrefix` already promises this ("*and just the specific file if it's a literal*"); it was implemented for the constant directory prefix but never for the file component.

### Why in `Cabal`, not `cabal-install`

Short-circuiting in `checkIsFileGlobPackage` looks smaller but is the wrong layer — it sits above the monitoring:

```haskell
matchFileGlob glob = do
  root <- askRoot
  monitorFiles [monitorFileGlobExistence glob]
  liftIO $ Glob.matchFileGlob root glob
```

Skipping that would stop cabal noticing when a `packages:` location appears or disappears — a correctness bug in place of a performance one. Fixing the glob keeps the monitoring and helps every caller.

## Verification

- Patch applies cleanly to the fork's Cabal.
- Patched module **typechecks** (`ghc -fno-code`, GHC 9.12, boot `Cabal`/`Cabal-syntax` hidden): `[141 of 141] Compiling Distribution.Simple.Glob`, 0 errors, and no diagnostics under `-Woverlapping-patterns -Wincomplete-patterns` (the added clause is neither redundant nor shadowing).

**Not yet verified:** no end-to-end plan-to-nix run with the patch in place. That needs a from-source nix-tools, since the default `nix-tools-unchecked` is a prebuilt static tarball that ignores these patches. Worth doing before merge.

This is a plain upstream bug and should go to cabal rather than live here indefinitely.