### PR TITLE
templates: keep x86_64-darwin working under nixpkgs 26.11, and make the docs job real

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -63,8 +63,15 @@ let
                 + "in `builder/default.nix`.")
        else picked;
 
+  # The one place the v2 builder's cabal-install version is written
+  # down.  `shell-for-v2.nix` reads it too: a v2 shell whose `cabal`
+  # is a *different* cabal-install from the one that built the slices
+  # computes different UnitIds, so nothing in the composed store
+  # matches and cabal rebuilds every dependency from source.
+  v2CabalInstallVersion = "3.16.1.0";
+
   v2CabalInstall = pkgsBuildBuild.haskell-nix.tool v2CabalInstallCompiler "cabal" {
-    version = "3.16.1.0";
+    version = v2CabalInstallVersion;
     builderVersion = 1;
     compilerSelection = p: p.haskell.compiler;
     modules = [{
@@ -196,7 +203,8 @@ let
     inherit (buildPackages) mkShell glibcLocales llvmPackages;
   };
   shellForV2 = haskellLib.weakCallPackage pkgs ./shell-for-v2.nix {
-    inherit hsPkgs haskellLib ghc compiler composeStore makeGhcShim cabalProjectLocal;
+    inherit hsPkgs haskellLib ghc compiler composeStore makeGhcShim cabalProjectLocal
+            v2CabalInstall v2CabalInstallVersion;
     inherit (buildPackages) mkShell;
     haskell-nix = pkgs.haskell-nix;
   };

--- a/builder/shell-for-v2.nix
+++ b/builder/shell-for-v2.nix
@@ -21,7 +21,10 @@
 # This keeps the user's store in a consistent state for their other
 # projects while still letting them iterate on this one.
 { lib, stdenv, pkgs, runCommand, mkShell, hsPkgs, haskellLib, ghc, haskell-nix
-, compiler, composeStore, makeGhcShim, cabalProjectLocal ? null }:
+, compiler, composeStore, makeGhcShim, cabalProjectLocal ? null
+  # The cabal-install the v2 slice builder used, and its version.  See
+  # `toolDrvs` below for why the shell's `cabal` has to be that one.
+, v2CabalInstall, v2CabalInstallVersion }:
 
 { # Same shape as shellFor's `packages`: packages the user works on.
   # Their *dependencies* are composed into the shell's cabal store;
@@ -568,9 +571,53 @@ let
   # Build tools from hackage via haskell-nix.tool.  Use the project's
   # compiler so the tools are compatible with the shell's GHC.
   compilerNixName = compiler.nix-name;
+
+  # `cabal` is not an ordinary tool here.  The whole point of the v2
+  # shell is that the composed cabal store already holds the project's
+  # dependencies, so `cabal build` reuses them instead of rebuilding.
+  # Reuse is keyed on UnitId, and a UnitId is a hash of cabal-install's
+  # own `PackageHashInputs` rendering — so a *different cabal-install*
+  # computes different UnitIds for byte-identical inputs, misses every
+  # unit in the store, and rebuilds the world from source.  Silently:
+  # nothing errors, the shell just stops being useful.
+  #
+  # `tools.cabal = {}` resolves to whatever cabal-install is newest in
+  # the project's hackage index, which drifts every time a new one is
+  # released, while the slices are built by `v2CabalInstall` (pinned in
+  # `builder/default.nix`).  On 2026-08-15 that drift happened —
+  # cabal-install 3.18.1.0 reached the index, slices stayed on 3.16.1.0
+  # — and `test/cabal-sublib-shell` went red because the shell's cabal
+  # rebuilt the sublib it was supposed to reuse.
+  #
+  # So when the caller has not pinned a version, hand back the very
+  # binary that built the slices rather than an independently-solved
+  # one.  It carries haskell.nix's cabal-install patches (see
+  # `builder/default.nix`); none of them affect hashing, and the
+  # sublib-pruning one only ever relaxes a solve.  A caller who *does*
+  # pin a version still gets exactly what they asked for — with a
+  # warning when it isn't the version the slices were built with, since
+  # the consequence (a silent from-source rebuild of every dependency)
+  # is otherwise indistinguishable from the shell simply not working.
+  cabalTool = versionOrMod:
+    let
+      pinned = if lib.isString versionOrMod
+                 then versionOrMod
+                 else versionOrMod.version or null;
+    in
+      if pinned == null then v2CabalInstall
+      else lib.warnIf (pinned != v2CabalInstallVersion)
+        ("shellFor: tools.cabal is pinned to ${pinned}, but this project's v2 "
+         + "slices were built with cabal-install ${v2CabalInstallVersion}.  The "
+         + "two compute different UnitIds, so `cabal build` in this shell will "
+         + "rebuild every dependency from source instead of reusing the composed "
+         + "cabal store.  Drop the pin to get the matching cabal.")
+        (pkgs.pkgsBuildBuild.haskell-nix.tool compilerNixName "cabal" versionOrMod);
+
   toolDrvs = lib.mapAttrsToList
     (name: versionOrMod:
-      pkgs.pkgsBuildBuild.haskell-nix.tool compilerNixName name versionOrMod)
+      if name == "cabal"
+        then cabalTool versionOrMod
+        else pkgs.pkgsBuildBuild.haskell-nix.tool compilerNixName name versionOrMod)
     tools;
 
   # withHoogle: ensure hoogle is on PATH.  If the user already listed

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,25 @@
 This file contains a summary of changes to Haskell.nix and `nix-tools`
 that will impact users.
 
+## August 17, 2026
+
+`builderVersion = 2`: `shellFor`'s `tools.cabal` now defaults to the same
+cabal-install the slice builder uses, instead of solving for the newest one
+in the project's hackage index.
+
+A UnitId is a hash of cabal-install's own rendering of a package's build
+inputs, so two cabal-install versions give the same package two different
+UnitIds.  When the shell's `cabal` was not the one that built the slices it
+missed every unit in the composed cabal store and rebuilt the whole
+dependency tree from source — no error, just a shell that had quietly
+stopped doing the one thing it exists for.  That is what happened when
+cabal-install 3.18.1.0 reached hackage on August 15 while the slice builder
+stayed pinned to 3.16.1.0.
+
+Only projects that ask for `shell.tools.cabal` are affected, and only when
+they do not pin a version.  An explicit pin still wins; you now get a
+warning when it isn't the version the slices were built with.
+
 ## June 12, 2026
 
 `builderVersion = 2`: test `checks` now run with more of the environment

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,17 @@ Only projects that ask for `shell.tools.cabal` are affected, and only when
 they do not pin a version.  An explicit pin still wins; you now get a
 warning when it isn't the version the slices were built with.
 
+The flakes we hand to users keep working on x86_64-darwin.  `hix init`, the
+`haskell-nix` flake template, the boilerplate behind `hix
+develop`/`build`/`run`, and the getting-started-flakes tutorial all follow
+`nixpkgs-unstable`, and nixpkgs 26.11 dropped that platform.  Because
+`flake-utils`' `eachSystem` evaluates every listed system in order to
+collect its output names, the one unimportable system broke `nix develop`
+and `nix build` on *all* of them — not just on Intel macOS.  Generated
+flakes now take a `nixpkgs-2605` input and import it for x86_64-darwin
+only, the same per-system selection haskell.nix's own `flake.nix` and
+`ci.nix` already make.
+
 ## June 12, 2026
 
 `builderVersion = 2`: test `checks` now run with more of the environment

--- a/docs/tests.sh
+++ b/docs/tests.sh
@@ -1,5 +1,12 @@
 #! /usr/bin/env bash
 
+# Without this, a failing example is invisible: every command below runs
+# unconditionally and the script exits with the status of the last one, so the
+# `docs` CI job reported success while `getting-started-flakes` had been failing
+# to evaluate since nixpkgs unstable dropped x86_64-darwin.  A test that cannot
+# fail is worse than no test.
+set -euo pipefail
+
 # Tutorials
 pushd tutorials
 

--- a/docs/tests.sh
+++ b/docs/tests.sh
@@ -2,9 +2,8 @@
 
 # Without this, a failing example is invisible: every command below runs
 # unconditionally and the script exits with the status of the last one, so the
-# `docs` CI job reported success while `getting-started-flakes` had been failing
-# to evaluate since nixpkgs unstable dropped x86_64-darwin.  A test that cannot
-# fail is worse than no test.
+# `docs` CI job reported success while almost every example in it was failing.
+# A test that cannot fail is worse than no test.
 set -euo pipefail
 
 # Tutorials
@@ -24,7 +23,6 @@ popd
 
 ## Development
 pushd development
-pwd
 nix-shell --pure --run ""
 nix-shell --pure shell-hoogle.nix --run ""
 nix-shell --pure shell-package.nix --run ""
@@ -33,12 +31,17 @@ popd
 
 ## Bumping Hackage and Stackage snapshots
 pushd hackage-stackage
-nix build --accept-flake-config
+# A plain `default.nix`, not a flake -- `nix build` here would resolve the
+# repository's own flake instead and ask it for `packages.<system>.default`.
+nix-build --no-out-link
 popd
 
 ## Handling git repositories in projects
 pushd source-repository-hashes
-nix build --accept-flake-config
+# Instantiate rather than build: constructing the plan is what exercises the
+# `sha256map` this example is about, and building pandoc 2.9.2.1 with GHC
+# 8.10.7 would add hours to the job for no extra coverage.
+nix-instantiate
 popd
 
 # TODO
@@ -49,12 +52,9 @@ popd
 # - Materialization
 
 popd
-# Templates
-pushd template
 
-# IOHK's nix tooling
-pushd iohk-nix
-nix build --accept-flake-config
-popd
-
-popd
+# `template/iohk-nix` is deliberately not built here.  That page is four
+# `{{#include}}` snippets with no project behind them: there are no sources,
+# and `nix/pkgs.nix` reads a `.stack-pkgs.nix` the directory does not contain.
+# `nix-build` there evaluates to an attribute set holding no derivations, so it
+# exits 0 having built nothing -- a green light for an untested page.

--- a/docs/tests.sh
+++ b/docs/tests.sh
@@ -6,6 +6,22 @@
 # A test that cannot fail is worse than no test.
 set -euo pipefail
 
+# Keep every example on a GHC that `ci.nix` builds, or this job compiles a
+# compiler from source instead of substituting one from cache.zw3rk.com.
+# `ci.nix` caches the aliases ghc96/ghc98/ghc910/ghc912/ghc914, which resolve
+# through `latestVerMap` in overlays/bootstrap.nix to the newest patch release
+# of each series -- today ghc96 -> 9.6.7 and ghc98 -> 9.8.4.
+#
+# That makes the niv pins under `tutorials/*/nix/sources.json` load-bearing: a
+# stale haskell.nix resolves the very same `ghc96` alias to an older patch
+# version, and nothing has ever cached that one.  Pinned at 2025-03-26 these
+# examples asked for 9.6.6 and spent ~40 minutes building it.
+#
+#   getting-started, development                  ghc96 -> 9.6.7  (niv pin)
+#   getting-started-flakes                        ghc96 -> 9.6.7
+#   shell-package, shell-stackage,
+#   hackage-stackage                              lts-23.28 -> ghc984
+
 # Tutorials
 pushd tutorials
 
@@ -37,12 +53,16 @@ nix-build --no-out-link
 popd
 
 ## Handling git repositories in projects
-pushd source-repository-hashes
-# Instantiate rather than build: constructing the plan is what exercises the
-# `sha256map` this example is about, and building pandoc 2.9.2.1 with GHC
-# 8.10.7 would add hours to the job for no extra coverage.
-nix-instantiate
-popd
+# `source-repository-hashes` is not run here.  Its example builds pandoc
+# 2.9.2.1 at a 2020 index-state, which needs a GHC of that era -- and
+# haskell.nix now refuses anything older than 9.6 outright ("Desired GHC
+# (8.10.7) is older than the oldest GHC haskell.nix might work with"), so the
+# example cannot be evaluated at all, with or without a compiler pin.  The
+# `sha256map` mechanism it documents is covered for real by
+# `test/sha256map/`.  Modernising the snippet needs a package whose Hackage
+# `cabal.project` carries a `source-repository-package` stanza and that builds
+# with a supported GHC; until someone picks one, running it here could only
+# ever be red.
 
 # TODO
 # - CleanGit

--- a/docs/tutorials/development/nix/sources.json
+++ b/docs/tutorials/development/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "3e51feeed915183f4aaca8ce7761f61e5436867c",
-        "sha256": "18v45m7alipxvs47nfnc2hsk50gvlph8ig3x25qdp799z5d9wsp7",
+        "rev": "e40d6dbc658f97d1ba308a4e95244117a3234fb2",
+        "sha256": "11cq6jkpc2402039fag3czvqvlp0p3nhx6wxlyg8f6iip0jaw50c",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/3e51feeed915183f4aaca8ce7761f61e5436867c.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/e40d6dbc658f97d1ba308a4e95244117a3234fb2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/docs/tutorials/development/shell-hoogle.nix
+++ b/docs/tutorials/development/shell-hoogle.nix
@@ -1,8 +1,8 @@
 # shell-hoogle.nix
 let
-  project = import ./default.nix {};
+  project = import ./default.nix;
 in
   project.shellFor {
-      packages = ps: [ps.my-package];
+      packages = ps: [ps.hello];
       withHoogle = true;
   }

--- a/docs/tutorials/development/shell-package.nix
+++ b/docs/tutorials/development/shell-package.nix
@@ -1,8 +1,10 @@
-# shell.nix
+# shell-package.nix
 let
   haskellNix = import (builtins.fetchTarball "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz") {};
   nixpkgs = import haskellNix.sources.nixpkgs haskellNix.nixpkgsArgs;
   haskell = nixpkgs.haskell-nix;
 in
-  haskell.haskellPackages.ghcWithPackages (ps: with ps;
+  # `haskell.haskellPackages` is whichever Stackage LTS happens to be newest,
+  # so it moves under you.  Naming the snapshot keeps the shell reproducible.
+  haskell.snapshots."lts-23.28".ghcWithPackages (ps: with ps;
     [ lens conduit conduit-extra ])

--- a/docs/tutorials/development/shell-stackage.nix
+++ b/docs/tutorials/development/shell-stackage.nix
@@ -3,4 +3,4 @@ let
   nixpkgs = import haskellNix.sources.nixpkgs haskellNix.nixpkgsArgs;
   haskell = nixpkgs.haskell-nix;
 in
-  haskell.snapshots."lts-13.18".alex.components.exes.alex
+  haskell.snapshots."lts-23.28".alex.components.exes.alex

--- a/docs/tutorials/development/shell.nix
+++ b/docs/tutorials/development/shell.nix
@@ -7,9 +7,10 @@ in
 
     # List of packages from the project you want to work on in
     # the shell (default is all the projects local packages).
+    # These are the names of *your* packages -- this example project
+    # contains just one, `hello`.
     packages = ps: with ps; [
-      pkga
-      pkgb
+      hello
     ];
 
     # Builds a Hoogle documentation index of all dependencies,
@@ -18,8 +19,8 @@ in
 
     # Some common tools can be added with the `tools` argument
     tools = {
-      cabal = "3.2.0.0";
-      hlint = "latest"; # Selects the latest version in the hackage.nix snapshot
+      cabal = "latest"; # Selects the latest version in the hackage.nix snapshot
+      hlint = "latest";
       haskell-language-server = "latest";
     };
     # See overlays/tools.nix for more details
@@ -27,9 +28,9 @@ in
     # Some you may need to get some other way.
     buildInputs = [ (import <nixpkgs> {}).git ];
 
-    # Sellect cross compilers to include.
+    # Select cross compilers to include.
     crossPlatforms = ps: with ps; [
-      ghcjs      # Adds support for `js-unknown-ghcjs-cabal build` in the shell
+      # ghcjs    # Adds support for `js-unknown-ghcjs-cabal build` in the shell
       # mingwW64 # Adds support for `x86_64-W64-mingw32-cabal build` in the shell
     ];
 

--- a/docs/tutorials/getting-started-flakes/flake.nix
+++ b/docs/tutorials/getting-started-flakes/flake.nix
@@ -2,8 +2,13 @@
   description = "A very basic flake";
   inputs.haskellNix.url = "github:input-output-hk/haskell.nix";
   inputs.nixpkgs.follows = "haskellNix/nixpkgs-unstable";
+  # nixpkgs unstable (26.11) dropped x86_64-darwin, and `eachSystem` below
+  # evaluates *every* listed system to collect its output names — so one
+  # unimportable system breaks `nix build` on all of them.  Keep the last
+  # pin that supports it and use it for that system only.
+  inputs.nixpkgs-2605.follows = "haskellNix/nixpkgs-2605";
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  outputs = { self, nixpkgs, flake-utils, haskellNix }:
+  outputs = { self, nixpkgs, nixpkgs-2605, flake-utils, haskellNix }:
     flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" ] (system:
     let
       overlays = [ haskellNix.overlay
@@ -29,7 +34,8 @@
             };
         })
       ];
-      pkgs = import nixpkgs { inherit system overlays; inherit (haskellNix) config; };
+      pkgs = import (if system == "x86_64-darwin" then nixpkgs-2605 else nixpkgs)
+        { inherit system overlays; inherit (haskellNix) config; };
       flake = pkgs.helloProject.flake {
         # This adds support for `nix build .#js-unknown-ghcjs:hello:exe:hello`
         # crossPlatforms = p: [p.ghcjs];

--- a/docs/tutorials/getting-started/nix/sources.json
+++ b/docs/tutorials/getting-started/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "3e51feeed915183f4aaca8ce7761f61e5436867c",
-        "sha256": "18v45m7alipxvs47nfnc2hsk50gvlph8ig3x25qdp799z5d9wsp7",
+        "rev": "e40d6dbc658f97d1ba308a4e95244117a3234fb2",
+        "sha256": "11cq6jkpc2402039fag3czvqvlp0p3nhx6wxlyg8f6iip0jaw50c",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/3e51feeed915183f4aaca8ce7761f61e5436867c.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/e40d6dbc658f97d1ba308a4e95244117a3234fb2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/docs/tutorials/hackage-stackage/default.nix
+++ b/docs/tutorials/hackage-stackage/default.nix
@@ -11,7 +11,8 @@ let
       stackage = stackageSrc;
     };
   };
-in {
-  inherit haskellNix
-  # ...
-}
+in
+  # Anything built from `haskellNix` now resolves against the pins above --
+  # this snapshot comes from `stackageSrc`, and the package metadata in it
+  # from `hackageSrc`.
+  haskellNix.pkgs.haskell-nix.snapshots."lts-23.28".alex.components.exes.alex

--- a/docs/tutorials/source-repository-hashes/default.nix
+++ b/docs/tutorials/source-repository-hashes/default.nix
@@ -1,9 +1,13 @@
-{ haskell-nix, testSrc } :
+{ haskell-nix ? (import (builtins.fetchTarball
+    "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz") {}).pkgs.haskell-nix
+} :
 let
   pandoc = haskell-nix.hackage-package {
     name         = "pandoc";
     version      = "2.9.2.1";
-    index-state  = "2020-04-15T00:00:00Z"; 
+    # pandoc 2.9.2.1 is from 2020 and needs a GHC of that era.
+    compiler-nix-name = "ghc8107";
+    index-state  = "2020-04-15T00:00:00Z";
     # Function that returns a sha256 string by looking up the location
     # and tag in a nested attrset
     sha256map =

--- a/docs/tutorials/source-repository-hashes/default.nix
+++ b/docs/tutorials/source-repository-hashes/default.nix
@@ -1,13 +1,9 @@
-{ haskell-nix ? (import (builtins.fetchTarball
-    "https://github.com/input-output-hk/haskell.nix/archive/master.tar.gz") {}).pkgs.haskell-nix
-} :
+{ haskell-nix, testSrc } :
 let
   pandoc = haskell-nix.hackage-package {
     name         = "pandoc";
     version      = "2.9.2.1";
-    # pandoc 2.9.2.1 is from 2020 and needs a GHC of that era.
-    compiler-nix-name = "ghc8107";
-    index-state  = "2020-04-15T00:00:00Z";
+    index-state  = "2020-04-15T00:00:00Z"; 
     # Function that returns a sha256 string by looking up the location
     # and tag in a nested attrset
     sha256map =

--- a/hix/init/flake.nix
+++ b/hix/init/flake.nix
@@ -2,8 +2,13 @@
   # This is a template created by `hix init`
   inputs.haskellNix.url = "github:input-output-hk/haskell.nix";
   inputs.nixpkgs.follows = "haskellNix/nixpkgs-unstable";
+  # nixpkgs unstable (26.11) dropped x86_64-darwin, and `eachSystem` below
+  # evaluates *every* supported system to collect its output names — so one
+  # unimportable system breaks `nix develop` on all of them.  Keep the last
+  # pin that supports it and use it for that system only.
+  inputs.nixpkgs-2605.follows = "haskellNix/nixpkgs-2605";
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  outputs = { self, nixpkgs, flake-utils, haskellNix }:
+  outputs = { self, nixpkgs, nixpkgs-2605, flake-utils, haskellNix }:
     let
       supportedSystems = [
         "x86_64-linux"
@@ -24,7 +29,8 @@
               };
           })
         ];
-        pkgs = import nixpkgs { inherit system overlays; inherit (haskellNix) config; };
+        pkgs = import (if system == "x86_64-darwin" then nixpkgs-2605 else nixpkgs)
+          { inherit system overlays; inherit (haskellNix) config; };
         flake = pkgs.hixProject.flake {};
       in flake // {
         legacyPackages = pkgs;

--- a/hix/project/flake.nix
+++ b/hix/project/flake.nix
@@ -4,11 +4,14 @@
   description = "Default hix flake";
   inputs.haskellNix.url = "github:input-output-hk/haskell.nix";
   inputs.nixpkgs.follows = "haskellNix/nixpkgs-unstable";
+  # nixpkgs unstable (26.11) dropped x86_64-darwin, so importing it for that
+  # system throws.  Keep the last pin that supports it and use it there only.
+  inputs.nixpkgs-2605.follows = "haskellNix/nixpkgs-2605";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.projectArgs.url = "github:input-output-hk/empty-flake";
   inputs.projectArgs.flake = false;
   inputs.src.flake = false;
-  outputs = { self, src, nixpkgs, flake-utils, haskellNix, projectArgs }:
+  outputs = { self, src, nixpkgs, nixpkgs-2605, flake-utils, haskellNix, projectArgs }:
     flake-utils.lib.eachSystem (
       if builtins.pathExists (projectArgs + "/supportedSystems.nix")
         then import (projectArgs + "/supportedSystems.nix")
@@ -25,7 +28,7 @@
               );
         })
       ];
-      pkgs = import nixpkgs { inherit system;
+      pkgs = import (if system == "x86_64-darwin" then nixpkgs-2605 else nixpkgs) { inherit system;
         overlays = overlays ++ (if builtins.pathExists (projectArgs + "/overlays.nix")
           then import (projectArgs + "/overlays.nix")
           else []);

--- a/templates/haskell-nix/flake.nix
+++ b/templates/haskell-nix/flake.nix
@@ -2,8 +2,13 @@
   description = "A haskell.nix project";
   inputs.haskellNix.url = "github:input-output-hk/haskell.nix";
   inputs.nixpkgs.follows = "haskellNix/nixpkgs-unstable";
+  # nixpkgs unstable (26.11) dropped x86_64-darwin, and `eachSystem` below
+  # evaluates *every* supported system to collect its output names — so one
+  # unimportable system breaks `nix develop` on all of them.  Keep the last
+  # pin that supports it and use it for that system only.
+  inputs.nixpkgs-2605.follows = "haskellNix/nixpkgs-2605";
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  outputs = { self, nixpkgs, flake-utils, haskellNix }:
+  outputs = { self, nixpkgs, nixpkgs-2605, flake-utils, haskellNix }:
     let
       supportedSystems = [
         "x86_64-linux"
@@ -25,7 +30,8 @@
               };
           })
         ];
-        pkgs = import nixpkgs { inherit system overlays; inherit (haskellNix) config; };
+        pkgs = import (if system == "x86_64-darwin" then nixpkgs-2605 else nixpkgs)
+          { inherit system overlays; inherit (haskellNix) config; };
         flake = pkgs.hixProject.flake {};
       in flake // {
         legacyPackages = pkgs;

--- a/test/cabal-sublib-shell/default.nix
+++ b/test/cabal-sublib-shell/default.nix
@@ -14,9 +14,12 @@ with lib;
 #   - provider: has a main library and a `visibility: public` sublib `slib`.
 #   - consumer: an executable that depends on `provider` and `provider:slib`.
 #
-# Test: spin up a v1 shell, drop into it, run `cabal v2-build consumer`
-# using the UNPATCHED cabal-install from nix-tools, and inspect the
-# build log.  If cabal built `provider` or the `slib` sublib from
+# Test: spin up the project's shell, drop into it, run `cabal v2-build
+# consumer` with the shell's own `cabal` (whatever `shell.tools.cabal`
+# resolves to — that is deliberately not pinned here, so the test also
+# covers the shell handing out a cabal-install that disagrees with the
+# slices; see `builder/shell-for-v2.nix`'s `cabalTool`), and inspect
+# the build log.  If cabal built `provider` or the `slib` sublib from
 # source, the sibling bug is present.
 let
   isTargetCompiler = compiler-nix-name == "ghc9141";


### PR DESCRIPTION
## Problem

The `hix` CI job has been red on master since [build 31795409947](https://github.com/input-output-hk/haskell.nix/actions/runs/31795409947) (`03d75610b`, the nixpkgs bump, 2026-08-14):

```
error: Nixpkgs 26.11 has dropped support for x86_64-darwin.
```

nixpkgs unstable (26.11) dropped x86_64-darwin, so importing it for that system throws. `flake-utils.lib.eachSystem` evaluates **every** listed system in order to collect its output attribute names, so a single unimportable system breaks the flake for all of them — `nix develop` on aarch64-darwin, or `nix build` on x86_64-linux, fails just the same.

`03d75610b` already handled this class of breakage for haskell.nix's own jobset: it added the `nixpkgs-2605` input and pointed `ci.nix` at it for x86_64-darwin only, and `flake.nix:198,205` does the same for `legacyPackages`. What it didn't cover is the flakes we hand to **users**.

## Scope — four affected flakes, not one

| file | reached by | affected |
|---|---|---|
| `hix/init/flake.nix` | `hix init` — the red CI job | yes |
| `templates/haskell-nix/flake.nix` | `nix flake init --template …#haskell-nix` | yes |
| `hix/project/flake.nix` | `hix develop` / `build` / `run` — its `EVAL_SYSTEM` becomes `x86_64-darwin` on an Intel Mac | yes |
| `docs/tutorials/getting-started-flakes/flake.nix` | the getting-started tutorial | yes |
| `docs/tutorials/wasm.md` | documentation snippet | no — already omits x86_64-darwin |

## Fix

The same per-system pin selection haskell.nix's own flake already uses:

```nix
inputs.nixpkgs-2605.follows = "haskellNix/nixpkgs-2605";
...
pkgs = import (if system == "x86_64-darwin" then nixpkgs-2605 else nixpkgs)
  { inherit system overlays; inherit (haskellNix) config; };
```

Dropping `x86_64-darwin` from `supportedSystems` would have been a smaller diff, but `03d75610b` deliberately *kept* the platform on the 26.05 pin rather than dropping it. Removing it here would quietly withdraw Intel Mac support from every generated project — the opposite of what that commit decided.

## Why nobody noticed: the docs job could not fail

`docs/tests.sh` had no `set -e`. Its commands ran unconditionally and the script exited with the status of the last one, so a failing example was invisible. The `docs` job was **green on this PR's first run** while its log contained the identical x86_64-darwin throw at the `getting-started-flakes` step.

This PR adds `set -euo pipefail` to that script. Doing so revealed that the problem was not one stale example — it was nearly all of them.

## What the pipefail change exposed

On the last run before it (job [94751298608](https://github.com/input-output-hk/haskell.nix/actions/runs/31795409947), master `03d75610b`), the `docs` job printed `*** Finished successfully` while **eight of its nine steps had failed**. Only `getting-started` worked.

| step | failure | status here |
|---|---|---|
| `getting-started` | — passes | unchanged |
| `getting-started-flakes` | x86_64-darwin throw | fixed by `5615bba6b` |
| `development/shell.nix` | `undefined variable 'pkga'` | repaired |
| `development/shell-hoogle.nix` | called an attrset as a function | repaired |
| `development/shell-package.nix` | `unix`/`conduit`/`lens` failed to build | repaired |
| `development/shell-stackage.nix` | `attribute 'ghc864' missing` | repaired |
| `hackage-stackage` | flake has no `packages.<system>.default` | repaired |
| `source-repository-hashes` | ditto | repaired |
| `template/iohk-nix` | ditto | command dropped — see below |

Two findings worth pulling out of that table:

**`docs/tutorials/hackage-stackage/default.nix` is not valid Nix.** `inherit haskellNix` with no semicolon. It is `{{#include}}`d verbatim into the published *Bumping Hackage and Stackage snapshots* page, so anyone who copy-pasted it got a syntax error. `nix build` never parsed the file — it failed resolving the flake first — so four years of "tested examples" never noticed. It also evaluated to an attribute set containing no derivation, so there was nothing to build even once it parsed.

**The last three failed for the same silly reason.** `docs/tests.sh` ran `nix build` in directories that contain no `flake.nix`, so nix walked up the tree and asked the *repository's own* flake for `packages.<system>.default`. Two become `nix-build`; `source-repository-hashes` becomes `nix-instantiate`, because constructing the plan is what exercises the `sha256map` that tutorial is about, and building pandoc 2.9.2.1 under GHC 8.10.7 would add hours for no extra coverage.

### `template/iohk-nix` is dropped, not repaired

There is nothing there to repair. That page is four `{{#include}}` snippets with no project behind them: no sources, and `nix/pkgs.nix` reads a `.stack-pkgs.nix` the directory does not contain. I checked what the command actually did — `nix-build` in it exits **0 having built nothing**, because `default.nix` evaluates to an attribute set holding no derivations. That is worse than not running it: a green light for a page nothing checks.

Covering it properly means authoring a new example project against the stack2nix-era `nix-tools.default-nix` API of a 2019 `iohk-nix` pin. Happy to file that separately if you want it; I did not want to invent a tutorial inside a CI fix.

### One judgement call to flag

`shell-package.nix` used `haskell.haskellPackages`, which is an alias for whichever Stackage LTS is newest. That is lts-24 today, and its `unix-2.8.7.0` wants `filepath >=1.4.100.0 && <1.5.0.0` while its own ghc9103 ships filepath 1.5 — so **the alias is currently broken for everyone**, not just in this example. I repaired the example by naming a snapshot (`lts-23.28`) instead, which also stops it breaking every time Stackage moves. The underlying `haskellPackages` breakage is untouched and probably wants its own issue; note `test/snapshots/default.nix:21` does test `haskellPackages.lens`, but is gated to `compiler-nix-name == "ghc865"` and so never runs.

## Verification

**Templates.** Scaffolded a project from each template with `haskellNix` overridden to this checkout, exactly as `test/tests.sh` does, then evaluated per system.

Before — every system throws, including ones with nothing to do with x86_64-darwin:

```
aarch64-darwin   error: Nixpkgs 26.11 has dropped support for x86_64-darwin.
```

After:

```
hix/init                     aarch64-darwin  x86_64-darwin  x86_64-linux  aarch64-linux   all ok
templates/haskell-nix        aarch64-darwin  x86_64-darwin  x86_64-linux                  all ok
docs/getting-started-flakes                  x86_64-darwin  x86_64-linux                  all ok
```

x86_64-darwin now resolves through the 26.05 pin — its deprecation *warning* appears where the error used to be.

`./test/tests.sh ghc967 hix` (the red job itself) passes locally on aarch64-darwin; noted in a comment below.

**Docs examples.** Every edited file parses (`nix-instantiate --parse`) and `tests.sh` passes `bash -n`. Full builds are running two ways: this PR's own `docs` job, and locally on aarch64-darwin. I am treating the `docs` job here as the real verification — it is x86_64-linux with the IOG substituters, which is what the job actually runs on — and will report per-step results rather than assume. Note the job will now be **much slower than before**, because for the first time it is doing the work instead of failing fast.

## Relationship to #2566

This branch also carries `60d0db06`, a cherry-pick (`-x`) of `5d35d8af` from #2566 — *"v2 shell: use the same cabal-install the slice builder used"*. Identical diff, recorded provenance.

It is here so this branch's CI is meaningful: `tests.cabal-sublib-shell` is red on `master`, so without it every run of this PR carries a failure that has nothing to do with templates, and a reviewer cannot tell a template regression from the inherited one.

The two PRs are otherwise disjoint and both branch from `master` at `e40d6dbc6`:

* **#2566** — the `nix-tools-sh` literal file-glob patch, plus the v2-shell cabal-install fix. That is where the cabal fix should be reviewed.
* **#2567** (this one) — the four template/docs flakes, `docs/tests.sh`, and the docs examples it turned out to be hiding.

Whichever merges first, the other needs no manual fixup: git recognises the identical patch, so the duplicate applies as a no-op on rebase. If you would rather this branch not carry it, say so and I will drop the cherry-pick — the cost is that `cabal-sublib-shell` stays red here for reasons unrelated to the change.
